### PR TITLE
[codex] Fix NixOS package build

### DIFF
--- a/daemon/src/profiles.rs
+++ b/daemon/src/profiles.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use crate::actions::{Action, get_default_actions};
+use crate::actions::{get_default_actions, Action};
 
 /// Current schema version for profiles.json
 pub const SCHEMA_VERSION: u32 = 1;
@@ -146,7 +146,10 @@ pub fn validate_icon_reference(icon: &str) -> bool {
     }
 
     // Check if it's a system icon name (letters, numbers, hyphens)
-    if icon.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+    if icon
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
         return true;
     }
 
@@ -191,8 +194,10 @@ pub fn get_profiles_path() -> PathBuf {
 
 /// Ensure config directory exists (Story 3.1: Task 2.4)
 pub fn ensure_config_dir() -> Result<PathBuf, ProfileError> {
-    let config_dir = get_config_dir();
+    ensure_config_dir_at(get_config_dir())
+}
 
+fn ensure_config_dir_at(config_dir: PathBuf) -> Result<PathBuf, ProfileError> {
     if !config_dir.exists() {
         fs::create_dir_all(&config_dir).map_err(ProfileError::IoError)?;
         tracing::info!("Created config directory: {:?}", config_dir);
@@ -645,17 +650,17 @@ mod tests {
 
     #[test]
     fn test_ensure_config_dir() {
-        // Test that ensure_config_dir creates directory if it doesn't exist
-        // Note: This test uses the real config path - in CI, use temp dir override
-        let config_dir = get_config_dir();
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir = temp_dir.path().join(CONFIG_DIR_NAME);
 
-        // Call ensure_config_dir - should succeed (creates if needed or uses existing)
-        let result = ensure_config_dir();
+        let result = ensure_config_dir_at(config_dir.clone());
         assert!(result.is_ok(), "ensure_config_dir should succeed");
 
-        // Verify the directory now exists
         let returned_path = result.unwrap();
-        assert!(returned_path.exists(), "Config directory should exist after ensure_config_dir");
+        assert!(
+            returned_path.exists(),
+            "Config directory should exist after ensure_config_dir"
+        );
         assert_eq!(returned_path, config_dir);
     }
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,18 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
 
+          gtkRuntimeLibs = with pkgs; [
+            glib
+            gtk4
+            libadwaita
+            gtk4-layer-shell
+            (lib.getLib pango)
+            gdk-pixbuf
+            graphene
+            gobject-introspection
+            harfbuzz
+          ];
+
           # Python environment with both PyQt6 (overlay) and PyGObject (settings)
           pythonEnv = pkgs.python3.withPackages (ps: with ps; [
             pyqt6
@@ -56,13 +68,10 @@
               gobject-introspection
             ];
 
-            buildInputs = with pkgs; [
-              gtk4
-              libadwaita
-              gtk4-layer-shell
+            buildInputs = gtkRuntimeLibs ++ (with pkgs; [
               qt6.qtbase
               qt6.qtsvg
-            ];
+            ]);
 
             dontBuild = true;
             dontWrapQtApps = true;
@@ -147,8 +156,7 @@
 
             # Wrap launcher scripts with GTK/Qt environment variables
             postFixup = let
-              gtkLibs = with pkgs; [ glib gtk4 libadwaita gtk4-layer-shell pango gdk-pixbuf ];
-              typelibPath = pkgs.lib.makeSearchPath "lib/girepository-1.0" gtkLibs;
+              typelibPath = pkgs.lib.makeSearchPath "lib/girepository-1.0" gtkRuntimeLibs;
               qtPluginPath = pkgs.lib.makeSearchPath "lib/qt-6/plugins" [ pkgs.qt6.qtbase pkgs.qt6.qtsvg ];
             in ''
               wrapProgram $out/bin/juhradial-mx \
@@ -212,7 +220,7 @@
               rustc cargo pkg-config
               dbus systemd
               (python3.withPackages (ps: with ps; [ pyqt6 pygobject3 ]))
-              gtk4 libadwaita gtk4-layer-shell
+              gtk4 libadwaita gtk4-layer-shell graphene harfbuzz
               qt6.qtbase qt6.qtsvg
               gobject-introspection
             ];


### PR DESCRIPTION
## Summary
- make the profile config-directory unit test use a temporary path instead of the real user config directory, so Nix sandbox builds do not need to disable checks
- add the missing GTK/GI runtime libraries to the Nix package wrapper used by `juhradial-settings`
- keep the public diff limited to `daemon/src/profiles.rs` and `flake.nix`

## Validation
- `cargo check`
- `HOME=/homeless-shelter cargo test profiles::tests::test_ensure_config_dir`
- `HOME=/homeless-shelter cargo test --lib`
- `cargo clippy --lib -- -D warnings -A clippy::too_many_arguments`
- `rustfmt --edition 2021 --check src/profiles.rs`
- `git diff --check`

Note: I could not run `nix build` locally because Nix is not installed in this environment.