### PR TITLE
Full Bluetooth support for MX Master 4 (PID 0xB042): udev, detection & haptics

### DIFF
--- a/daemon/src/evdev.rs
+++ b/daemon/src/evdev.rs
@@ -25,6 +25,7 @@ pub const LOGITECH_VENDOR_ID: u16 = 0x046D;
 pub const MX_MASTER_4_PRODUCT_IDS: &[u16] = &[
     0xB034, // USB receiver
     0xB035, // Bluetooth
+    0xB042, // Bluetooth (variant reported by some MX Master 4 units)
     0x4082, // Bolt receiver (variant)
     0xC548, // Unifying receiver (fallback)
 ];

--- a/daemon/src/hidpp/device.rs
+++ b/daemon/src/hidpp/device.rs
@@ -102,6 +102,12 @@ impl HidppDevice {
                 } else if uevent.contains("B034") || uevent.contains("b034") {
                     // MX Master 4 direct USB
                     ConnectionType::Usb
+                } else if uevent.contains("HID_ID=0005") {
+                    // Direct Bluetooth connection. The kernel exposes a virtual
+                    // uhid device whose uevent has no "input2" interface marker;
+                    // detect it by the HID bus id (0005 = Bluetooth). This covers
+                    // MX Master 4 units that pair over BT as e.g. PID B042.
+                    ConnectionType::Bluetooth
                 } else {
                     // Other Logitech device - check if interface 2
                     if uevent.contains("input2") {
@@ -300,6 +306,15 @@ impl HidppDevice {
     ///
     /// Uses polling with timeout (same approach as battery module).
     fn hidpp_request(&mut self, feature_index: u8, function: u8, params: &[u8]) -> Option<Vec<u8>> {
+        // Bluetooth-connected devices do not expose the short (0x10) HID++
+        // report — their HID descriptor only contains the long (0x11) report.
+        // Writing a short report there is dropped and never answered, so route
+        // every short request through the long path. This makes HID++
+        // validation, feature enumeration and haptics work over Bluetooth.
+        if self.connection_type == ConnectionType::Bluetooth {
+            return self.hidpp_long_request(feature_index, function, params);
+        }
+
         // Drain any pending data first
         self.drain_buffer();
 
@@ -1051,6 +1066,32 @@ impl HidppDevice {
         const MX4_HAPTIC_SW_ID: u8 = 0x0E; // Software ID used by mx4notifications
 
         self.drain_buffer();
+
+        // Bluetooth devices only expose the long (0x11) report, so send the
+        // haptic command as a 20-byte long report there. The short-report path
+        // below is left untouched for USB/Bolt where it is already verified.
+        // On Bluetooth the 0x0B feature index can differ, so prefer the index
+        // discovered during feature enumeration (falling back to 0x0B).
+        if self.connection_type == ConnectionType::Bluetooth {
+            let feature_index = self
+                .mx4_haptic_feature_index
+                .unwrap_or(MX4_HAPTIC_FEATURE_INDEX);
+
+            let mut request = [0u8; 20];
+            request[0] = report_type::LONG;
+            request[1] = self.device_index;
+            request[2] = feature_index;
+            request[3] = (MX4_HAPTIC_FUNCTION << 4) | MX4_HAPTIC_SW_ID;
+            request[4] = pattern.to_id();
+
+            tracing::debug!("Sending MX4 haptic packet (long/BT): {:02X?}", &request);
+
+            self.device
+                .write_all(&request)
+                .map_err(HapticError::IoError)?;
+
+            return Ok(());
+        }
 
         let mut request = [0u8; 7];
         request[0] = report_type::SHORT;

--- a/packaging/udev/99-juhradialmx.rules
+++ b/packaging/udev/99-juhradialmx.rules
@@ -45,6 +45,14 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c548", MODE="06
 SUBSYSTEM=="input", ATTRS{idVendor}=="046d", TAG+="uaccess"
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", TAG+="uaccess"
 
+# Bluetooth-connected MX Master 4 (and other Logitech HID devices)
+# Over Bluetooth the kernel creates a virtual uhid device with NO parent
+# exposing idVendor/idProduct, so the ATTRS{idVendor} rules above never match.
+# These devices are named "<bus>:<VID>:<PID>.<n>", e.g. 0005:046D:B042.0003
+# (bus 0005 = Bluetooth, 0003 = USB). Match the parent device name instead.
+SUBSYSTEM=="hidraw", KERNELS=="0005:046D:*", MODE="0660", GROUP="input", TAG+="uaccess"
+SUBSYSTEM=="hidraw", KERNELS=="0003:046D:*", MODE="0660", GROUP="input", TAG+="uaccess"
+
 # Auto-restart JuhRadial MX daemon when a Logitech HID device appears (e.g. Easy-Switch)
 # The daemon monitors hidraw devices, so when a mouse reconnects after being
 # on another computer, the daemon picks it up automatically via udev events.


### PR DESCRIPTION
## Summary

A Bluetooth-connected MX Master 4 (this unit enumerates as product ID **`0xB042`** over a virtual `uhid` device) was broken in **three independent ways**. All are fixed here and **verified on hardware** (haptics, gesture button and detection all work over Bluetooth).

Closes #19.

---

### 1. Permission denied on `/dev/hidrawN`

Over Bluetooth the kernel exposes the mouse as a virtual `uhid` device:

```
/devices/virtual/misc/uhid/0005:046D:B042.0003/hidraw/hidraw2
```

This tree has **no parent exposing `idVendor`/`idProduct`**, so every rule keyed on `ATTRS{idVendor}=="046d"` in `99-juhradialmx.rules` silently never matched — leaving the node `root:root 0600`:

```
ERROR juhradiald::hidraw: Permission denied opening "/dev/hidraw2".
```

Added rules matching the `uhid` device-name format (`<bus>:<VID>:<PID>.<n>`) via `KERNELS`, for both Bluetooth (`0005`) and USB (`0003`):

```
SUBSYSTEM=="hidraw", KERNELS=="0005:046D:*", MODE="0660", GROUP="input", TAG+="uaccess"
SUBSYSTEM=="hidraw", KERNELS=="0003:046D:*", MODE="0660", GROUP="input", TAG+="uaccess"
```

`/dev/hidraw2` then becomes `root:input 0660`. ✅

### 2. "MX Master 4 not found" via evdev

The daemon found and logged the device, then discarded it:

```
INFO  Found device ... name=Logitech MX Master 4 vendor="0x046D" product="0xB042"
WARN  MX Master 4 not found. Waiting for connection...
```

`MX_MASTER_4_PRODUCT_IDS` was missing `0xB042`. Added it. (`has_gesture_buttons` already passes — the device exposes BTN_SIDE/BTN_EXTRA/BTN_BACK.)

### 3. Haptics never fired / `TriggerHaptic` timed out (`NoReply`)

Over Bluetooth the device's HID report descriptor exposes **only the long HID++ report (`0x11`)** — the short report (`0x10`) is absent:

```
Report IDs present: ['0x11', '0x2']
0x10 short report present: False
0x11 long report present : True
```

The HID++ layer sent every request as a short report, which the device silently dropped, so:
- `HidppDevice::open()` never validated HID++ 2.0 (the ping used a short report and timed out) → haptics disabled (`No MX Master 4 found for haptics`);
- the timed-out requests held the shared haptic-manager mutex for seconds → the D-Bus `TriggerHaptic` handler blocked → overlay reported `NoReply`.

Fixes in `hidpp/device.rs`:
- **Bluetooth connection detection**: identify direct BT connections by the HID bus id (`HID_ID=0005`) instead of the `input2` USB interface marker, which the `uhid` device lacks.
- `hidpp_request()` routes through the long-report path when the connection is Bluetooth — validation, feature enumeration and all HID++ commands now work.
- `send_haptic_pattern()` emits the haptic command as a 20-byte long report on Bluetooth, using the feature index discovered during enumeration (the hardcoded `0x0B` only holds for USB/Bolt). The short-report USB/Bolt path is left **byte-for-byte unchanged**.

---

## Testing

- **Hardware**: detection, gesture button, and haptic feedback all confirmed working over Bluetooth on a real MX Master 4 (`046D:B042`).
- Verified `/dev/hidraw2` flips to `root:input 0660` after `udevadm control --reload-rules && udevadm trigger`.
- Confirmed via `udevadm info -a` that the BT device has no `idVendor` parent, and parsed its report descriptor to confirm only report `0x11` exists.
- `cargo build --release` clean; **all 244 daemon tests pass** (`cargo test --release`).
- USB/Bolt code paths untouched.

## Environment

- Logitech MX Master 4, VID `046D` / PID `B042`, over Bluetooth
- Linux 7.0.10 (CachyOS / Arch-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
