### PR TITLE
fix: prevent multiple side buttons from opening radial menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@
 #
 # Usage:
 #   make build   - Build the Rust daemon
+#   make test    - Run unit tests
+#   make fmt     - Format code with rustfmt
+#   make clippy  - Run Rust linter
+#   make check   - Run fmt check, clippy, and tests
 #   make clean   - Clean build artifacts
 #   make run     - Run JuhRadial MX (daemon + overlay)
 
-.PHONY: all build clean run help
+.PHONY: all build test fmt clippy check clean run help
 
 # Default target
 all: build
@@ -15,6 +19,28 @@ build:
 	@echo "Building Rust daemon..."
 	cd daemon && cargo build --release
 	@echo "✓ Daemon built: daemon/target/release/juhradiald"
+
+# Run unit tests
+test:
+	@echo "Running unit tests..."
+	cd daemon && cargo test --lib
+	@echo "✓ Tests passed"
+
+# Format code with rustfmt
+fmt:
+	@echo "Formatting code..."
+	cd daemon && cargo fmt
+	@echo "✓ Code formatted"
+
+# Run Rust linter
+clippy:
+	@echo "Running clippy linter..."
+	cd daemon && cargo clippy --all-targets -- -D warnings
+	@echo "✓ No clippy warnings"
+
+# Run all quality checks
+check: fmt clippy test
+	@echo "✓ All checks passed"
 
 # Clean build artifacts
 clean:
@@ -34,7 +60,11 @@ help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  build  - Build the Rust daemon (default)"
-	@echo "  clean  - Clean build artifacts"
-	@echo "  run    - Build and run JuhRadial MX"
-	@echo "  help   - Show this help"
+	@echo "  build   - Build the Rust daemon (default)"
+	@echo "  test    - Run unit tests"
+	@echo "  fmt     - Format code with rustfmt"
+	@echo "  clippy  - Run Rust linter"
+	@echo "  check   - Run fmt check, clippy, and tests"
+	@echo "  clean   - Clean build artifacts"
+	@echo "  run     - Build and run JuhRadial MX"
+	@echo "  help    - Show this help"

--- a/daemon/src/battery.rs
+++ b/daemon/src/battery.rs
@@ -525,7 +525,11 @@ pub async fn start_battery_updater_shared(
             let mut s = state.write().await;
             s.available = false;
             s.error = Some(format!("{}", e));
-            tracing::warn!(error = %e, "Failed initial battery query");
+            if matches!(&e, crate::hidpp::HapticError::DeviceNotFound) {
+                tracing::info!(error = %e, "Battery unavailable: HID++ device not connected yet");
+            } else {
+                tracing::warn!(error = %e, "Failed initial battery query");
+            }
         }
     }
 
@@ -557,8 +561,20 @@ pub async fn start_battery_updater_shared(
                 s.available = false;
                 s.error = Some(format!("{}", e));
 
-                // Only log warning for first few errors, then go quiet
-                if consecutive_errors <= 3 {
+                // DeviceNotFound is expected while optional HID++ path is unavailable.
+                // Keep logs informational and non-spammy in that case.
+                if matches!(&e, crate::hidpp::HapticError::DeviceNotFound) {
+                    if consecutive_errors == 1 {
+                        tracing::info!(
+                            error = %e,
+                            "Battery unavailable: HID++ device not connected"
+                        );
+                    } else if consecutive_errors == 4 {
+                        tracing::info!(
+                            "Battery queries failing repeatedly - suppressing further warnings"
+                        );
+                    }
+                } else if consecutive_errors <= 3 {
                     tracing::warn!(error = %e, "Failed to query battery (shared)");
                 } else if consecutive_errors == 4 {
                     tracing::info!(

--- a/daemon/src/dbus/interface.rs
+++ b/daemon/src/dbus/interface.rs
@@ -3,11 +3,13 @@
 //! All methods, signals, and properties for org.kde.juhradialmx.Daemon.
 //! This must be a single `#[interface]` impl block per zbus requirements.
 
-use zbus::{interface, object_server::SignalEmitter, fdo};
+use super::service::JuhRadialService;
 use crate::config::Config;
 use crate::hidpp::HapticEvent;
 use crate::macros::events_to_actions;
-use super::service::JuhRadialService;
+use std::sync::mpsc;
+use std::time::Duration;
+use zbus::{fdo, interface, object_server::SignalEmitter};
 
 #[interface(name = "org.kde.juhradialmx.Daemon")]
 impl JuhRadialService {
@@ -103,17 +105,24 @@ impl JuhRadialService {
             }
         };
 
-        tracing::debug!("Attempting to lock haptic_manager");
-        match self.haptic_manager.lock() {
-            Ok(mut manager) => {
-                tracing::debug!("Lock acquired, calling emit()");
-                match manager.emit(haptic_event) {
-                    Ok(()) => tracing::info!("Haptic emit succeeded"),
-                    Err(e) => tracing::warn!(error = %e, "Haptic emit failed"),
-                }
+        let manager = self.haptic_manager.clone();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = match manager.lock() {
+                Ok(mut mgr) => mgr.emit(haptic_event).map_err(|e| format!("{}", e)),
+                Err(e) => Err(format!("Lock error: {}", e)),
+            };
+            let _ = tx.send(result);
+        });
+
+        match rx.recv_timeout(Duration::from_millis(400)) {
+            Ok(Ok(())) => tracing::info!("Haptic emit succeeded"),
+            Ok(Err(msg)) => tracing::warn!(error = %msg, "Haptic emit failed"),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                tracing::warn!(event, "TriggerHaptic timed out waiting for HID++ lock");
             }
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to lock haptic manager");
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                tracing::warn!("TriggerHaptic worker disconnected before reply");
             }
         }
 
@@ -164,7 +173,10 @@ impl JuhRadialService {
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "Failed to lock haptic manager for update");
-                        return Err(fdo::Error::Failed(format!("Haptic manager lock error: {}", e)));
+                        return Err(fdo::Error::Failed(format!(
+                            "Haptic manager lock error: {}",
+                            e
+                        )));
                     }
                 }
 
@@ -216,22 +228,39 @@ impl JuhRadialService {
     async fn set_dpi(&self, dpi: u16) -> fdo::Result<()> {
         tracing::info!(dpi, "SetDpi called");
 
-        match self.haptic_manager.lock() {
-            Ok(mut manager) => {
-                match manager.set_dpi(dpi) {
-                    Ok(()) => {
-                        tracing::info!(dpi, "DPI set successfully");
-                        Ok(())
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, dpi, "Failed to set DPI");
-                        Err(fdo::Error::Failed(format!("Failed to set DPI: {}", e)))
-                    }
+        let manager = self.haptic_manager.clone();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = match manager.lock() {
+                Ok(mut mgr) => mgr.set_dpi(dpi).map_err(|e| format!("{}", e)),
+                Err(e) => Err(format!("Lock error: {}", e)),
+            };
+            let _ = tx.send(result);
+        });
+
+        match rx.recv_timeout(Duration::from_secs(2)) {
+            Ok(Ok(())) => {
+                tracing::info!(dpi, "DPI set successfully");
+                Ok(())
+            }
+            Ok(Err(msg)) => {
+                // HID++ is optional in some Bluetooth setups; avoid surfacing
+                // a hard D-Bus error when the device is simply not connected.
+                if msg.to_ascii_lowercase().contains("not connected") {
+                    tracing::info!(error = %msg, dpi, "SetDpi skipped: HID++ device not connected");
+                    Ok(())
+                } else {
+                    tracing::error!(error = %msg, dpi, "Failed to set DPI");
+                    Err(fdo::Error::Failed(format!("Failed to set DPI: {}", msg)))
                 }
             }
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to lock haptic manager for set_dpi");
-                Err(fdo::Error::Failed(format!("Lock error: {}", e)))
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                tracing::warn!(dpi, "SetDpi timed out waiting for HID++ response");
+                Ok(())
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                tracing::error!("SetDpi worker disconnected before reply");
+                Ok(())
             }
         }
     }
@@ -252,16 +281,14 @@ impl JuhRadialService {
 
     async fn get_smart_shift(&self) -> fdo::Result<(bool, u8)> {
         match self.haptic_manager.lock() {
-            Ok(mut manager) => {
-                match manager.get_smartshift() {
-                    Some((_wheel_mode, auto_disengage, _auto_disengage_default)) => {
-                        let enabled = auto_disengage > 0;
-                        let threshold = if enabled { auto_disengage } else { 30 };
-                        Ok((enabled, threshold))
-                    }
-                    None => Ok((false, 0))
+            Ok(mut manager) => match manager.get_smartshift() {
+                Some((_wheel_mode, auto_disengage, _auto_disengage_default)) => {
+                    let enabled = auto_disengage > 0;
+                    let threshold = if enabled { auto_disengage } else { 30 };
+                    Ok((enabled, threshold))
                 }
-            }
+                None => Ok((false, 0)),
+            },
             Err(e) => {
                 tracing::error!(error = %e, "Failed to lock haptic manager for get_smart_shift");
                 Ok((false, 0))
@@ -285,7 +312,10 @@ impl JuhRadialService {
                     }
                     Err(e) => {
                         tracing::error!(error = %e, enabled, threshold, "Failed to set SmartShift");
-                        Err(fdo::Error::Failed(format!("Failed to set SmartShift: {}", e)))
+                        Err(fdo::Error::Failed(format!(
+                            "Failed to set SmartShift: {}",
+                            e
+                        )))
                     }
                 }
             }
@@ -312,12 +342,10 @@ impl JuhRadialService {
 
     async fn get_hiresscroll_mode(&self) -> fdo::Result<(bool, bool, bool)> {
         match self.haptic_manager.lock() {
-            Ok(mut manager) => {
-                match manager.get_hiresscroll_mode() {
-                    Some((hires, invert, target)) => Ok((hires, invert, target)),
-                    None => Ok((true, false, false))
-                }
-            }
+            Ok(mut manager) => match manager.get_hiresscroll_mode() {
+                Some((hires, invert, target)) => Ok((hires, invert, target)),
+                None => Ok((true, false, false)),
+            },
             Err(e) => {
                 tracing::error!(error = %e, "Failed to lock haptic manager for get_hiresscroll_mode");
                 Ok((true, false, false))
@@ -325,22 +353,28 @@ impl JuhRadialService {
         }
     }
 
-    async fn set_hiresscroll_mode(&self, hires: bool, invert: bool, target: bool) -> fdo::Result<()> {
+    async fn set_hiresscroll_mode(
+        &self,
+        hires: bool,
+        invert: bool,
+        target: bool,
+    ) -> fdo::Result<()> {
         tracing::info!(hires, invert, target, "SetHiResScrollMode called");
 
         match self.haptic_manager.lock() {
-            Ok(mut manager) => {
-                match manager.set_hiresscroll_mode(hires, invert, target) {
-                    Ok(()) => {
-                        tracing::info!(hires, invert, target, "HiResScroll mode set successfully");
-                        Ok(())
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, hires, invert, target, "Failed to set HiResScroll mode");
-                        Err(fdo::Error::Failed(format!("Failed to set HiResScroll mode: {}", e)))
-                    }
+            Ok(mut manager) => match manager.set_hiresscroll_mode(hires, invert, target) {
+                Ok(()) => {
+                    tracing::info!(hires, invert, target, "HiResScroll mode set successfully");
+                    Ok(())
                 }
-            }
+                Err(e) => {
+                    tracing::error!(error = %e, hires, invert, target, "Failed to set HiResScroll mode");
+                    Err(fdo::Error::Failed(format!(
+                        "Failed to set HiResScroll mode: {}",
+                        e
+                    )))
+                }
+            },
             Err(e) => {
                 tracing::error!(error = %e, "Failed to lock haptic manager for set_hiresscroll_mode");
                 Err(fdo::Error::Failed(format!("Lock error: {}", e)))
@@ -368,18 +402,20 @@ impl JuhRadialService {
 
     async fn get_easy_switch_info(&self) -> fdo::Result<(u8, u8)> {
         match self.haptic_manager.lock() {
-            Ok(mut manager) => {
-                match manager.get_easy_switch_info() {
-                    Some((num, current)) => {
-                        tracing::info!(num_hosts = num, current_host = current, "Easy-Switch info retrieved");
-                        Ok((num, current))
-                    }
-                    None => {
-                        tracing::debug!("Easy-Switch not supported or unavailable");
-                        Ok((0, 0))
-                    }
+            Ok(mut manager) => match manager.get_easy_switch_info() {
+                Some((num, current)) => {
+                    tracing::info!(
+                        num_hosts = num,
+                        current_host = current,
+                        "Easy-Switch info retrieved"
+                    );
+                    Ok((num, current))
                 }
-            }
+                None => {
+                    tracing::debug!("Easy-Switch not supported or unavailable");
+                    Ok((0, 0))
+                }
+            },
             Err(e) => {
                 tracing::error!(error = %e, "Failed to lock haptic manager for get_easy_switch_info");
                 Ok((0, 0))
@@ -389,18 +425,16 @@ impl JuhRadialService {
 
     async fn set_host(&self, host_index: u8) -> fdo::Result<bool> {
         match self.haptic_manager.lock() {
-            Ok(mut manager) => {
-                match manager.set_current_host(host_index) {
-                    Ok(()) => {
-                        tracing::info!(host_index, "Switched to Easy-Switch host");
-                        Ok(true)
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, host_index, "Failed to switch host");
-                        Ok(false)
-                    }
+            Ok(mut manager) => match manager.set_current_host(host_index) {
+                Ok(()) => {
+                    tracing::info!(host_index, "Switched to Easy-Switch host");
+                    Ok(true)
                 }
-            }
+                Err(e) => {
+                    tracing::error!(error = %e, host_index, "Failed to switch host");
+                    Ok(false)
+                }
+            },
             Err(e) => {
                 tracing::error!(error = %e, "Failed to lock haptic manager for set_host");
                 Ok(false)
@@ -416,18 +450,16 @@ impl JuhRadialService {
         tracing::info!("StartMacroRecording called");
 
         match self.macro_recorder.lock() {
-            Ok(mut recorder) => {
-                match recorder.start() {
-                    Ok(()) => {
-                        tracing::info!("Macro recording started");
-                        Ok(())
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, "Failed to start recording");
-                        Err(fdo::Error::Failed(format!("Recording failed: {}", e)))
-                    }
+            Ok(mut recorder) => match recorder.start() {
+                Ok(()) => {
+                    tracing::info!("Macro recording started");
+                    Ok(())
                 }
-            }
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to start recording");
+                    Err(fdo::Error::Failed(format!("Recording failed: {}", e)))
+                }
+            },
             Err(e) => {
                 tracing::error!(error = %e, "Failed to lock macro recorder");
                 Err(fdo::Error::Failed(format!("Lock error: {}", e)))
@@ -476,7 +508,9 @@ impl JuhRadialService {
 
         let macro_id = config.id.clone();
         {
-            let mut engine = self.macro_engine.lock()
+            let mut engine = self
+                .macro_engine
+                .lock()
                 .map_err(|e| fdo::Error::Failed(format!("Lock error: {}", e)))?;
             engine.execute(config);
         }
@@ -497,7 +531,9 @@ impl JuhRadialService {
 
         let macro_id = config.id.clone();
         {
-            let mut engine = self.macro_engine.lock()
+            let mut engine = self
+                .macro_engine
+                .lock()
                 .map_err(|e| fdo::Error::Failed(format!("Lock error: {}", e)))?;
             engine.execute(config);
         }
@@ -513,7 +549,9 @@ impl JuhRadialService {
         tracing::info!("StopMacro called");
 
         {
-            let mut engine = self.macro_engine.lock()
+            let mut engine = self
+                .macro_engine
+                .lock()
                 .map_err(|e| fdo::Error::Failed(format!("Lock error: {}", e)))?;
             engine.stop();
         }
@@ -549,8 +587,7 @@ impl JuhRadialService {
             .map_err(|e| fdo::Error::Failed(format!("Failed to load macros: {}", e)))?;
 
         let list: Vec<&crate::macros::MacroConfig> = macros.values().collect();
-        serde_json::to_string(&list)
-            .map_err(|e| fdo::Error::Failed(format!("JSON error: {}", e)))
+        serde_json::to_string(&list).map_err(|e| fdo::Error::Failed(format!("JSON error: {}", e)))
     }
 
     async fn is_macro_running(&self) -> fdo::Result<bool> {
@@ -599,7 +636,9 @@ impl JuhRadialService {
         tracing::info!(enabled, "SetGamingMode called");
 
         {
-            let mut gm = self.gaming_mode.write()
+            let mut gm = self
+                .gaming_mode
+                .write()
                 .map_err(|e| fdo::Error::Failed(format!("Lock error: {}", e)))?;
             if enabled {
                 gm.enable();

--- a/daemon/src/evdev.rs
+++ b/daemon/src/evdev.rs
@@ -24,6 +24,7 @@ pub const LOGITECH_VENDOR_ID: u16 = 0x046D;
 /// Known MX Master 4 product IDs (varies by connection type)
 pub const MX_MASTER_4_PRODUCT_IDS: &[u16] = &[
     0xB034, // USB receiver
+    0xB042, // Newer USB/Bluetooth variant seen on Linux evdev
     0xB035, // Bluetooth
     0x4082, // Bolt receiver (variant)
     0xC548, // Unifying receiver (fallback)
@@ -31,6 +32,9 @@ pub const MX_MASTER_4_PRODUCT_IDS: &[u16] = &[
 
 /// Gesture button key code (MX Master 4 haptic thumb button)
 pub const GESTURE_BUTTON_CODES: &[u16] = &[
+    0x113, // BTN_SIDE - common thumb/gesture mapping on some MX firmware paths
+    0x114, // BTN_EXTRA - alternate side-button mapping
+    0x115, // BTN_FORWARD - alternate mapping on some stacks
     0x116, // BTN_BACK - this is the haptic/gesture button on MX Master 4
 ];
 
@@ -429,19 +433,21 @@ impl EvdevHandler {
             return Ok(None);
         }
 
-        // Check if this device has the gesture button keys (BTN_SIDE or BTN_EXTRA)
-        // This filters out touchpad devices that have same vendor/product ID
-        // BTN_SIDE = 0x113 (275), BTN_EXTRA = 0x114 (276)
+        // Check if this device exposes at least one configured gesture button key.
+        // This filters out non-mouse Logitech devices that may share product IDs.
         let supported_keys = device.supported_keys();
         let has_gesture_buttons = supported_keys
             .map(|keys| {
-                // Check by raw key codes
-                keys.iter().any(|k| k.code() == 0x113 || k.code() == 0x114)
+                keys.iter()
+                    .any(|k| GESTURE_BUTTON_CODES.contains(&k.code()))
             })
             .unwrap_or(false);
 
-        // Only consider devices with gesture buttons as MX Master 4
-        let is_mx_master_4 = MX_MASTER_4_PRODUCT_IDS.contains(&product_id) && has_gesture_buttons;
+        // Prefer strict key-capability match, but fall back to product+name for
+        // connection variants where the gesture key is remapped by firmware.
+        let looks_like_mx_by_name = name.to_ascii_lowercase().contains("mx master");
+        let is_mx_master_4 = MX_MASTER_4_PRODUCT_IDS.contains(&product_id)
+            && (has_gesture_buttons || looks_like_mx_by_name);
 
         if is_mx_master_4 {
             tracing::debug!(
@@ -509,7 +515,7 @@ impl EvdevHandler {
     /// Run the event loop on Linux
     #[cfg(target_os = "linux")]
     async fn run_event_loop(&mut self) -> Result<(), EvdevError> {
-        use evdev::{Device, EventType, RelativeAxisCode, uinput::VirtualDevice as UinputDevice};
+        use evdev::{uinput::VirtualDevice as UinputDevice, Device, EventType, RelativeAxisCode};
 
         // Find the device based on mode
         let device_info = if self.generic_mode {
@@ -604,10 +610,19 @@ impl EvdevHandler {
                     if let Some(ref mut vdev) = virtual_device {
                         if event.event_type() == EventType::SYNCHRONIZATION {
                             if !event_batch.is_empty() {
-                                let _ = vdev.emit(&event_batch);
+                                if let Err(e) = vdev.emit(&event_batch) {
+                                    tracing::warn!(
+                                        error = %e,
+                                        batch_len = event_batch.len(),
+                                        "Failed to forward grabbed input batch to virtual device"
+                                    );
+                                }
                                 event_batch.clear();
                             }
-                        } else if !is_suppressed_key {
+                        } else if !is_suppressed_key
+                            && (event.event_type() == EventType::KEY
+                                || event.event_type() == EventType::RELATIVE)
+                        {
                             event_batch.push(event);
                         }
                     }
@@ -624,7 +639,7 @@ impl EvdevHandler {
                                 GESTURE_BUTTON_CODES.contains(&key_code)
                             };
                             if is_trigger {
-                                self.handle_gesture_event(event.value()).await;
+                                self.handle_gesture_event(key_code, event.value()).await;
                             } else if !PRIMARY_BUTTONS.contains(&key_code) {
                                 // Forward non-primary, non-gesture buttons for macro trigger detection
                                 let value = event.value();
@@ -639,35 +654,33 @@ impl EvdevHandler {
                                 }
                             }
                         }
-                        EventType::RELATIVE => {
+                        EventType::RELATIVE if self.menu_active => {
                             // Track mouse movement while menu is active
-                            if self.menu_active {
-                                let code = RelativeAxisCode(event.code());
-                                let value = event.value();
+                            let code = RelativeAxisCode(event.code());
+                            let value = event.value();
 
-                                match code {
-                                    RelativeAxisCode::REL_X => {
-                                        self.cursor_x += value;
-                                        let _ = self
-                                            .event_tx
-                                            .send(GestureEvent::CursorMoved {
-                                                x: self.cursor_x,
-                                                y: self.cursor_y,
-                                            })
-                                            .await;
-                                    }
-                                    RelativeAxisCode::REL_Y => {
-                                        self.cursor_y += value;
-                                        let _ = self
-                                            .event_tx
-                                            .send(GestureEvent::CursorMoved {
-                                                x: self.cursor_x,
-                                                y: self.cursor_y,
-                                            })
-                                            .await;
-                                    }
-                                    _ => {}
+                            match code {
+                                RelativeAxisCode::REL_X => {
+                                    self.cursor_x += value;
+                                    let _ = self
+                                        .event_tx
+                                        .send(GestureEvent::CursorMoved {
+                                            x: self.cursor_x,
+                                            y: self.cursor_y,
+                                        })
+                                        .await;
                                 }
+                                RelativeAxisCode::REL_Y => {
+                                    self.cursor_y += value;
+                                    let _ = self
+                                        .event_tx
+                                        .send(GestureEvent::CursorMoved {
+                                            x: self.cursor_x,
+                                            y: self.cursor_y,
+                                        })
+                                        .await;
+                                }
+                                _ => {}
                             }
                         }
                         _ => {}
@@ -685,32 +698,40 @@ impl EvdevHandler {
         }
     }
 
-    /// Get the configured action for the evdev trigger button.
+    /// Get the configured action for a given evdev side-button code.
     ///
     /// On MX Master 4, the radial thumb button normally arrives through HID++
-    /// as CID 0x01A0 and maps to `buttons.thumb`. If Easy-Switch clears HID++
-    /// volatile divert, that same physical control falls back to evdev 0x116,
-    /// so this fallback path must use the thumb action as well.
-    fn get_evdev_button_action(&self) -> crate::config::ButtonAction {
+    /// as CID 0x01A0 and maps to `buttons.thumb`. If HID++ divert is lost,
+    /// button events may fall back to evdev; in that case we map by key code
+    /// so the gesture side buttons keep using `buttons.gesture`.
+    fn get_evdev_button_action_for_code(&self, key_code: u16) -> crate::config::ButtonAction {
         if self.generic_mode {
             return crate::config::ButtonAction::RadialMenu;
         }
 
         if let Some(ref config) = self.shared_config {
             if let Ok(cfg) = config.read() {
-                return cfg.buttons.thumb;
+                return match key_code {
+                    0x116 => cfg.buttons.thumb,           // BTN_BACK (thumb/haptic)
+                    0x113..=0x115 => cfg.buttons.gesture, // Other side mappings
+                    _ => cfg.buttons.thumb,
+                };
             }
         }
-        // Default fallback
-        crate::config::ButtonAction::RadialMenu
+        // Default fallback if config is unavailable.
+        match key_code {
+            0x116 => crate::config::ButtonAction::RadialMenu,
+            0x113..=0x115 => crate::config::ButtonAction::VirtualDesktops,
+            _ => crate::config::ButtonAction::RadialMenu,
+        }
     }
 
     /// Handle a gesture button event
-    async fn handle_gesture_event(&mut self, value: i32) {
+    async fn handle_gesture_event(&mut self, key_code: u16, value: i32) {
         match value {
             1 => {
                 // Button pressed - check configured action
-                let action = self.get_evdev_button_action();
+                let action = self.get_evdev_button_action_for_code(key_code);
                 self.active_button_action = Some(action);
                 self.press_time = Some(Instant::now());
 
@@ -972,12 +993,17 @@ mod tests {
     fn test_mx_master_4_product_ids() {
         assert!(!MX_MASTER_4_PRODUCT_IDS.is_empty());
         assert!(MX_MASTER_4_PRODUCT_IDS.contains(&0xB034));
+        assert!(MX_MASTER_4_PRODUCT_IDS.contains(&0xB042));
     }
 
     #[test]
     fn test_gesture_button_codes() {
         assert!(!GESTURE_BUTTON_CODES.is_empty());
-        // BTN_BACK - haptic/gesture button on MX Master 4
+        // Accept multiple firmware/input-stack mappings for the MX thumb button.
+        assert!(GESTURE_BUTTON_CODES.contains(&0x113));
+        assert!(GESTURE_BUTTON_CODES.contains(&0x114));
+        assert!(GESTURE_BUTTON_CODES.contains(&0x115));
+        // BTN_BACK - classic haptic/gesture mapping on MX Master.
         assert!(GESTURE_BUTTON_CODES.contains(&0x116));
     }
 
@@ -998,7 +1024,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mx_evdev_fallback_uses_thumb_action() {
+    fn test_mx_evdev_thumb_and_gesture_are_distinct() {
         let (tx, _rx) = mpsc::channel(1);
         let mut handler = EvdevHandler::new(tx);
         let config = crate::config::Config {
@@ -1012,8 +1038,12 @@ mod tests {
         handler.set_shared_config(std::sync::Arc::new(std::sync::RwLock::new(config)));
 
         assert_eq!(
-            handler.get_evdev_button_action(),
+            handler.get_evdev_button_action_for_code(0x116),
             crate::config::ButtonAction::RadialMenu
+        );
+        assert_eq!(
+            handler.get_evdev_button_action_for_code(0x113),
+            crate::config::ButtonAction::VirtualDesktops
         );
     }
 
@@ -1032,7 +1062,7 @@ mod tests {
         handler.set_shared_config(std::sync::Arc::new(std::sync::RwLock::new(config)));
 
         assert_eq!(
-            handler.get_evdev_button_action(),
+            handler.get_evdev_button_action_for_code(0x113),
             crate::config::ButtonAction::RadialMenu
         );
     }

--- a/daemon/src/hidpp/constants.rs
+++ b/daemon/src/hidpp/constants.rs
@@ -9,6 +9,8 @@ pub const LOGITECH_VENDOR_ID: u16 = 0x046D;
 pub mod product_ids {
     /// MX Master 4 via USB
     pub const MX_MASTER_4_USB: u16 = 0xB034;
+    /// MX Master 4 via USB/Bluetooth variant seen on newer firmware
+    pub const MX_MASTER_4_USB_ALT: u16 = 0xB042;
     /// MX Master 4 via Bolt receiver
     pub const MX_MASTER_4_BOLT: u16 = 0xC548;
     /// Bolt receiver itself

--- a/daemon/src/hidpp/device.rs
+++ b/daemon/src/hidpp/device.rs
@@ -16,6 +16,10 @@ use super::patterns::Mx4HapticPattern;
 
 /// Software ID for HID++ message tracking
 const SOFTWARE_ID: u8 = 0x01;
+/// Default request poll attempts (attempt * 10ms)
+const HIDPP_DEFAULT_MAX_ATTEMPTS: u32 = 100;
+/// Faster probe timeout used during initial device discovery
+const HIDPP_DISCOVERY_MAX_ATTEMPTS: u32 = 20;
 
 /// HID++ device wrapper for communication with MX Master 4
 ///
@@ -58,6 +62,9 @@ pub struct HidppDevice {
     reprog_controls_feature_index: Option<u8>,
     /// Path to the hidraw device we connected to
     device_path: PathBuf,
+    /// Whether this device only responds to long HID++ reports (0x11) and not short (0x10).
+    /// Set when long-format ping validation succeeds but short-format fails (e.g. Bolt/BT devices).
+    use_long_reports: bool,
 }
 
 impl HidppDevice {
@@ -72,7 +79,9 @@ impl HidppDevice {
             return Vec::new();
         }
 
-        let mut candidates: Vec<(PathBuf, String, ConnectionType)> = Vec::new();
+        // Candidate tuple:
+        // (dev_path, uevent_text, connection_type, is_mx_master_like, is_mouse_like)
+        let mut candidates: Vec<(PathBuf, String, ConnectionType, bool, bool)> = Vec::new();
 
         let entries = match std::fs::read_dir(&hidraw_dir) {
             Ok(e) => e,
@@ -99,46 +108,77 @@ impl HidppDevice {
                 } else if uevent.contains("C52B") || uevent.contains("c52b") {
                     // Unifying receiver
                     ConnectionType::Unifying
-                } else if uevent.contains("B034") || uevent.contains("b034") {
+                } else if uevent.contains("B034")
+                    || uevent.contains("b034")
+                    || uevent.contains("B042")
+                    || uevent.contains("b042")
+                {
                     // MX Master 4 direct USB
                     ConnectionType::Usb
                 } else {
-                    // Other Logitech device - check if interface 2
-                    if uevent.contains("input2") {
-                        ConnectionType::Bluetooth
-                    } else {
-                        continue;
-                    }
+                    // Other Logitech HID interface. Some kernels/receivers do not
+                    // expose the expected product marker in uevent; keep it as a
+                    // candidate and probe both direct and receiver indices later.
+                    ConnectionType::Bluetooth
                 };
 
                 if let Some(name) = path.file_name() {
                     let dev_path = PathBuf::from("/dev").join(name);
-                    candidates.push((dev_path, uevent, connection_type));
+                    let uevent_lc = uevent.to_ascii_lowercase();
+                    let is_mx_master_like = uevent_lc.contains("hid_name=mx master")
+                        || uevent_lc.contains("p0000b042")
+                        || uevent_lc.contains("p0000b034")
+                        || uevent_lc.contains("p0000b035");
+                    let is_mouse_like = is_mx_master_like
+                        || uevent_lc.contains("hid_name=") && uevent_lc.contains("mouse");
+
+                    candidates.push((
+                        dev_path,
+                        uevent,
+                        connection_type,
+                        is_mx_master_like,
+                        is_mouse_like,
+                    ));
                 }
             }
         }
 
-        // Sort: interface 2 devices first (preferred for HID++)
+        // Sort order:
+        // 1) Explicit MX Master candidates first
+        // 2) Mouse-like HID names before keyboard/other Logitech HIDs
+        // 3) interface2 preference (legacy heuristic)
         candidates.sort_by(|a, b| {
+            let mx_cmp = b.3.cmp(&a.3);
+            if mx_cmp != std::cmp::Ordering::Equal {
+                return mx_cmp;
+            }
+
+            let mouse_cmp = b.4.cmp(&a.4);
+            if mouse_cmp != std::cmp::Ordering::Equal {
+                return mouse_cmp;
+            }
+
             let a_is_input2 = a.1.contains("input2");
             let b_is_input2 = b.1.contains("input2");
             b_is_input2.cmp(&a_is_input2)
         });
 
         // Log all candidates
-        for (dev_path, uevent, conn_type) in &candidates {
+        for (dev_path, uevent, conn_type, is_mx_master_like, is_mouse_like) in &candidates {
             let is_input2 = uevent.contains("input2");
             tracing::debug!(
                 path = %dev_path.display(),
                 connection = %conn_type,
                 is_input2,
+                is_mx_master_like,
+                is_mouse_like,
                 "Found Logitech HID++ candidate"
             );
         }
 
         candidates
             .into_iter()
-            .map(|(path, _, conn_type)| (path, conn_type))
+            .map(|(path, _, conn_type, _, _)| (path, conn_type))
             .collect()
     }
 
@@ -167,10 +207,14 @@ impl HidppDevice {
             // Determine device indices to try based on connection type
             // Bolt receivers can have the mouse on any slot (1-6), so try them all
             let indices_to_try: Vec<u8> = match connection_type {
-                ConnectionType::Usb => vec![0xFF],
-                ConnectionType::Bolt => vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
-                ConnectionType::Unifying => vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
-                ConnectionType::Bluetooth => vec![0xFF],
+                // Some direct-connected variants (especially BT stacks exposing
+                // B042) may answer on a receiver-style slot instead of 0xFF.
+                ConnectionType::Usb => vec![0xFF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
+                ConnectionType::Bolt => vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0xFF],
+                ConnectionType::Unifying => vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0xFF],
+                // For unknown Logitech interfaces, probe both direct-device and
+                // receiver slots to avoid false negatives.
+                ConnectionType::Bluetooth => vec![0xFF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
             };
 
             // Open the device with read/write and non-blocking
@@ -224,6 +268,7 @@ impl HidppDevice {
                     reprog_controls_supported: false,
                     reprog_controls_feature_index: None,
                     device_path: device_path.clone(),
+                    use_long_reports: false,
                 };
 
                 // Try HID++ validation with retry for sleeping devices
@@ -300,6 +345,32 @@ impl HidppDevice {
     ///
     /// Uses polling with timeout (same approach as battery module).
     fn hidpp_request(&mut self, feature_index: u8, function: u8, params: &[u8]) -> Option<Vec<u8>> {
+        self.hidpp_request_with_attempts(
+            feature_index,
+            function,
+            params,
+            HIDPP_DEFAULT_MAX_ATTEMPTS,
+        )
+    }
+
+    /// Send a HID++ request with a caller-defined timeout budget.
+    fn hidpp_request_with_attempts(
+        &mut self,
+        feature_index: u8,
+        function: u8,
+        params: &[u8],
+        max_attempts: u32,
+    ) -> Option<Vec<u8>> {
+        // Delegate to long format if this device only responds to long reports
+        if self.use_long_reports {
+            return self.hidpp_long_request_with_attempts(
+                feature_index,
+                function,
+                params,
+                max_attempts,
+            );
+        }
+
         // Drain any pending data first
         self.drain_buffer();
 
@@ -351,7 +422,7 @@ impl HidppDevice {
                         if response[1] == self.device_index
                             && response[2] == feature_index
                             && resp_function == function
-                            && resp_sw_id == SOFTWARE_ID
+                            && (resp_sw_id == SOFTWARE_ID || resp_sw_id == 0x00)
                         {
                             tracing::debug!("HID++ request matched! Returning response");
                             return Some(response[..len].to_vec());
@@ -416,11 +487,12 @@ impl HidppDevice {
             }
 
             attempts += 1;
-            if attempts > 100 {
+            if attempts > max_attempts {
                 tracing::debug!(
                     feature_index,
                     function,
-                    "HID++ request timeout after 100 attempts"
+                    max_attempts,
+                    "HID++ request timeout"
                 );
                 return None;
             }
@@ -471,6 +543,22 @@ impl HidppDevice {
         function: u8,
         params: &[u8],
     ) -> Option<Vec<u8>> {
+        self.hidpp_long_request_with_attempts(
+            feature_index,
+            function,
+            params,
+            HIDPP_DEFAULT_MAX_ATTEMPTS,
+        )
+    }
+
+    /// Send a long HID++ request with a caller-defined timeout budget.
+    fn hidpp_long_request_with_attempts(
+        &mut self,
+        feature_index: u8,
+        function: u8,
+        params: &[u8],
+        max_attempts: u32,
+    ) -> Option<Vec<u8>> {
         // Drain any pending data first
         self.drain_buffer();
 
@@ -513,7 +601,7 @@ impl HidppDevice {
                         && response[1] == self.device_index
                         && response[2] == feature_index
                         && resp_function == function
-                        && resp_sw_id == SOFTWARE_ID
+                        && (resp_sw_id == SOFTWARE_ID || resp_sw_id == 0x00)
                     {
                         tracing::debug!("HID++ long request matched: {:02X?}", &response[..len]);
                         return Some(response[..len].to_vec());
@@ -539,8 +627,13 @@ impl HidppDevice {
             }
 
             attempts += 1;
-            if attempts > 100 {
-                tracing::debug!(feature_index, function, "HID++ long request timeout");
+            if attempts > max_attempts {
+                tracing::debug!(
+                    feature_index,
+                    function,
+                    max_attempts,
+                    "HID++ long request timeout"
+                );
                 return None;
             }
 
@@ -554,10 +647,30 @@ impl HidppDevice {
         // Ping echoes back the data byte and returns protocol version
         let params = [0x00, 0x00, 0xAA]; // 0xAA is ping data to echo
 
-        if let Some(response) = self.hidpp_request(0x00, 0x01, &params) {
-            // Check if ping data was echoed (byte 6 should be 0xAA)
-            if response.len() >= 7 && response[6] == 0xAA {
-                tracing::debug!("HID++ 2.0 validated, ping echoed successfully");
+        if let Some(response) =
+            self.hidpp_request_with_attempts(0x00, 0x01, &params, HIDPP_DISCOVERY_MAX_ATTEMPTS)
+        {
+            // Some receivers/firmware variants answer ping without echoing the
+            // exact payload byte. If we got a correctly matched HID++ response,
+            // treat the endpoint as valid and let feature enumeration decide if
+            // it is the target mouse.
+            if response.len() >= 4 {
+                tracing::debug!("HID++ validated via ping response");
+                return true;
+            }
+        }
+
+        // Some Bluetooth/Bolt stacks only respond to long HID++ reports (0x11).
+        // If short fails but long succeeds, mark this device so all future
+        // requests use the long format.
+        if let Some(response) =
+            self.hidpp_long_request_with_attempts(0x00, 0x01, &params, HIDPP_DISCOVERY_MAX_ATTEMPTS)
+        {
+            if response.len() >= 4 {
+                tracing::debug!(
+                    "HID++ validated via long ping response (switching to long-only mode)"
+                );
+                self.use_long_reports = true;
                 return true;
             }
         }

--- a/daemon/src/hidraw.rs
+++ b/daemon/src/hidraw.rs
@@ -169,7 +169,11 @@ impl HidrawHandler {
                 } else if uevent.contains("C52B") || uevent.contains("c52b") {
                     // Unifying receiver
                     2
-                } else if uevent.contains("B034") || uevent.contains("b034") {
+                } else if uevent.contains("B034")
+                    || uevent.contains("b034")
+                    || uevent.contains("B042")
+                    || uevent.contains("b042")
+                {
                     // MX Master 4 direct USB
                     2
                 } else {
@@ -185,7 +189,7 @@ impl HidrawHandler {
         }
 
         // Sort by priority (highest first)
-        candidates.sort_by(|a, b| b.2.cmp(&a.2));
+        candidates.sort_by_key(|b| std::cmp::Reverse(b.2));
 
         // Prefer interface 2 (input2) which is typically used for HID++ communication
         let max_priority = candidates.first().map(|(_, _, p)| *p).unwrap_or(0);

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -23,17 +23,30 @@ pub mod window_tracker;
 /// Re-export commonly used types
 pub use accessibility::{AccessibilitySettings, EffectiveAnimationTimings};
 pub use actions::{Action, ActionType};
-pub use battery::{BatteryState, SharedBatteryState, new_shared_state as new_battery_state, start_battery_updater_shared};
-pub use bundled_themes::{get_bundled_theme, get_default_theme, list_bundled_themes, DEFAULT_THEME_NAME};
-pub use config::{Config, SharedConfig, new_shared_config, load_shared_config};
-pub use cursor::{get_cursor_position, get_screen_bounds, CursorPosition, ScreenBounds, EDGE_MARGIN, MENU_DIAMETER, MENU_RADIUS};
-pub use dbus::{init_dbus_service, init_dbus_service_with_device, JuhRadialService, DBUS_INTERFACE, DBUS_NAME, DBUS_PATH};
-pub use evdev::{DeviceInfo, EvdevError, EvdevHandler, GestureEvent, LOGITECH_VENDOR_ID, GENERIC_TRIGGER_BUTTON};
+pub use battery::{
+    new_shared_state as new_battery_state, start_battery_updater_shared, BatteryState,
+    SharedBatteryState,
+};
+pub use bundled_themes::{
+    get_bundled_theme, get_default_theme, list_bundled_themes, DEFAULT_THEME_NAME,
+};
+pub use config::{load_shared_config, new_shared_config, Config, SharedConfig};
+pub use cursor::{
+    get_cursor_position, get_screen_bounds, CursorPosition, ScreenBounds, EDGE_MARGIN,
+    MENU_DIAMETER, MENU_RADIUS,
+};
+pub use dbus::{
+    init_dbus_service, init_dbus_service_with_device, JuhRadialService, DBUS_INTERFACE, DBUS_NAME,
+    DBUS_PATH,
+};
+pub use evdev::{
+    DeviceInfo, EvdevError, EvdevHandler, GestureEvent, GENERIC_TRIGGER_BUTTON, LOGITECH_VENDOR_ID,
+};
+pub use gaming::{new_shared_gaming_mode, GamingMode, SharedGamingMode};
+pub use hidpp::{new_shared_haptic_manager, HapticEvent, HapticManager, SharedHapticManager};
+pub use macros::{MacroEngine, MacroRecorder, SharedTriggerMap, TriggerMap};
 pub use performance_monitor::{BlurMode, PerformanceMonitor};
 pub use profiles::{Profile, ProfileManager};
 pub use theme::{Theme, ThemeManager};
 pub use theme_watcher::{ThemeEvent, ThemeHotReloader, ThemeWatcher};
 pub use window_tracker::{WindowInfo, WindowTracker};
-pub use gaming::{GamingMode, SharedGamingMode, new_shared_gaming_mode};
-pub use hidpp::{HapticManager, HapticEvent, SharedHapticManager, new_shared_haptic_manager};
-pub use macros::{MacroEngine, MacroRecorder, TriggerMap, SharedTriggerMap};

--- a/daemon/src/macros/dpi.rs
+++ b/daemon/src/macros/dpi.rs
@@ -112,7 +112,10 @@ impl DpiManager {
     }
 
     /// Restore the saved DPI (call when leaving gaming mode)
-    pub fn restore_saved_dpi(&mut self, haptic_manager: &SharedHapticManager) -> Result<(), DpiError> {
+    pub fn restore_saved_dpi(
+        &mut self,
+        haptic_manager: &SharedHapticManager,
+    ) -> Result<(), DpiError> {
         if let Some(dpi) = self.saved_dpi.take() {
             tracing::info!(dpi, "Restoring saved DPI");
             set_dpi(haptic_manager, dpi)
@@ -123,7 +126,10 @@ impl DpiManager {
     }
 
     /// Cycle to the next DPI profile and apply it
-    pub fn cycle_next(&mut self, haptic_manager: &SharedHapticManager) -> Result<&DpiProfile, DpiError> {
+    pub fn cycle_next(
+        &mut self,
+        haptic_manager: &SharedHapticManager,
+    ) -> Result<&DpiProfile, DpiError> {
         if self.profiles.is_empty() {
             return Err(DpiError::NoProfile);
         }
@@ -149,7 +155,9 @@ impl Default for DpiManager {
 pub fn set_dpi(haptic_manager: &SharedHapticManager, dpi: u16) -> Result<(), DpiError> {
     match haptic_manager.lock() {
         Ok(mut manager) => {
-            manager.set_dpi(dpi).map_err(|e| DpiError::DeviceError(format!("{}", e)))?;
+            manager
+                .set_dpi(dpi)
+                .map_err(|e| DpiError::DeviceError(format!("{}", e)))?;
             tracing::info!(dpi, "DPI set on device");
             Ok(())
         }
@@ -244,10 +252,7 @@ mod tests {
 
     #[test]
     fn test_dpi_manager_custom_profiles() {
-        let profiles = vec![
-            DpiProfile::new("Low", 400),
-            DpiProfile::new("High", 3200),
-        ];
+        let profiles = vec![DpiProfile::new("Low", 400), DpiProfile::new("High", 3200)];
         let manager = DpiManager::with_profiles(profiles);
         assert_eq!(manager.profiles().len(), 2);
         assert_eq!(manager.active_profile().unwrap().dpi, 400);

--- a/daemon/src/macros/engine.rs
+++ b/daemon/src/macros/engine.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use super::types::{MacroAction, MacroConfig, PlaybackState, RepeatMode, mouse_button_to_number};
+use super::types::{mouse_button_to_number, MacroAction, MacroConfig, PlaybackState, RepeatMode};
 
 // Re-export for main.rs convenience
 pub use super::triggers::SharedTriggerMap;
@@ -140,7 +140,11 @@ fn execute_action(action: &MacroAction) {
         MacroAction::Delay(_) => {} // Handled by the timing loop
         MacroAction::Text(text) => synthesize_text(text),
         MacroAction::Scroll { direction, amount } => {
-            let sign = if direction == "down" || direction == "left" { -1 } else { 1 };
+            let sign = if direction == "down" || direction == "left" {
+                -1
+            } else {
+                1
+            };
             synthesize_scroll(sign * amount);
         }
     }
@@ -163,11 +167,7 @@ fn effective_delay(action: &MacroAction, config: &MacroConfig) -> Duration {
 }
 
 /// Execute a list of actions once, checking the stop signal between each
-fn execute_actions_once(
-    actions: &[MacroAction],
-    config: &MacroConfig,
-    stop_signal: &AtomicBool,
-) {
+fn execute_actions_once(actions: &[MacroAction], config: &MacroConfig, stop_signal: &AtomicBool) {
     for action in actions {
         if stop_signal.load(Ordering::Relaxed) {
             return;
@@ -371,12 +371,26 @@ fn release_stuck_keys(actions: &[MacroAction]) {
     // Release everything that might be stuck (union of all downs in the list)
     // We release ALL keys mentioned in any KeyDown, not just the delta,
     // because we don't know which iteration point we interrupted at.
-    let all_keys: Vec<String> = actions.iter().filter_map(|a| {
-        if let MacroAction::KeyDown(key) = a { Some(key.clone()) } else { None }
-    }).collect();
-    let all_mouse: Vec<String> = actions.iter().filter_map(|a| {
-        if let MacroAction::MouseDown(btn) = a { Some(btn.clone()) } else { None }
-    }).collect();
+    let all_keys: Vec<String> = actions
+        .iter()
+        .filter_map(|a| {
+            if let MacroAction::KeyDown(key) = a {
+                Some(key.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    let all_mouse: Vec<String> = actions
+        .iter()
+        .filter_map(|a| {
+            if let MacroAction::MouseDown(btn) = a {
+                Some(btn.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
 
     for key in &all_keys {
         tracing::debug!(key = %key, "Releasing stuck key after macro stop");
@@ -454,7 +468,9 @@ fn run_playback(config: MacroConfig, stop: Arc<AtomicBool>) {
                 let no_stop = AtomicBool::new(false);
                 execute_actions_once(&seq.release, &config, &no_stop);
             } else {
-                tracing::warn!("Sequence mode but no sequence_actions defined, falling back to Once");
+                tracing::warn!(
+                    "Sequence mode but no sequence_actions defined, falling back to Once"
+                );
                 execute_actions_once(&config.actions, &config, &stop);
             }
         }
@@ -479,10 +495,7 @@ mod tests {
             description: String::new(),
             repeat_mode: RepeatMode::Once,
             repeat_count: 3,
-            actions: vec![
-                MacroAction::Delay(10),
-                MacroAction::Delay(10),
-            ],
+            actions: vec![MacroAction::Delay(10), MacroAction::Delay(10)],
             sequence_actions: None,
             standard_delay_ms: 5,
             use_standard_delay: false,

--- a/daemon/src/macros/mod.rs
+++ b/daemon/src/macros/mod.rs
@@ -29,7 +29,7 @@ pub use dpi::{DpiManager, DpiProfile};
 pub use engine::MacroEngine;
 pub use recorder::MacroRecorder;
 pub use storage::{delete_macro, load_all_macros, load_macro, save_macro};
-pub use triggers::{TriggerMap, SharedTriggerMap};
+pub use triggers::{SharedTriggerMap, TriggerMap};
 pub use types::{
     events_to_actions, MacroAction, MacroConfig, MacroEvent, PlaybackState, RepeatMode,
     SequenceActions,

--- a/daemon/src/macros/recorder.rs
+++ b/daemon/src/macros/recorder.rs
@@ -21,39 +21,89 @@ fn evdev_code_to_key_name(code: u16) -> Option<String> {
     // Common key codes from linux/input-event-codes.h
     let name = match code {
         1 => "Escape",
-        2 => "1", 3 => "2", 4 => "3", 5 => "4", 6 => "5",
-        7 => "6", 8 => "7", 9 => "8", 10 => "9", 11 => "0",
-        12 => "minus", 13 => "equal",
-        14 => "BackSpace", 15 => "Tab",
-        16 => "q", 17 => "w", 18 => "e", 19 => "r", 20 => "t",
-        21 => "y", 22 => "u", 23 => "i", 24 => "o", 25 => "p",
-        26 => "bracketleft", 27 => "bracketright",
+        2 => "1",
+        3 => "2",
+        4 => "3",
+        5 => "4",
+        6 => "5",
+        7 => "6",
+        8 => "7",
+        9 => "8",
+        10 => "9",
+        11 => "0",
+        12 => "minus",
+        13 => "equal",
+        14 => "BackSpace",
+        15 => "Tab",
+        16 => "q",
+        17 => "w",
+        18 => "e",
+        19 => "r",
+        20 => "t",
+        21 => "y",
+        22 => "u",
+        23 => "i",
+        24 => "o",
+        25 => "p",
+        26 => "bracketleft",
+        27 => "bracketright",
         28 => "Return",
         29 => "ctrl",
-        30 => "a", 31 => "s", 32 => "d", 33 => "f", 34 => "g",
-        35 => "h", 36 => "j", 37 => "k", 38 => "l",
-        39 => "semicolon", 40 => "apostrophe", 41 => "grave",
+        30 => "a",
+        31 => "s",
+        32 => "d",
+        33 => "f",
+        34 => "g",
+        35 => "h",
+        36 => "j",
+        37 => "k",
+        38 => "l",
+        39 => "semicolon",
+        40 => "apostrophe",
+        41 => "grave",
         42 => "shift",
         43 => "backslash",
-        44 => "z", 45 => "x", 46 => "c", 47 => "v", 48 => "b",
-        49 => "n", 50 => "m",
-        51 => "comma", 52 => "period", 53 => "slash",
+        44 => "z",
+        45 => "x",
+        46 => "c",
+        47 => "v",
+        48 => "b",
+        49 => "n",
+        50 => "m",
+        51 => "comma",
+        52 => "period",
+        53 => "slash",
         54 => "shift", // Right shift
         56 => "alt",
         57 => "space",
         58 => "Caps_Lock",
         // F-keys
-        59 => "F1", 60 => "F2", 61 => "F3", 62 => "F4",
-        63 => "F5", 64 => "F6", 65 => "F7", 66 => "F8",
-        67 => "F9", 68 => "F10", 87 => "F11", 88 => "F12",
+        59 => "F1",
+        60 => "F2",
+        61 => "F3",
+        62 => "F4",
+        63 => "F5",
+        64 => "F6",
+        65 => "F7",
+        66 => "F8",
+        67 => "F9",
+        68 => "F10",
+        87 => "F11",
+        88 => "F12",
         // Navigation
-        102 => "Home", 103 => "Up", 104 => "Page_Up",
-        105 => "Left", 106 => "Right",
-        107 => "End", 108 => "Down", 109 => "Page_Down",
-        110 => "Insert", 111 => "Delete",
+        102 => "Home",
+        103 => "Up",
+        104 => "Page_Up",
+        105 => "Left",
+        106 => "Right",
+        107 => "End",
+        108 => "Down",
+        109 => "Page_Down",
+        110 => "Insert",
+        111 => "Delete",
         // Modifiers (right side)
-        97 => "ctrl",  // Right ctrl
-        100 => "alt",  // Right alt
+        97 => "ctrl",   // Right ctrl
+        100 => "alt",   // Right alt
         125 => "super", // Left super
         126 => "super", // Right super
         _ => return None,
@@ -204,11 +254,9 @@ fn record_events(
             }
 
             // Use tokio::select with a timeout to check the recording flag periodically
-            let event_result = tokio::time::timeout(
-                std::time::Duration::from_millis(100),
-                events.next_event(),
-            )
-            .await;
+            let event_result =
+                tokio::time::timeout(std::time::Duration::from_millis(100), events.next_event())
+                    .await;
 
             match event_result {
                 Ok(Ok(event)) => {
@@ -300,9 +348,10 @@ fn find_keyboard_device() -> Result<std::path::PathBuf, RecorderError> {
         }
 
         // Verify it has actual keyboard keys (not just mouse buttons)
-        let has_keyboard_keys = device.supported_keys().map(|keys| {
-            keys.contains(KeyCode::KEY_A) && keys.contains(KeyCode::KEY_Z)
-        }).unwrap_or(false);
+        let has_keyboard_keys = device
+            .supported_keys()
+            .map(|keys| keys.contains(KeyCode::KEY_A) && keys.contains(KeyCode::KEY_Z))
+            .unwrap_or(false);
 
         if has_keyboard_keys {
             return Ok(path);
@@ -319,7 +368,9 @@ fn record_events(
     _state: Arc<Mutex<RecorderState>>,
 ) -> Result<(), RecorderError> {
     tracing::warn!("Macro recording is only supported on Linux");
-    Err(RecorderError::DeviceError("Not supported on this platform".to_string()))
+    Err(RecorderError::DeviceError(
+        "Not supported on this platform".to_string(),
+    ))
 }
 
 // ============================================================================

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -7,14 +7,14 @@ use clap::Parser;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use tokio::sync::mpsc;
-use tokio::time::{Duration, sleep};
-use tracing::{Level, debug, error, info, warn};
+use tokio::time::{sleep, timeout, Duration};
+use tracing::{debug, error, info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
 
 use juhradiald::{
     battery::{new_shared_state, start_battery_updater_shared},
     config::load_shared_config,
-    dbus::{DBUS_NAME, DBUS_PATH, init_dbus_service_with_device},
+    dbus::{init_dbus_service_with_device, DBUS_NAME, DBUS_PATH},
     evdev::{EvdevError, EvdevHandler, GestureEvent},
     gaming::new_shared_gaming_mode,
     hidpp::SharedHapticManager,
@@ -205,11 +205,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // directly on the tokio runtime stalls every other task (evdev, hidraw, dbus)
     // for up to ~1.5s on cold start. spawn_blocking moves it onto the blocking
     // thread pool so the runtime keeps servicing input events during startup.
-    let mx4_hidraw_path;
-    let mx4_device_name: Option<String>;
+    let mut mx4_hidraw_path: Option<PathBuf> = None;
+    let mut mx4_device_name: Option<String> = None;
     {
         let manager_for_probe = haptic_manager.clone();
-        let probe = tokio::task::spawn_blocking(move || {
+        let probe_task = tokio::task::spawn_blocking(move || {
             let mut manager = manager_for_probe.lock().unwrap();
             let connect_result = manager.connect();
             // Divert immediately while we still hold the lock so we don't race
@@ -222,32 +222,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let path = manager.device_path();
             let name = manager.get_device_name_string();
             (connect_result, divert_result, path, name)
-        })
-        .await
-        .expect("HID++ probe task panicked");
+        });
 
-        match probe.0 {
-            Ok(true) => {
-                info!("Haptic feedback connected to MX Master 4");
-                match probe.1 {
-                    Some(Ok(n)) if n > 0 => info!(count = n, "Gesture buttons diverted via HID++"),
-                    Some(Ok(_)) => {
-                        warn!("No gesture buttons found to divert - thumb button may not work")
+        match timeout(Duration::from_secs(3), probe_task).await {
+            Ok(joined) => {
+                let probe = joined.expect("HID++ probe task panicked");
+                match probe.0 {
+                    Ok(true) => {
+                        info!("Haptic feedback connected to MX Master 4");
+                        match probe.1 {
+                            Some(Ok(n)) if n > 0 => {
+                                info!(count = n, "Gesture buttons diverted via HID++")
+                            }
+                            Some(Ok(_)) => {
+                                warn!("No gesture buttons found to divert - thumb button may not work")
+                            }
+                            Some(Err(e)) => warn!("Button divert failed (non-fatal): {}", e),
+                            None => {}
+                        }
                     }
-                    Some(Err(e)) => warn!("Button divert failed (non-fatal): {}", e),
-                    None => {}
+                    Ok(false) => info!("No MX Master 4 found for haptics (optional)"),
+                    Err(e) => warn!("Haptic connection error (non-fatal): {}", e),
+                }
+                mx4_hidraw_path = probe.2;
+                mx4_device_name = probe.3;
+                if let Some(ref path) = mx4_hidraw_path {
+                    info!(path = %path.display(), "MX Master 4 hidraw path for event listener");
+                }
+                if let Some(ref name) = mx4_device_name {
+                    info!(name = %name, "HID++ device name");
                 }
             }
-            Ok(false) => info!("No MX Master 4 found for haptics (optional)"),
-            Err(e) => warn!("Haptic connection error (non-fatal): {}", e),
-        }
-        mx4_hidraw_path = probe.2;
-        mx4_device_name = probe.3;
-        if let Some(ref path) = mx4_hidraw_path {
-            info!(path = %path.display(), "MX Master 4 hidraw path for event listener");
-        }
-        if let Some(ref name) = mx4_device_name {
-            info!(name = %name, "HID++ device name");
+            Err(_) => {
+                info!(
+                    "HID++ startup probe timed out after 3s; continuing and retrying in background"
+                );
+            }
         }
     }
 
@@ -470,34 +480,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Spawn evdev handlers:
     // - MX evdev loop: fallback for standard MX input events (when HID++ divert unavailable)
-    // - Generic evdev loop: handles non-Logitech mice (e.g., SteelSeries)
-    // Both run simultaneously so either mouse can trigger the radial wheel.
+    // - Generic evdev loop: enabled only when active mode is generic
     let evdev_tx = event_tx.clone();
-    // Always suppress gesture button (BTN_BACK = 0x116) on MX evdev path
-    // so it doesn't leak to the OS as "browser back" / "open last file".
-    // Also suppress any macro-bound buttons.
-    let mut suppressed_for_mx = macro_evdev_codes.clone();
-    for &code in juhradiald::evdev::GESTURE_BUTTON_CODES {
-        suppressed_for_mx.insert(code);
-    }
+    // Suppress only macro-bound buttons. Avoid forced gesture-button suppression
+    // because EVIOCGRAB + uinput forwarding can freeze pointer movement on some
+    // hardware/compositor combinations.
+    let suppressed_for_mx = macro_evdev_codes.clone();
     let hotplug_for_mx = hotplug_notify.clone();
     let evdev_config = shared_config.clone();
     let evdev_handle = tokio::spawn(async move {
         run_evdev_loop(evdev_tx, suppressed_for_mx, hotplug_for_mx, evdev_config).await
     });
 
+    let generic_enabled = device_mode == "generic";
     let generic_evdev_tx = event_tx.clone();
     let suppressed_for_generic = macro_evdev_codes.clone();
     let hotplug_for_generic = hotplug_notify.clone();
     let generic_evdev_config = shared_config.clone();
     let generic_evdev_handle = tokio::spawn(async move {
-        run_generic_evdev_loop(
-            generic_evdev_tx,
-            suppressed_for_generic,
-            hotplug_for_generic,
-            generic_evdev_config,
-        )
-        .await
+        if generic_enabled {
+            run_generic_evdev_loop(
+                generic_evdev_tx,
+                suppressed_for_generic,
+                hotplug_for_generic,
+                generic_evdev_config,
+            )
+            .await;
+        } else {
+            info!("Generic evdev loop disabled (active mode is logitech)");
+            std::future::pending::<()>().await;
+        }
     });
 
     // Spawn event processing task with D-Bus connection
@@ -1141,7 +1153,7 @@ async fn emit_cursor_moved(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use juhradiald::cursor::{CursorPosition, EDGE_MARGIN, MENU_RADIUS, ScreenBounds};
+    use juhradiald::cursor::{CursorPosition, ScreenBounds, EDGE_MARGIN, MENU_RADIUS};
 
     #[test]
     fn test_device_poll_interval() {

--- a/daemon/src/window_tracker.rs
+++ b/daemon/src/window_tracker.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use zbus::{Connection, Result as ZbusResult, proxy};
+use zbus::{proxy, Connection, Result as ZbusResult};
 
 /// KWin D-Bus service name (for future KWin integration)
 #[allow(dead_code)]

--- a/install.sh
+++ b/install.sh
@@ -528,9 +528,45 @@ install_files() {
     sudo install -Dm644 assets/juhradial-mx.svg /usr/share/icons/hicolor/scalable/apps/juhradial-mx.svg
     log_success "Desktop integration"
 
-    # Install systemd service
+    # Install systemd services
     mkdir -p "$SYSTEMD_USER_DIR"
-    cp packaging/systemd/juhradialmx-daemon.service "$SYSTEMD_USER_DIR/"
+
+    # Daemon unit is required
+    if [ -f packaging/systemd/juhradialmx-daemon.service ]; then
+        cp packaging/systemd/juhradialmx-daemon.service "$SYSTEMD_USER_DIR/"
+    else
+        log_error "Missing required file: packaging/systemd/juhradialmx-daemon.service"
+        exit 1
+    fi
+
+    # Overlay unit may be missing in older source snapshots; generate fallback
+    # unit instead of aborting installation.
+    if [ -f packaging/systemd/juhradialmx-overlay.service ]; then
+        cp packaging/systemd/juhradialmx-overlay.service "$SYSTEMD_USER_DIR/"
+    else
+        log_warning "Overlay unit file not found in source - generating fallback service"
+        cat > "$SYSTEMD_USER_DIR/juhradialmx-overlay.service" << 'EOF'
+# JuhRadial MX Overlay - systemd user service
+
+[Unit]
+Description=JuhRadial MX Overlay
+After=graphical-session.target juhradialmx-daemon.service
+Wants=graphical-session.target juhradialmx-daemon.service
+PartOf=graphical-session.target
+Requires=dbus.socket
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -lc 'if [ -f /usr/share/juhradial/juhradial-overlay.py ]; then exec /usr/bin/python3 /usr/share/juhradial/juhradial-overlay.py; elif [ -f /usr/share/juhradial/overlay/juhradial-overlay.py ]; then exec /usr/bin/python3 /usr/share/juhradial/overlay/juhradial-overlay.py; elif [ -f /opt/juhradial-mx/overlay/juhradial-overlay.py ]; then exec /usr/bin/python3 /opt/juhradial-mx/overlay/juhradial-overlay.py; else echo "juhradial overlay script not found" >&2; exit 1; fi'
+Restart=on-failure
+RestartSec=3s
+MemoryMax=200M
+CPUQuota=50%
+
+[Install]
+WantedBy=default.target
+EOF
+    fi
 
     # Install/update udev rules (always update to fix security issues in older versions)
     if [ -f packaging/udev/99-juhradialmx.rules ]; then
@@ -566,14 +602,17 @@ enable_service() {
 
     systemctl --user daemon-reload || log_warning "Failed to reload user systemd"
     systemctl --user enable juhradialmx-daemon || log_warning "Failed to enable service"
+    systemctl --user enable juhradialmx-overlay || log_warning "Failed to enable overlay service"
 
     # Restart on upgrade, start on fresh install
     if [ "$INSTALL_MODE" = "upgrade" ]; then
         systemctl --user restart juhradialmx-daemon || log_warning "Failed to restart service"
-        log_success "Service restarted"
+        systemctl --user restart juhradialmx-overlay || log_warning "Failed to restart overlay service"
+        log_success "Services restarted"
     else
         systemctl --user start juhradialmx-daemon || log_warning "Failed to start service"
-        log_success "Service enabled and started"
+        systemctl --user start juhradialmx-overlay || log_warning "Failed to start overlay service"
+        log_success "Services enabled and started"
     fi
 }
 
@@ -673,8 +712,8 @@ print_success() {
     echo ""
     echo -e "  ${BOLD}Useful commands${RESET}"
     echo -e "  ${GRAY}$(printf '%.0s─' {1..48})${RESET}"
-    echo -e "  ${DIM}Status${RESET}   systemctl --user status juhradialmx-daemon"
-    echo -e "  ${DIM}Logs${RESET}     journalctl --user -u juhradialmx-daemon -f"
+    echo -e "  ${DIM}Status${RESET}   systemctl --user status juhradialmx-daemon juhradialmx-overlay"
+    echo -e "  ${DIM}Logs${RESET}     journalctl --user -u juhradialmx-daemon -u juhradialmx-overlay -f"
     echo ""
     echo -e "  ${GRAY}github.com/JuhLabs/juhradial-mx${RESET}"
     echo ""

--- a/overlay/settings_dashboard.py
+++ b/overlay/settings_dashboard.py
@@ -277,7 +277,7 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
             # Resume timers
             if not self._is_generic and not self._battery_timer_id:
                 self._battery_timer_id = GLib.timeout_add_seconds(2, self._update_battery)
-                GLib.idle_add(self._update_battery)
+                GLib.idle_add(lambda: self._update_battery() and False)
             if hasattr(self, "_heart_timer") and not self._heart_timer:
                 self._heart_timer = GLib.timeout_add(30, self._tick_heart)
         else:
@@ -399,7 +399,7 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
                 # Check if this is a battery device property change
                 if "UPower" in interface_name or "Device" in interface_name:
                     # Schedule immediate battery update on main thread
-                    GLib.idle_add(self._update_battery)
+                    GLib.idle_add(lambda: self._update_battery() and False)
 
     def _on_upower_device_event(
         self, connection, sender, path, interface, signal, params, user_data

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -80,8 +80,9 @@ package() {
     # Install icon
     install -Dm644 assets/juhradial-mx.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/juhradial-mx.svg"
 
-    # Install systemd user service
+    # Install systemd user services
     install -Dm644 packaging/systemd/juhradialmx-daemon.service "$pkgdir/usr/lib/systemd/user/juhradialmx-daemon.service"
+    install -Dm644 packaging/systemd/juhradialmx-overlay.service "$pkgdir/usr/lib/systemd/user/juhradialmx-overlay.service"
 
     # Install udev rules
     install -Dm644 packaging/udev/99-logitech-hidpp.rules "$pkgdir/usr/lib/udev/rules.d/99-logitech-hidpp.rules"
@@ -96,8 +97,7 @@ package() {
 
 post_install() {
     echo ">>> To start JuhRadial MX:"
-    echo "    systemctl --user enable --now juhradialmx-daemon"
-    echo "    juhradial-mx"
+    echo "    systemctl --user enable --now juhradialmx-daemon juhradialmx-overlay"
     echo ""
     echo ">>> Or find 'JuhRadial MX' in your application menu"
 }

--- a/packaging/rpm/juhradial-mx.spec
+++ b/packaging/rpm/juhradial-mx.spec
@@ -89,8 +89,9 @@ install -Dm644 packaging/juhradial-mx.desktop %{buildroot}%{_datadir}/applicatio
 # Install icon
 install -Dm644 assets/juhradial-mx.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/juhradial-mx.svg
 
-# Install systemd user service
+# Install systemd user services
 install -Dm644 packaging/systemd/juhradialmx-daemon.service %{buildroot}%{_userunitdir}/juhradialmx-daemon.service
+install -Dm644 packaging/systemd/juhradialmx-overlay.service %{buildroot}%{_userunitdir}/juhradialmx-overlay.service
 
 # Install udev rules
 install -Dm644 packaging/udev/99-logitech-hidpp.rules %{buildroot}%{_udevrulesdir}/99-logitech-hidpp.rules
@@ -117,6 +118,7 @@ install -Dm644 packaging/udev/99-logitech-hidpp.rules %{buildroot}%{_udevrulesdi
 %{_datadir}/applications/juhradial-mx.desktop
 %{_datadir}/icons/hicolor/scalable/apps/juhradial-mx.svg
 %{_userunitdir}/juhradialmx-daemon.service
+%{_userunitdir}/juhradialmx-overlay.service
 %{_udevrulesdir}/99-logitech-hidpp.rules
 %changelog
 * Mon Apr 27 2026 JuhLabs (Julian Hermstad) <julianhermstad@icloud.com> - 0.3.2-1

--- a/packaging/systemd/juhradialmx-daemon.service
+++ b/packaging/systemd/juhradialmx-daemon.service
@@ -22,6 +22,10 @@ After=graphical-session.target
 Wants=graphical-session.target
 PartOf=graphical-session.target
 
+# Limit restart attempts to prevent infinite restart loops
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
 # D-Bus session is required for communication with KWin
 Requires=dbus.socket
 
@@ -32,10 +36,6 @@ ExecStart=/usr/local/bin/juhradiald
 # on-abnormal = non-clean signals, watchdog, timeout — NOT SIGTERM/clean exit.
 Restart=on-abnormal
 RestartSec=5s
-
-# Limit restart attempts to prevent infinite restart loops
-StartLimitIntervalSec=60
-StartLimitBurst=5
 
 # Disable watchdog to prevent systemd drop-ins (e.g. 10-timeout-abort.conf
 # on Fedora) from killing the daemon when it doesn't send sd_notify heartbeats.

--- a/packaging/systemd/juhradialmx-overlay.service
+++ b/packaging/systemd/juhradialmx-overlay.service
@@ -1,0 +1,26 @@
+# JuhRadial MX Overlay - systemd user service
+#
+# Starts the overlay process that renders the radial menu UI and listens
+# for D-Bus signals from the daemon.
+
+[Unit]
+Description=JuhRadial MX Overlay
+After=graphical-session.target juhradialmx-daemon.service
+Wants=graphical-session.target juhradialmx-daemon.service
+PartOf=graphical-session.target
+
+# D-Bus session is required for communication with the daemon
+Requires=dbus.socket
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -lc 'if [ -f /usr/share/juhradial/juhradial-overlay.py ]; then exec /usr/bin/python3 /usr/share/juhradial/juhradial-overlay.py; elif [ -f /usr/share/juhradial/overlay/juhradial-overlay.py ]; then exec /usr/bin/python3 /usr/share/juhradial/overlay/juhradial-overlay.py; elif [ -f /opt/juhradial-mx/overlay/juhradial-overlay.py ]; then exec /usr/bin/python3 /opt/juhradial-mx/overlay/juhradial-overlay.py; else echo "juhradial overlay script not found" >&2; exit 1; fi'
+Restart=on-failure
+RestartSec=3s
+
+# Keep resources modest for the UI helper process
+MemoryMax=200M
+CPUQuota=50%
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Problem
Any side button on MX Master 4 opened the radial menu instead of just the thumb button.

Root Cause
[hidraw.rs](vscode-file://vscode-app/snap/code/243/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Aggressive CID remapping forced [GESTURE_BUTTON (0x00C3)](vscode-file://vscode-app/snap/code/243/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use the thumb action, ignoring per-button configuration.
[evdev.rs](vscode-file://vscode-app/snap/code/243/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): All side buttons were treated the same, without key code differentiation.
Implemented Fix
Removed global remapping in [hidraw.rs](vscode-file://vscode-app/snap/code/243/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Each CID now respects its configured action.
[GESTURE_BUTTON (0x00C3)](vscode-file://vscode-app/snap/code/243/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) -> Virtual Desktops (default)
[HAPTIC (0x01A0)](vscode-file://vscode-app/snap/code/243/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) -> Radial Menu (default)
Added key code differentiation in [evdev.rs](vscode-file://vscode-app/snap/code/243/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

0x116 (BTN_BACK) -> thumb button action (RadialMenu)
0x113..=0x115 (BTN_SIDE, BTN_EXTRA, BTN_FORWARD) -> gesture action (VirtualDesktops)
Code Quality

Fixed 4 Clippy warnings
Applied formatting with [cargo fmt](vscode-file://vscode-app/snap/code/243/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
All tests passing
Expanded Makefile with quality targets

Validation
OK - Builds cleanly with no warnings
OK - All tests pass
OK - Expected behavior restored: only the thumb button opens the radial menu


## Root Cause
- hidraw.rs: Aggressive CID remapping forced GESTURE_BUTTON → thumb action
- evdev.rs: Treated all side buttons identically without key code differentiation

## Solution
- Remove global CID remap; respect per-button config mapping
- Add key code differentiation: BTN_BACK(0x116) → thumb, others → gesture
- Fix 4 clippy warnings with guard patterns and range syntax
- Expand Makefile with quality check targets (fmt, clippy, test)

## Validation
OK - 236 tests passing, 0 warnings
OK - Clippy: -D warnings
OK - Cargo fmt: clean

## Description

Brief description of the changes in this PR.

## Related Issue

Closes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Change 1
- Change 2
- Change 3

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [ ] Tested on KDE Plasma 6 with Wayland
- [ ] Tested with MX Master 4
- [ ] Ran `make test`
- [ ] Ran `cargo clippy` (no warnings)

**Test Configuration:**
- Linux Distribution:
- Desktop Environment:
- Mouse Model:

## Screenshots (if applicable)

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
