### PR TITLE
Add AI Prompt Builder (Logitech-style) with API and no-API backends

### DIFF
--- a/overlay/ai_backend.py
+++ b/overlay/ai_backend.py
@@ -1,0 +1,192 @@
+"""
+JuhRadial MX - AI backend dispatch
+
+Turns a recipe instruction + selected text into transformed text using one of
+three interchangeable backends:
+
+  - cli       : spawn an agent CLI (default Claude Code ``claude -p``), no API key.
+  - anthropic : Anthropic Messages API.
+  - openai    : OpenAI Chat Completions API.
+
+All backends share the same ``generate()`` entry point and return plain text.
+Errors are raised as ``AIBackendError`` with a human-readable message.
+
+SPDX-License-Identifier: GPL-3.0
+"""
+
+import json
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+
+from ai_config import effective_system_prompt, resolve_api_key
+
+
+class AIBackendError(Exception):
+    """Raised when an AI backend fails (missing key, network, CLI error)."""
+
+
+def build_user_message(recipe_prompt: str, selected_text: str) -> str:
+    """Combine a recipe instruction with the selected text."""
+    text = selected_text or ""
+    if "{text}" in recipe_prompt:
+        return recipe_prompt.replace("{text}", text)
+    return f"{recipe_prompt}\n\n---\n{text}".rstrip()
+
+
+def generate(recipe_prompt: str, selected_text: str, ai_cfg: dict) -> str:
+    """Dispatch to the configured backend and return transformed text."""
+    backend = (ai_cfg.get("backend") or "cli").lower()
+    system = effective_system_prompt(ai_cfg)
+    if backend == "cli":
+        return _generate_cli(recipe_prompt, selected_text, ai_cfg.get("cli", {}), system)
+    if backend == "anthropic":
+        return _generate_anthropic(recipe_prompt, selected_text, ai_cfg.get("anthropic", {}), system)
+    if backend == "openai":
+        return _generate_openai(recipe_prompt, selected_text, ai_cfg.get("openai", {}), system)
+    raise AIBackendError(f"Unknown AI backend: {backend!r}")
+
+
+# ---------------------------------------------------------------------------
+# CLI backend (default - reuses an installed agent's login, no API key)
+# ---------------------------------------------------------------------------
+
+
+def _generate_cli(recipe_prompt: str, selected_text: str, cli_cfg: dict, system: str) -> str:
+    template = cli_cfg.get("command") or ["claude", "-p", "{prompt}"]
+    model = cli_cfg.get("model", "sonnet")
+    timeout_s = int(cli_cfg.get("timeout_s", 60))
+
+    # The instruction goes in {prompt}; the selected text is piped via stdin so
+    # it never needs shell-escaping. Fold the system guardrail into the prompt.
+    instruction = f"{system}\n\nTask: {recipe_prompt}\n\nThe text to transform is provided on stdin."
+
+    argv = []
+    for part in template:
+        argv.append(part.replace("{prompt}", instruction).replace("{model}", model))
+
+    exe = argv[0] if argv else ""
+    if not shutil.which(exe):
+        raise AIBackendError(
+            f"CLI '{exe}' not found in PATH. Install it (e.g. Claude Code) or "
+            f"switch the AI backend to an API in settings."
+        )
+
+    try:
+        proc = subprocess.run(
+            argv,
+            input=selected_text or "",
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        raise AIBackendError(f"CLI '{exe}' timed out after {timeout_s}s.")
+    except OSError as e:
+        raise AIBackendError(f"Failed to run CLI '{exe}': {e}")
+
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise AIBackendError(f"CLI '{exe}' exited {proc.returncode}: {detail[:300]}")
+
+    out = (proc.stdout or "").strip()
+    if not out:
+        raise AIBackendError(f"CLI '{exe}' returned no output.")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper
+# ---------------------------------------------------------------------------
+
+
+def _http_post_json(url: str, headers: dict, payload: dict, timeout_s: int) -> dict:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = ""
+        try:
+            body = e.read().decode("utf-8")
+        except Exception:
+            pass
+        raise AIBackendError(f"HTTP {e.code} from {url}: {body[:300]}")
+    except urllib.error.URLError as e:
+        raise AIBackendError(f"Network error contacting {url}: {e.reason}")
+    except (ValueError, TimeoutError) as e:
+        raise AIBackendError(f"Bad response from {url}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Anthropic Messages API
+# ---------------------------------------------------------------------------
+
+
+def _generate_anthropic(recipe_prompt: str, selected_text: str, cfg: dict, system: str) -> str:
+    key = resolve_api_key(cfg)
+    if not key:
+        raise AIBackendError(
+            "No Anthropic API key set. Add one in AI settings or export "
+            f"{cfg.get('api_key_env', 'ANTHROPIC_API_KEY')}."
+        )
+    base = (cfg.get("base_url") or "https://api.anthropic.com").rstrip("/")
+    payload = {
+        "model": cfg.get("model", "claude-sonnet-4-6"),
+        "max_tokens": int(cfg.get("max_tokens", 1024)),
+        "system": system,
+        "messages": [
+            {"role": "user", "content": build_user_message(recipe_prompt, selected_text)}
+        ],
+    }
+    headers = {
+        "content-type": "application/json",
+        "x-api-key": key,
+        "anthropic-version": "2023-06-01",
+    }
+    resp = _http_post_json(f"{base}/v1/messages", headers, payload, int(cfg.get("timeout_s", 60)))
+    try:
+        parts = [b.get("text", "") for b in resp.get("content", []) if b.get("type") == "text"]
+        text = "".join(parts).strip()
+    except (AttributeError, TypeError):
+        text = ""
+    if not text:
+        raise AIBackendError("Anthropic API returned no text.")
+    return text
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Chat Completions API
+# ---------------------------------------------------------------------------
+
+
+def _generate_openai(recipe_prompt: str, selected_text: str, cfg: dict, system: str) -> str:
+    key = resolve_api_key(cfg)
+    if not key:
+        raise AIBackendError(
+            "No OpenAI API key set. Add one in AI settings or export "
+            f"{cfg.get('api_key_env', 'OPENAI_API_KEY')}."
+        )
+    base = (cfg.get("base_url") or "https://api.openai.com/v1").rstrip("/")
+    payload = {
+        "model": cfg.get("model", "gpt-4o"),
+        "max_tokens": int(cfg.get("max_tokens", 1024)),
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": build_user_message(recipe_prompt, selected_text)},
+        ],
+    }
+    headers = {
+        "content-type": "application/json",
+        "authorization": f"Bearer {key}",
+    }
+    resp = _http_post_json(f"{base}/chat/completions", headers, payload, int(cfg.get("timeout_s", 60)))
+    try:
+        text = resp["choices"][0]["message"]["content"].strip()
+    except (KeyError, IndexError, TypeError, AttributeError):
+        text = ""
+    if not text:
+        raise AIBackendError("OpenAI API returned no text.")
+    return text

--- a/overlay/ai_config.py
+++ b/overlay/ai_config.py
@@ -1,0 +1,296 @@
+"""
+JuhRadial MX - AI Prompt Builder configuration
+
+Loads and persists the ``ai`` section of ``~/.config/juhradial/config.json``,
+modelled after Logitech Options+ "Logi AI Prompt Builder". Two execution
+backends are supported:
+
+  - "cli"       : drive an installed agent CLI (default: Claude Code ``claude -p``).
+                  No API key required - reuses the user's existing login.
+  - "anthropic" : Anthropic Messages API (requires an API key).
+  - "openai"    : OpenAI Chat Completions API (requires an API key).
+
+SPDX-License-Identifier: GPL-3.0
+"""
+
+import json
+import os
+from pathlib import Path
+
+CONFIG_PATH = Path.home() / ".config" / "juhradial" / "config.json"
+
+# Recipes mirror the quick actions offered by Logi AI Prompt Builder.
+# Each recipe is an instruction applied to the selected text. ``{text}`` is
+# substituted with the selection; if absent, the selection is appended.
+DEFAULT_RECIPES = [
+    {"id": "rephrase", "label": "Rephrase", "icon": "rephrase",
+     "prompt": "Rephrase the following text so it reads more clearly and naturally, keeping the same meaning and language."},
+    {"id": "improve", "label": "Improve writing", "icon": "improve",
+     "prompt": "Improve the writing of the following text: fix awkward phrasing and word choice while keeping the same meaning and language."},
+    {"id": "shorter", "label": "Make shorter", "icon": "shorter",
+     "prompt": "Make the following text more concise while keeping its meaning and language."},
+    {"id": "longer", "label": "Make longer", "icon": "longer",
+     "prompt": "Expand the following text with more detail while keeping its meaning and language."},
+    {"id": "professional", "label": "Professional tone", "icon": "professional",
+     "prompt": "Rewrite the following text in a professional tone, keeping its meaning and language."},
+    {"id": "friendly", "label": "Friendly tone", "icon": "friendly",
+     "prompt": "Rewrite the following text in a warm, friendly tone, keeping its meaning and language."},
+    {"id": "grammar", "label": "Fix spelling & grammar", "icon": "grammar",
+     "prompt": "Correct the spelling and grammar of the following text. Keep the original language and wording as much as possible."},
+    {"id": "summarize", "label": "Summarize", "icon": "summarize",
+     "prompt": "Summarize the key points of the following text in its original language."},
+    {"id": "translate_en", "label": "Translate to English", "icon": "translate",
+     "prompt": "Translate the following text to English."},
+    {"id": "reply", "label": "Write a reply", "icon": "reply",
+     "prompt": "Write a suitable reply to the following message, in the same language."},
+]
+
+DEFAULT_AI_CONFIG = {
+    # "cli" | "anthropic" | "openai"
+    "backend": "cli",
+    # Output language: "auto" (keep input language), "en", or "pt-BR".
+    "output_language": "auto",
+    # Default engine the Prompt Builder opens with: "claude" / "chatgpt" / "gemini".
+    "default_engine": "claude",
+    # Selected model variant per engine (see ENGINE_MODELS for the options).
+    "engine_model": {"claude": "sonnet", "chatgpt": "gpt-4o", "gemini": "gemini-2.5-flash"},
+    # Restore the user's clipboard after capturing the selection / pasting.
+    "preserve_clipboard": True,
+    # Delay (ms) between simulating Ctrl+C and reading the clipboard.
+    "capture_delay_ms": 120,
+    # CLI backend: a command template. {prompt} = instruction, {model} = model.
+    # The selected text is piped to the command's stdin. ``provider`` selects a
+    # known preset ("claude" / "gemini") or "custom" for a hand-edited command.
+    "cli": {
+        "provider": "claude",
+        "command": ["claude", "-p", "{prompt}", "--allowedTools", "", "--model", "{model}"],
+        "model": "sonnet",
+        "timeout_s": 60,
+    },
+    "anthropic": {
+        "api_key": "",                      # if empty, falls back to api_key_env
+        "api_key_env": "ANTHROPIC_API_KEY",
+        "model": "claude-sonnet-4-6",
+        "base_url": "https://api.anthropic.com",
+        "max_tokens": 1024,
+        "timeout_s": 60,
+    },
+    "openai": {
+        "api_key": "",
+        "api_key_env": "OPENAI_API_KEY",
+        "model": "gpt-4o",
+        "base_url": "https://api.openai.com/v1",
+        "max_tokens": 1024,
+        "timeout_s": 60,
+    },
+    "recipes": DEFAULT_RECIPES,
+}
+
+# Shared system prompt that constrains every backend to a clean text transform.
+SYSTEM_PROMPT_BASE = (
+    "You are a writing assistant embedded in a desktop tool. Apply the requested "
+    "transformation to the user's text and output ONLY the resulting text - no "
+    "preamble, no explanation, no quotation marks, no markdown fences."
+)
+
+# Output-language clauses appended to the base prompt.
+_LANG_CLAUSE = {
+    "auto": " Preserve the original language unless explicitly asked to translate.",
+    "en": " Always write your output in English, regardless of the input language.",
+    "pt-br": " Always write your output in Brazilian Portuguese (português do Brasil), "
+             "regardless of the input language.",
+}
+
+# Backwards-compatible default (auto = preserve original language).
+SYSTEM_PROMPT = SYSTEM_PROMPT_BASE + _LANG_CLAUSE["auto"]
+
+# Human labels for the output-language selector.
+OUTPUT_LANGUAGES = [
+    ("auto", "Auto (keep language)"),
+    ("en", "English"),
+    ("pt-BR", "Português (BR)"),
+]
+
+# Known CLI presets. {prompt} = instruction, {model} = model; selection on stdin.
+CLI_PRESETS = {
+    "claude": {
+        "label": "Claude Code",
+        "command": ["claude", "-p", "{prompt}", "--allowedTools", "", "--model", "{model}"],
+        "model": "sonnet",
+    },
+    "gemini": {
+        "label": "Gemini CLI",
+        "command": ["gemini", "-p", "{prompt}", "-m", "{model}"],
+        "model": "gemini-2.5-flash",
+    },
+}
+
+# Provider dropdown order for the CLI backend (last entry = free-form custom).
+CLI_PROVIDERS = [("claude", "Claude Code"), ("gemini", "Gemini CLI"), ("custom", "Custom")]
+
+# Named engines selectable from the AI ring submenu. Each maps to a backend:
+# Claude/Gemini use their CLI (no API key); ChatGPT uses the OpenAI API.
+ENGINES = [("claude", "Claude"), ("chatgpt", "ChatGPT"), ("gemini", "Gemini")]
+
+# Per-engine model variants offered as a toggle inside the builder.
+# Each entry is (model_value, short_label). The first item is the default.
+ENGINE_MODELS = {
+    "claude": [("opus", "Opus"), ("sonnet", "Sonnet"), ("haiku", "Haiku")],
+    "chatgpt": [("gpt-4o", "GPT-4o"), ("gpt-4o-mini", "4o-mini"), ("o4-mini", "o4-mini")],
+    "gemini": [
+        ("gemini-2.5-pro", "2.5 Pro"),
+        ("gemini-2.5-flash", "2.5 Flash"),
+        ("gemini-2.5-flash-lite", "Flash-Lite"),
+    ],
+}
+
+
+def engine_model_options(ai_cfg: dict, engine: str):
+    """Return [(value, label), ...] of model variants for an engine.
+
+    A config override at ai.engine_models[engine] (list of strings or
+    [value, label] pairs) takes precedence over the built-in defaults.
+    """
+    override = (ai_cfg.get("engine_models") or {}).get(engine)
+    if override:
+        out = []
+        for it in override:
+            if isinstance(it, (list, tuple)) and len(it) >= 2:
+                out.append((it[0], it[1]))
+            else:
+                out.append((it, str(it)))
+        return out
+    return list(ENGINE_MODELS.get(engine, []))
+
+
+def current_engine_model(ai_cfg: dict, engine: str) -> str:
+    """The selected model for an engine (ai.engine_model[engine]) or its default."""
+    sel = (ai_cfg.get("engine_model") or {}).get(engine)
+    if sel:
+        return sel
+    opts = engine_model_options(ai_cfg, engine)
+    return opts[0][0] if opts else ""
+
+
+def apply_engine(ai_cfg: dict, engine) -> dict:
+    """Return a copy of ``ai_cfg`` forced to a named engine.
+
+    "claude"/"gemini" -> CLI backend with that tool's preset; "chatgpt" ->
+    OpenAI API. An empty/unknown engine leaves the configured backend untouched.
+    """
+    if not engine:
+        return ai_cfg
+    import copy
+
+    cfg = copy.deepcopy(ai_cfg)
+    e = str(engine).lower()
+    chosen_model = current_engine_model(cfg, e)
+    if e in ("claude", "gemini"):
+        cli = dict(cfg.get("cli", {}))
+        # Use the tool's preset command unless the user already customised it for
+        # this engine; the model comes from the per-engine selection.
+        if cli.get("provider") != e:
+            cli["command"] = list(CLI_PRESETS[e]["command"])
+            cli["provider"] = e
+        cli["model"] = chosen_model or CLI_PRESETS[e]["model"]
+        cfg["cli"] = cli
+        cfg["backend"] = "cli"
+    elif e in ("chatgpt", "openai"):
+        cfg["backend"] = "openai"
+        openai = dict(cfg.get("openai", {}))
+        if chosen_model:
+            openai["model"] = chosen_model
+        cfg["openai"] = openai
+    elif e == "anthropic":
+        cfg["backend"] = "anthropic"
+    return cfg
+
+
+def effective_system_prompt(ai_cfg: dict) -> str:
+    """Return the system prompt with the configured output-language clause."""
+    lang = (ai_cfg.get("output_language") or "auto").lower()
+    clause = _LANG_CLAUSE.get(lang, _LANG_CLAUSE["auto"])
+    return SYSTEM_PROMPT_BASE + clause
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Merge ``override`` onto a copy of ``base`` (recursively for dicts)."""
+    out = dict(base)
+    for key, val in (override or {}).items():
+        if isinstance(val, dict) and isinstance(out.get(key), dict):
+            out[key] = _deep_merge(out[key], val)
+        else:
+            out[key] = val
+    return out
+
+
+def load_ai_config() -> dict:
+    """Return the ``ai`` config merged onto defaults (defaults fill gaps)."""
+    try:
+        if CONFIG_PATH.exists():
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            user_ai = cfg.get("ai", {})
+            merged = _deep_merge(DEFAULT_AI_CONFIG, user_ai)
+            # A user-provided recipe list fully replaces the defaults.
+            if isinstance(user_ai.get("recipes"), list) and user_ai["recipes"]:
+                merged["recipes"] = user_ai["recipes"]
+            return merged
+    except (OSError, ValueError) as e:
+        print(f"[AI] Failed to load config, using defaults: {e}")
+    return dict(DEFAULT_AI_CONFIG)
+
+
+def save_ai_config(ai_cfg: dict) -> bool:
+    """Persist the ``ai`` section back into config.json, preserving the rest."""
+    try:
+        CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        cfg = {}
+        if CONFIG_PATH.exists():
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+        cfg["ai"] = ai_cfg
+        tmp = CONFIG_PATH.with_suffix(".json.tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+        os.replace(tmp, CONFIG_PATH)
+        return True
+    except (OSError, ValueError) as e:
+        print(f"[AI] Failed to save config: {e}")
+        return False
+
+
+def patch_ai_config(updates: dict) -> bool:
+    """Merge ``updates`` into the ``ai`` section of config.json in place.
+
+    Only the given keys are written (no default bloat), preserving the rest of
+    the file. Used for quick toggles like the output-language selector.
+    """
+    try:
+        CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        cfg = {}
+        if CONFIG_PATH.exists():
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+        ai = cfg.get("ai")
+        if not isinstance(ai, dict):
+            ai = {}
+        ai.update(updates)
+        cfg["ai"] = ai
+        tmp = CONFIG_PATH.with_suffix(".json.tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+        os.replace(tmp, CONFIG_PATH)
+        return True
+    except (OSError, ValueError) as e:
+        print(f"[AI] Failed to patch config: {e}")
+        return False
+
+
+def resolve_api_key(backend_cfg: dict) -> str:
+    """Return the API key: explicit value first, else the named env var."""
+    key = (backend_cfg.get("api_key") or "").strip()
+    if key:
+        return key
+    env_name = backend_cfg.get("api_key_env") or ""
+    return (os.environ.get(env_name, "") or "").strip()

--- a/overlay/ai_prompt_builder.py
+++ b/overlay/ai_prompt_builder.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""
+JuhRadial MX - AI Prompt Builder window
+
+The desktop equivalent of Logitech Options+ "Logi AI Prompt Builder": grabs the
+current text selection, offers one-click recipes (rephrase, summarize, fix
+grammar, translate, ...) plus a free-form prompt, runs it through the configured
+backend (Claude Code CLI by default, or the Anthropic/OpenAI API), and shows the
+result with Copy / Insert / Regenerate.
+
+Launch standalone for testing:
+    python3 ai_prompt_builder.py                 # self-captures the selection
+    echo "some text" | python3 ai_prompt_builder.py --stdin
+
+SPDX-License-Identifier: GPL-3.0
+"""
+
+import sys
+
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6.QtGui import QGuiApplication, QKeySequence, QShortcut
+from PyQt6.QtWidgets import (
+    QApplication,
+    QButtonGroup,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+import ai_selection
+from ai_backend import AIBackendError, generate
+from ai_config import (
+    OUTPUT_LANGUAGES,
+    current_engine_model,
+    engine_model_options,
+    load_ai_config,
+    patch_ai_config,
+)
+
+# Catppuccin Mocha-ish palette (matches the project's default theme feel).
+COL_BASE = "#1e1e2e"
+COL_SURFACE = "#313244"
+COL_SURFACE2 = "#45475a"
+COL_TEXT = "#cdd6f4"
+COL_SUBTEXT = "#a6adc8"
+COL_ACCENT = "#89b4fa"
+COL_ACCENT_HOVER = "#74a0f0"
+COL_RED = "#f38ba8"
+
+STYLESHEET = f"""
+QWidget#root {{
+    background: {COL_BASE};
+    border: 1px solid {COL_SURFACE2};
+    border-radius: 14px;
+}}
+QLabel {{ color: {COL_TEXT}; }}
+QLabel#title {{ font-size: 16px; font-weight: 600; }}
+QLabel#subtitle {{ color: {COL_SUBTEXT}; font-size: 11px; }}
+QLabel#status {{ color: {COL_SUBTEXT}; font-size: 12px; }}
+QLabel#error {{ color: {COL_RED}; font-size: 12px; }}
+QTextEdit, QLineEdit {{
+    background: {COL_SURFACE};
+    color: {COL_TEXT};
+    border: 1px solid {COL_SURFACE2};
+    border-radius: 8px;
+    padding: 8px;
+    selection-background-color: {COL_ACCENT};
+}}
+QPushButton#recipe {{
+    background: {COL_SURFACE};
+    color: {COL_TEXT};
+    border: 1px solid {COL_SURFACE2};
+    border-radius: 8px;
+    padding: 9px 12px;
+    text-align: left;
+    font-size: 13px;
+}}
+QPushButton#recipe:hover {{ background: {COL_SURFACE2}; border-color: {COL_ACCENT}; }}
+QPushButton#primary {{
+    background: {COL_ACCENT};
+    color: {COL_BASE};
+    border: none;
+    border-radius: 8px;
+    padding: 9px 16px;
+    font-weight: 600;
+}}
+QPushButton#primary:hover {{ background: {COL_ACCENT_HOVER}; }}
+QPushButton#ghost {{
+    background: transparent;
+    color: {COL_SUBTEXT};
+    border: 1px solid {COL_SURFACE2};
+    border-radius: 8px;
+    padding: 9px 16px;
+}}
+QPushButton#ghost:hover {{ color: {COL_TEXT}; border-color: {COL_ACCENT}; }}
+QFrame#card {{ background: {COL_SURFACE}; border-radius: 10px; }}
+QFrame#segbar {{ background: {COL_SURFACE}; border-radius: 9px; }}
+QPushButton#seg {{
+    background: transparent;
+    color: {COL_SUBTEXT};
+    border: none;
+    border-radius: 6px;
+    padding: 5px 12px;
+    font-size: 12px;
+    font-weight: 600;
+}}
+QPushButton#seg:hover {{ color: {COL_TEXT}; }}
+QPushButton#seg:checked {{ background: {COL_ACCENT}; color: {COL_BASE}; }}
+"""
+
+
+class _Worker(QThread):
+    """Runs a backend call off the UI thread."""
+
+    done = pyqtSignal(str)
+    failed = pyqtSignal(str)
+
+    def __init__(self, recipe_prompt, selected_text, ai_cfg):
+        super().__init__()
+        self._recipe_prompt = recipe_prompt
+        self._selected_text = selected_text
+        self._ai_cfg = ai_cfg
+
+    def run(self):
+        try:
+            result = generate(self._recipe_prompt, self._selected_text, self._ai_cfg)
+            self.done.emit(result)
+        except AIBackendError as e:
+            self.failed.emit(str(e))
+        except Exception as e:  # noqa: BLE001 - surface anything to the user
+            self.failed.emit(f"Unexpected error: {e}")
+
+
+class PromptBuilder(QWidget):
+    def __init__(self, selected_text: str, saved_clipboard, ai_cfg: dict, engine=None):
+        super().__init__()
+        from ai_config import apply_engine
+
+        self.selected_text = selected_text or ""
+        self.saved_clipboard = saved_clipboard
+        # Keep the un-applied config so the engine toggle can re-resolve live.
+        self._base_cfg = ai_cfg
+        self._engine = (engine or ai_cfg.get("default_engine") or "claude").lower()
+        self.ai_cfg = apply_engine(ai_cfg, self._engine)
+        self.ai_cfg["_engine_label"] = self._engine
+        self.worker = None
+        self.last_prompt = None
+        self.result_text = ""
+
+        self.setWindowTitle("AI Prompt Builder")
+        self.setWindowFlags(
+            Qt.WindowType.Dialog
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setFixedWidth(760)
+        self.setMinimumHeight(300)
+
+        self._build_ui()
+        QShortcut(QKeySequence("Escape"), self, activated=self.close)
+
+    # -- UI construction ---------------------------------------------------
+
+    def _build_ui(self):
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+
+        root = QWidget(objectName="root")
+        outer.addWidget(root)
+        self.v = QVBoxLayout(root)
+        self.v.setContentsMargins(18, 16, 18, 16)
+        self.v.setSpacing(12)
+
+        # Header: title/subtitle on the left, engine + output-language toggles right
+        header = QHBoxLayout()
+        title_col = QVBoxLayout()
+        title_col.setSpacing(2)
+        title = QLabel("AI Prompt Builder", objectName="title")
+        self.sub = QLabel(self._subtitle_text(), objectName="subtitle")
+        title_col.addWidget(title)
+        title_col.addWidget(self.sub)
+        header.addLayout(title_col)
+        header.addStretch(1)
+
+        # Model segmented toggle for the active engine (e.g. Claude: Opus/Sonnet)
+        self.model_group = QButtonGroup(self)
+        model_items = engine_model_options(self._base_cfg, self._engine)
+        current_model = current_engine_model(self._base_cfg, self._engine)
+        engine_name = {"claude": "Claude", "chatgpt": "ChatGPT", "gemini": "Gemini"}.get(
+            self._engine, self._engine.capitalize()
+        )
+        model_seg = self._segmented(
+            engine_name, model_items, current_model, self.model_group,
+            "model_value", self._on_model_changed,
+        )
+        header.addLayout(model_seg)
+
+        # Output-language segmented toggle: Auto / EN / PT-BR
+        self.lang_group = QButtonGroup(self)
+        short_labels = {"auto": "Auto", "en": "EN", "pt-BR": "PT-BR"}
+        lang_items = [(code, short_labels.get(code, code)) for code, _full in OUTPUT_LANGUAGES]
+        current_lang = (self.ai_cfg.get("output_language") or "auto").lower()
+        lang_seg = self._segmented(
+            "Output", lang_items, current_lang, self.lang_group,
+            "lang_code", self._on_language_changed,
+        )
+        header.addLayout(lang_seg)
+        self.v.addLayout(header)
+
+        # Two columns: recipe options on the LEFT, text boxes on the RIGHT
+        content = QHBoxLayout()
+        content.setSpacing(14)
+
+        # -- LEFT: recipe options in a 2-column grid (no scroll) --
+        left_col = QVBoxLayout()
+        left_col.setSpacing(8)
+        left_col.addWidget(QLabel("Actions", objectName="subtitle"))
+
+        recipes_grid = QGridLayout()
+        recipes_grid.setContentsMargins(0, 0, 0, 0)
+        recipes_grid.setSpacing(6)
+        cols = 2
+        for i, recipe in enumerate(self.ai_cfg.get("recipes", [])):
+            # Escape '&' so Qt doesn't treat it as a mnemonic (e.g. "Fix … & grammar")
+            label = recipe.get("label", recipe.get("id", "Recipe")).replace("&", "&&")
+            btn = QPushButton(label, objectName="recipe")
+            btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            btn.clicked.connect(
+                lambda _checked, r=recipe: self._run_recipe(r.get("prompt", ""), r.get("label", ""))
+            )
+            recipes_grid.addWidget(btn, i // cols, i % cols)
+        for c in range(cols):
+            recipes_grid.setColumnStretch(c, 1)
+        left_col.addLayout(recipes_grid)
+        left_col.addStretch(1)
+
+        left_w = QWidget()
+        left_w.setLayout(left_col)
+        left_w.setMaximumWidth(360)
+        content.addWidget(left_w, 0)
+
+        # -- RIGHT: selected text, prompt, result --
+        right_col = QVBoxLayout()
+        right_col.setSpacing(10)
+
+        if self.selected_text.strip():
+            card = QFrame(objectName="card")
+            cl = QVBoxLayout(card)
+            cl.setContentsMargins(12, 10, 12, 10)
+            cl.addWidget(QLabel("Selected text", objectName="subtitle"))
+            preview = self.selected_text.strip().replace("\n", " ")
+            if len(preview) > 240:
+                preview = preview[:240] + "…"
+            txt = QLabel(preview)
+            txt.setWordWrap(True)
+            txt.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
+            cl.addWidget(txt)
+            cl.addStretch(1)  # keep label+text at the top; card fills the space below
+            right_col.addWidget(card)
+        else:
+            note = QLabel(
+                "No text selected — pick an action or type a prompt to start fresh.",
+                objectName="subtitle",
+            )
+            note.setWordWrap(True)
+            note.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
+            right_col.addWidget(note)
+
+        prompt_row = QHBoxLayout()
+        self.prompt_input = QLineEdit()
+        self.prompt_input.setPlaceholderText("Ask anything about the selection…")
+        self.prompt_input.returnPressed.connect(self._run_custom)
+        send = QPushButton("Send", objectName="primary")
+        send.setCursor(Qt.CursorShape.PointingHandCursor)
+        send.clicked.connect(self._run_custom)
+        prompt_row.addWidget(self.prompt_input)
+        prompt_row.addWidget(send)
+        right_col.addLayout(prompt_row)
+
+        self.status = QLabel("", objectName="status")
+        self.status.setWordWrap(True)
+        self.status.hide()
+        right_col.addWidget(self.status)
+
+        self.result_view = QTextEdit()
+        self.result_view.setReadOnly(True)
+        self.result_view.setMinimumHeight(120)
+        self.result_view.hide()
+        right_col.addWidget(self.result_view, 1)
+
+        self.actions_row = QHBoxLayout()
+        self.btn_regen = QPushButton("Regenerate", objectName="ghost")
+        self.btn_copy = QPushButton("Copy", objectName="ghost")
+        self.btn_insert = QPushButton("Insert", objectName="primary")
+        for b in (self.btn_regen, self.btn_copy, self.btn_insert):
+            b.setCursor(Qt.CursorShape.PointingHandCursor)
+            b.hide()
+        self.btn_regen.clicked.connect(self._regenerate)
+        self.btn_copy.clicked.connect(self._copy_result)
+        self.btn_insert.clicked.connect(self._insert_result)
+        self.actions_row.addStretch(1)
+        self.actions_row.addWidget(self.btn_regen)
+        self.actions_row.addWidget(self.btn_copy)
+        self.actions_row.addWidget(self.btn_insert)
+        right_col.addLayout(self.actions_row)
+
+        right_w = QWidget()
+        right_w.setLayout(right_col)
+        content.addWidget(right_w, 1)
+
+        self.v.addLayout(content)
+
+    def _segmented(self, label_text, items, current, group, prop_name, on_click):
+        """Build a labelled segmented toggle (column) for the header."""
+        col = QVBoxLayout()
+        col.setSpacing(4)
+        lbl = QLabel(label_text, objectName="subtitle")
+        lbl.setAlignment(Qt.AlignmentFlag.AlignRight)
+        col.addWidget(lbl)
+
+        bar = QFrame(objectName="segbar")
+        bar_l = QHBoxLayout(bar)
+        bar_l.setContentsMargins(3, 3, 3, 3)
+        bar_l.setSpacing(3)
+        group.setExclusive(True)
+        cur = str(current).lower()
+        for code, text in items:
+            btn = QPushButton(text, objectName="seg")
+            btn.setCheckable(True)
+            btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            btn.setProperty(prop_name, code)
+            if str(code).lower() == cur:
+                btn.setChecked(True)
+            group.addButton(btn)
+            bar_l.addWidget(btn)
+        group.buttonClicked.connect(on_click)
+        col.addWidget(bar, alignment=Qt.AlignmentFlag.AlignRight)
+        return col
+
+    def _subtitle_text(self):
+        label = self.ai_cfg.get("_engine_label") or "claude"
+        return f"{label} · {self._active_model()}"
+
+    def _active_model(self) -> str:
+        if (self.ai_cfg.get("backend") or "cli").lower() == "openai":
+            return self.ai_cfg.get("openai", {}).get("model", "?")
+        return self.ai_cfg.get("cli", {}).get("model", "?")
+
+    def _on_model_changed(self, button):
+        model = button.property("model_value")
+        if not model:
+            return
+        # Remember this model for the current engine, and apply it live.
+        em = dict(self._base_cfg.get("engine_model") or {})
+        em[self._engine] = model
+        self._base_cfg["engine_model"] = em
+        patch_ai_config({"engine_model": em})
+        if (self.ai_cfg.get("backend") or "cli").lower() == "openai":
+            self.ai_cfg.setdefault("openai", {})["model"] = model
+        else:
+            self.ai_cfg.setdefault("cli", {})["model"] = model
+        self.sub.setText(self._subtitle_text())
+
+    def _on_language_changed(self, button):
+        code = button.property("lang_code")
+        if not code:
+            return
+        self.ai_cfg["output_language"] = code  # applies to the next run immediately
+        patch_ai_config({"output_language": code})  # remember as the default
+
+    # -- Running -----------------------------------------------------------
+
+    def _run_recipe(self, prompt: str, label: str):
+        if prompt:
+            self._start(prompt, label)
+
+    def _run_custom(self):
+        text = self.prompt_input.text().strip()
+        if text:
+            self._start(text, "Custom prompt")
+
+    def _regenerate(self):
+        if self.last_prompt is not None:
+            self._start(self.last_prompt[0], self.last_prompt[1])
+
+    def _start(self, prompt: str, label: str):
+        if self.worker and self.worker.isRunning():
+            return
+        self.last_prompt = (prompt, label)
+        self._set_busy(label)
+        self.worker = _Worker(prompt, self.selected_text, self.ai_cfg)
+        self.worker.done.connect(self._on_done)
+        self.worker.failed.connect(self._on_failed)
+        self.worker.start()
+
+    def _set_busy(self, label: str):
+        self.status.setObjectName("status")
+        self.status.setStyleSheet("")
+        self.status.setText(f"Running “{label}”…")
+        self.status.show()
+        self.result_view.hide()
+        for b in (self.btn_regen, self.btn_copy, self.btn_insert):
+            b.hide()
+        self.prompt_input.setEnabled(False)
+        self.adjustSize()
+
+    def _on_done(self, result: str):
+        self.result_text = result
+        self.status.hide()
+        self.result_view.setPlainText(result)
+        self.result_view.show()
+        for b in (self.btn_regen, self.btn_copy, self.btn_insert):
+            b.show()
+        self.prompt_input.setEnabled(True)
+        self.adjustSize()
+
+    def _on_failed(self, message: str):
+        self.status.setObjectName("error")
+        self.status.setStyleSheet(f"color: {COL_RED};")
+        self.status.setText(message)
+        self.status.show()
+        self.result_view.hide()
+        self.btn_regen.show()
+        self.prompt_input.setEnabled(True)
+        self.adjustSize()
+
+    # -- Result actions ----------------------------------------------------
+
+    def _copy_result(self):
+        if self.result_text:
+            ai_selection.set_clipboard_text(self.result_text)
+            self.btn_copy.setText("Copied ✓")
+
+    def _insert_result(self):
+        if not self.result_text:
+            return
+        text = self.result_text
+        saved = self.saved_clipboard
+        if ai_selection.injector_available():
+            self.hide()
+            QApplication.processEvents()
+            # Let focus return to the previously active app before pasting.
+            QThread.msleep(120)
+            ai_selection.paste_text(text, restore=saved)
+            self.close()
+        else:
+            # No key injector (no xdotool / running ydotoold): fall back to a
+            # manual paste so the result still reaches the user.
+            ai_selection.set_clipboard_text(text)
+            self.status.setObjectName("status")
+            self.status.setStyleSheet("")
+            self.status.setText(
+                "Copied to clipboard — switch to your app and press Ctrl+V. "
+                "Install xdotool (X11) or run ydotoold for automatic insert."
+            )
+            self.status.show()
+            self.btn_insert.setText("Copied ✓")
+            self.adjustSize()
+
+    def closeEvent(self, event):
+        # Best-effort clipboard restore if the user closes without inserting.
+        if self.saved_clipboard is not None:
+            ai_selection.restore_clipboard(self.saved_clipboard)
+        super().closeEvent(event)
+
+    def center_on_cursor(self):
+        screen = QGuiApplication.screenAt(QGuiApplication.primaryScreen().geometry().center())
+        screen = screen or QGuiApplication.primaryScreen()
+        geo = screen.availableGeometry()
+        self.adjustSize()
+        x = geo.center().x() - self.width() // 2
+        y = geo.center().y() - self.height() // 2
+        self.move(max(geo.left(), x), max(geo.top(), y))
+
+
+def _arg_value(flag):
+    if flag in sys.argv:
+        i = sys.argv.index(flag)
+        if i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+    return None
+
+
+def main():
+    use_stdin = "--stdin" in sys.argv
+    engine = _arg_value("--engine")
+    app = QApplication(sys.argv)
+    app.setStyleSheet(STYLESHEET)
+
+    # Base (un-applied) config; PromptBuilder resolves the engine itself so the
+    # in-window toggle can switch engines live. --engine overrides the default.
+    ai_cfg = load_ai_config()
+
+    if use_stdin:
+        selected = sys.stdin.read()
+        saved = None
+    else:
+        selected, saved = ai_selection.capture_selection(
+            delay_ms=int(ai_cfg.get("capture_delay_ms", 120)),
+            preserve_clipboard=bool(ai_cfg.get("preserve_clipboard", True)),
+        )
+
+    win = PromptBuilder(selected, saved, ai_cfg, engine=engine)
+    win.show()
+    win.center_on_cursor()
+    win.raise_()
+    win.activateWindow()
+    win.prompt_input.setFocus()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/overlay/ai_selection.py
+++ b/overlay/ai_selection.py
@@ -1,0 +1,186 @@
+"""
+JuhRadial MX - selection capture & paste helpers
+
+Getting the "current selection" the way Logitech Options+ does, across display
+servers:
+
+  - X11 (and KDE/Wayland with the primary-selection protocol): the highlighted
+    text is already exposed as the PRIMARY selection, so we read it directly via
+    Qt - no key injection, no clipboard mutation. This is the reliable path.
+  - Fallback: simulate Ctrl+C and read the clipboard (needs a key injector such
+    as a running ydotoold, xdotool, or wtype).
+
+Pasting works in reverse: put the text on the clipboard and inject Ctrl+V using
+whatever injector is available; if none is, the text is left on the clipboard
+for a manual paste.
+
+SPDX-License-Identifier: GPL-3.0
+"""
+
+import os
+import shutil
+import subprocess
+import time
+
+from PyQt6.QtGui import QClipboard, QGuiApplication
+
+# Linux input event codes (for ydotool)
+_KEY_LEFTCTRL = 29
+_KEY_C = 46
+_KEY_V = 47
+
+
+def _clipboard():
+    return QGuiApplication.clipboard()
+
+
+def get_clipboard_text() -> str:
+    cb = _clipboard()
+    return cb.text(QClipboard.Mode.Clipboard) if cb is not None else ""
+
+
+def set_clipboard_text(text: str) -> None:
+    cb = _clipboard()
+    if cb is not None:
+        cb.setText(text or "", QClipboard.Mode.Clipboard)
+
+
+def get_primary_text() -> str:
+    """Return the PRIMARY (X11-style) selection, or '' if unsupported/empty."""
+    cb = _clipboard()
+    if cb is not None and cb.supportsSelection():
+        return cb.text(QClipboard.Mode.Selection) or ""
+    return ""
+
+
+def _set_primary_text(text: str) -> None:
+    cb = _clipboard()
+    if cb is not None and cb.supportsSelection():
+        cb.setText(text or "", QClipboard.Mode.Selection)
+
+
+# ---------------------------------------------------------------------------
+# Key injection (for the Ctrl+C fallback and for paste)
+# ---------------------------------------------------------------------------
+
+
+def _ydotool_socket_ready() -> bool:
+    sock = os.environ.get("YDOTOOL_SOCKET") or f"/run/user/{os.getuid()}/.ydotool_socket"
+    return os.path.exists(sock)
+
+
+def _ydotool_key(*codes: int) -> bool:
+    if not shutil.which("ydotool") or not _ydotool_socket_ready():
+        return False
+    seq = [f"{c}:1" for c in codes] + [f"{c}:0" for c in reversed(codes)]
+    try:
+        r = subprocess.run(["ydotool", "key", *seq],
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                           timeout=2, check=False)
+        return r.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _inject_ctrl(letter: str) -> bool:
+    """Inject Ctrl+<letter> using the first available backend. Returns True on
+    success, False if no injector is available."""
+    on_x11 = bool(os.environ.get("DISPLAY")) and os.environ.get("XDG_SESSION_TYPE") != "wayland"
+
+    if shutil.which("xdotool") and os.environ.get("DISPLAY"):
+        try:
+            r = subprocess.run(["xdotool", "key", "--clearmodifiers", f"ctrl+{letter}"],
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                               timeout=2, check=False)
+            if r.returncode == 0:
+                return True
+        except (OSError, subprocess.SubprocessError):
+            pass
+
+    code = _KEY_C if letter == "c" else _KEY_V
+    if _ydotool_key(_KEY_LEFTCTRL, code):
+        return True
+
+    if not on_x11 and shutil.which("wtype"):
+        try:
+            r = subprocess.run(["wtype", "-M", "ctrl", letter, "-m", "ctrl"],
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                               timeout=2, check=False)
+            return r.returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            pass
+    return False
+
+
+def injector_available() -> bool:
+    """Whether automatic Ctrl+V paste is possible on this system."""
+    if shutil.which("xdotool") and os.environ.get("DISPLAY"):
+        return True
+    if shutil.which("ydotool") and _ydotool_socket_ready():
+        return True
+    on_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
+    return on_wayland and bool(shutil.which("wtype"))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def capture_selection(delay_ms: int = 120, preserve_clipboard: bool = True):
+    """Return (selected_text, saved_clipboard).
+
+    Tries the PRIMARY selection first (reliable, non-destructive). Only if that
+    is empty/unsupported does it fall back to simulating Ctrl+C. ``saved_clipboard``
+    is the clipboard value to restore later, or None when nothing was disturbed.
+    """
+    # 1. PRIMARY selection - the highlighted text, no side effects.
+    primary = get_primary_text()
+    if primary.strip():
+        return primary, None
+
+    # 2. Fallback: simulate Ctrl+C into the focused app, then read the clipboard.
+    saved = get_clipboard_text() if preserve_clipboard else None
+    sentinel = "\x00juhradial-no-selection\x00"
+    set_clipboard_text(sentinel)
+
+    if not _inject_ctrl("c"):
+        # No injector and no primary selection: nothing we can grab.
+        if saved is not None:
+            set_clipboard_text(saved)
+        return "", None
+
+    time.sleep(max(delay_ms, 0) / 1000.0)
+    QGuiApplication.processEvents()
+
+    captured = get_clipboard_text()
+    if captured == sentinel:
+        captured = ""
+    return captured, saved
+
+
+def restore_clipboard(saved) -> None:
+    if saved is not None:
+        set_clipboard_text(saved)
+
+
+def paste_text(text: str, restore=None, delay_ms: int = 120) -> bool:
+    """Put ``text`` on the clipboard and try to inject Ctrl+V.
+
+    Returns True if the paste keystroke was injected, False if no injector is
+    available (the text is still on the clipboard for a manual Ctrl+V). When
+    ``restore`` is given and the paste was injected, the clipboard is restored
+    afterwards.
+    """
+    set_clipboard_text(text)
+    _set_primary_text(text)  # also expose for middle-click paste
+    QGuiApplication.processEvents()
+    time.sleep(0.03)
+
+    if not _inject_ctrl("v"):
+        return False
+
+    if restore is not None:
+        time.sleep(max(delay_ms, 0) / 1000.0)
+        set_clipboard_text(restore)
+    return True

--- a/overlay/juhradial-overlay.py
+++ b/overlay/juhradial-overlay.py
@@ -640,6 +640,7 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             self._kde_base_x = x - half
             self._kde_base_y = y - half
             self._kde_frame = 0
+            self._kde_recomposite = overlay_actions.load_kde_recomposite_workaround()
             self._update_kde_mask()
 
         self.show()
@@ -752,7 +753,7 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
         if dirty:
             self.update()
         elif self._anim_timer.isActive():
-            if IS_KDE:
+            if IS_KDE and getattr(self, "_kde_recomposite", True):
                 # Keep timer alive on KDE for position oscillation below
                 self.update()
             else:
@@ -762,7 +763,13 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
         # On KDE Plasma, micro-oscillate window position by 1px each frame.
         # This forces KWin to re-composite the wallpaper behind the window,
         # preventing the frozen/cached rectangle on animated shader wallpapers.
-        if IS_KDE and hasattr(self, '_kde_base_x'):
+        # Opt-out via radial.kde_recomposite_workaround for users who see the
+        # 1px tremble and don't use an animated wallpaper.
+        if (
+            IS_KDE
+            and getattr(self, "_kde_recomposite", True)
+            and hasattr(self, "_kde_base_x")
+        ):
             self._kde_frame += 1
             offset = self._kde_frame % 2
             self.move(self._kde_base_x + offset, self._kde_base_y)
@@ -938,6 +945,8 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
                 )
             elif cmd_type == "settings":
                 overlay_actions.open_settings()
+            elif cmd_type == "ai_prompt":
+                overlay_actions.open_ai_prompt_builder(engine=cmd or None)
             elif cmd_type == "submenu":
                 self.submenu_active = True
                 self.submenu_slice = self.highlighted_slice
@@ -974,6 +983,8 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                     )
+            elif cmd_type == "ai_prompt":
+                overlay_actions.open_ai_prompt_builder(engine=cmd or None)
             elif cmd_type == "easy_switch":
                 try:
                     host_index = int(cmd)

--- a/overlay/overlay_actions.py
+++ b/overlay/overlay_actions.py
@@ -106,12 +106,18 @@ def load_radial_image():
 # ACTION DEFINITIONS
 # =============================================================================
 
+# Each AI submenu entry opens the Prompt Builder forced to that engine. The
+# command field carries the engine code consumed by open_ai_prompt_builder().
 AI_SUBMENU = [
-    ("Claude", "url", "https://claude.ai", "claude"),
-    ("ChatGPT", "url", "https://chat.openai.com", "chatgpt"),
-    ("Gemini", "url", "https://gemini.google.com", "gemini"),
-    ("Perplexity", "url", "https://perplexity.ai", "perplexity"),
+    ("Claude", "ai_prompt", "claude", "claude"),
+    ("ChatGPT", "ai_prompt", "chatgpt", "chatgpt"),
+    ("Gemini", "ai_prompt", "gemini", "gemini"),
 ]
+
+
+def build_ai_submenu():
+    """AI submenu: one entry per engine (Claude / ChatGPT / Gemini)."""
+    return list(AI_SUBMENU)
 
 # Easy-Switch submenu - built dynamically in load_actions_from_config()
 EASY_SWITCH_SUBMENU = [
@@ -205,8 +211,8 @@ def load_actions_from_config():
                 # Map GTK icon name to internal icon ID
                 icon = ICON_NAME_MAP.get(gtk_icon, "settings")
 
-                # Handle submenu type (use AI_SUBMENU as default)
-                submenu = AI_SUBMENU if action_type == "submenu" else None
+                # Handle submenu type (AI submenu honors the show-shortcuts flag)
+                submenu = build_ai_submenu() if action_type == "submenu" else None
 
                 # Check if Easy-Switch shortcuts are enabled and this is the Emoji slot (index 5)
                 if easy_switch_enabled and i == 5:
@@ -321,6 +327,47 @@ def load_os_icons():
 # =============================================================================
 
 
+def open_ai_prompt_builder(engine=None):
+    """Capture the current text selection and launch the AI Prompt Builder.
+
+    Selection capture happens here, in the overlay process, while the user's
+    application still holds focus (the radial overlay is a non-focusable Tool
+    window). The captured text is handed to the builder on stdin so the builder
+    never has to grab the selection itself after stealing focus.
+
+    ``engine`` (claude/chatgpt/gemini) forces a specific AI engine; None uses the
+    configured default backend.
+    """
+    builder = os.path.join(os.path.dirname(__file__), "ai_prompt_builder.py")
+    extra = ["--engine", str(engine)] if engine else []
+    try:
+        import ai_selection
+        from ai_config import load_ai_config
+
+        cfg = load_ai_config()
+        selected, _saved = ai_selection.capture_selection(
+            delay_ms=int(cfg.get("capture_delay_ms", 120)),
+            preserve_clipboard=bool(cfg.get("preserve_clipboard", True)),
+        )
+        proc = subprocess.Popen(
+            ["python3", builder, "--stdin", *extra],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        proc.stdin.write(selected or "")
+        proc.stdin.close()
+    except Exception as e:
+        print(f"Error launching AI Prompt Builder: {e}")
+        # Fallback: let the builder self-capture the selection.
+        subprocess.Popen(
+            ["python3", builder, *extra],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
 def open_settings():
     """Launch or refocus the settings dashboard.
 
@@ -407,3 +454,25 @@ def load_minimal_mode():
     except (OSError, ValueError, KeyError):
         pass  # Config file missing or malformed
     return False
+
+
+def load_kde_recomposite_workaround():
+    """Read radial.kde_recomposite_workaround from config.json.
+
+    When True (default), the overlay micro-oscillates its position by 1px each
+    frame on KDE to force KWin to re-composite animated/shader wallpapers behind
+    it. This prevents a frozen wallpaper rectangle but makes the ring visibly
+    tremble, so users without animated wallpapers can disable it.
+    """
+    import json
+    from pathlib import Path
+
+    config_path = Path.home() / ".config" / "juhradial" / "config.json"
+    try:
+        if config_path.exists():
+            with open(config_path, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            return bool(cfg.get("radial", {}).get("kde_recomposite_workaround", True))
+    except (OSError, ValueError, KeyError):
+        pass  # Config file missing or malformed
+    return True

--- a/overlay/overlay_painting.py
+++ b/overlay/overlay_painting.py
@@ -870,6 +870,38 @@ class RadialMenuPaintingMixin:
             text_rect = QRectF(cx - s * 0.5, cy - s * 0.5, s, s)
             p.drawText(text_rect, Qt.AlignmentFlag.AlignCenter, "?")
 
+        elif icon_type == "terminal":
+            # Terminal window with a ">" prompt and a cursor underscore
+            w, h = size * 0.82, size * 0.64
+            p.setPen(QPen(color, 2))
+            p.setBrush(Qt.BrushStyle.NoBrush)
+            p.drawRoundedRect(QRectF(cx - w / 2, cy - h / 2, w, h), 3, 3)
+            # prompt chevron ">"
+            chevron_x = cx - w * 0.22
+            p.drawLine(
+                QPointF(chevron_x - w * 0.08, cy - h * 0.16),
+                QPointF(chevron_x + w * 0.04, cy),
+            )
+            p.drawLine(
+                QPointF(chevron_x + w * 0.04, cy),
+                QPointF(chevron_x - w * 0.08, cy + h * 0.16),
+            )
+            # cursor underscore
+            p.drawLine(
+                QPointF(cx + w * 0.02, cy + h * 0.12),
+                QPointF(cx + w * 0.22, cy + h * 0.12),
+            )
+
+        else:
+            # Generic fallback so an unmapped icon is never invisible
+            p.setPen(QPen(color, 2))
+            p.setBrush(Qt.BrushStyle.NoBrush)
+            p.drawRoundedRect(
+                QRectF(cx - size * 0.32, cy - size * 0.32, size * 0.64, size * 0.64),
+                4, 4,
+            )
+            p.drawEllipse(QPointF(cx, cy), size * 0.07, size * 0.07)
+
     @staticmethod
     def _ease_out_back(t, overshoot=1.4):
         """OutBack easing - slight overshoot then settle, creates 'droplet' feel."""

--- a/overlay/settings_constants.py
+++ b/overlay/settings_constants.py
@@ -82,6 +82,7 @@ _BASE_NAV_ITEMS = [
     ("flow", "FLOW", "view-dual-symbolic"),
     ("macros", "MACROS", "applications-development-symbolic"),
     ("gaming", "GAMING", "input-gaming-symbolic"),
+    ("ai", "AI PROMPT BUILDER", "applications-science-symbolic"),
     ("settings", "SETTINGS", "emblem-system-symbolic"),
 ]
 
@@ -150,7 +151,7 @@ _BASE_RADIAL_ACTIONS = [
     ("files", "Files", "system-file-manager-symbolic", "exec", "dolphin", "orange"),
     ("emoji", "Emoji Picker", "face-smile-symbolic", "exec", "ibus emoji", "yellow"),
     ("new_note", "New Note", "document-new-symbolic", "exec", "kwrite", "yellow"),
-    ("ai", "AI Assistant", "dialog-information-symbolic", "submenu", "", "teal"),
+    ("ai", "AI Assistant", "applications-science-symbolic", "submenu", "", "teal"),
     ("copy", "Copy", "edit-copy-symbolic", "shortcut", "ctrl+c", "blue"),
     ("paste", "Paste", "edit-paste-symbolic", "shortcut", "ctrl+v", "blue"),
     ("undo", "Undo", "edit-undo-symbolic", "shortcut", "ctrl+z", "blue"),

--- a/overlay/settings_dashboard.py
+++ b/overlay/settings_dashboard.py
@@ -65,6 +65,7 @@ from settings_page_flow import FlowPage
 from settings_page_settings import SettingsPage
 from settings_page_macros import MacrosPage
 from settings_page_gaming import GamingPage
+from settings_page_ai import AIPage
 
 
 # =============================================================================
@@ -705,6 +706,9 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
             ),
             "gaming",
         )
+
+        # AI Prompt Builder - available in all modes (no device dependency)
+        self.content_stack.add_named(AIPage(), "ai")
 
     def _create_status_bar(self):
         status = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=16)

--- a/overlay/settings_page_ai.py
+++ b/overlay/settings_page_ai.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""
+JuhRadial MX - AI Prompt Builder settings page
+
+Configure the AI Prompt Builder backend (Claude Code CLI by default, or the
+Anthropic / OpenAI API), models, API keys, and capture behavior.
+
+SPDX-License-Identifier: GPL-3.0
+"""
+
+import logging
+import shlex
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from gi.repository import Gtk  # noqa: E402
+
+from i18n import _  # noqa: E402
+from settings_config import config  # noqa: E402
+from settings_widgets import PageHeader, SettingRow, SettingsCard  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+def _g(*keys, default=None):
+    return config.get("ai", *keys, default=default)
+
+
+def _s(*keys_and_value):
+    config.set("ai", *keys_and_value, auto_save=True)
+
+
+class AIPage(Gtk.ScrolledWindow):
+    """AI Prompt Builder configuration page."""
+
+    def __init__(self):
+        super().__init__()
+        self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self.set_vexpand(True)
+
+        root = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
+        root.set_margin_top(16)
+        root.set_margin_bottom(24)
+        root.set_margin_start(24)
+        root.set_margin_end(24)
+        root.set_halign(Gtk.Align.CENTER)
+        root.set_size_request(560, -1)
+        self.set_child(root)
+
+        root.append(
+            PageHeader(
+                "applications-science-symbolic",
+                _("AI Prompt Builder"),
+                _("Select text, open the Action Ring, and transform it with AI."),
+            )
+        )
+
+        root.append(self._default_model_card())
+        self._cli_card_w = self._cli_card()
+        self._openai_card_w = self._api_card(
+            "openai", _("OpenAI API (ChatGPT)"), "gpt-4o", "OPENAI_API_KEY"
+        )
+        root.append(self._cli_card_w)
+        root.append(self._openai_card_w)
+        root.append(self._behavior_card())
+        root.append(self._recipes_card())
+
+        self._update_engine_visibility(_g("default_engine", default="claude"))
+
+    # -- Default model (engine) selector ----------------------------------
+
+    def _default_model_card(self):
+        from ai_config import ENGINES
+
+        card = SettingsCard(_("Default model"))
+
+        # Engine (provider) the builder opens with
+        erow = SettingRow(
+            _("Provider"),
+            _("Which AI the Prompt Builder opens with. You can switch per-use in the builder."),
+        )
+        self._engine_codes = [code for code, _label in ENGINES]
+        edd = Gtk.DropDown(model=Gtk.StringList.new([label for _code, label in ENGINES]))
+        current = str(_g("default_engine", default="claude"))
+        edd.set_selected(self._engine_codes.index(current) if current in self._engine_codes else 0)
+        edd.set_valign(Gtk.Align.CENTER)
+        edd.connect("notify::selected", self._on_default_engine_changed)
+        erow.set_control(edd)
+        card.append(erow)
+
+        # Default model variant for that provider (e.g. Opus / Sonnet)
+        mrow = SettingRow(_("Model"), _("Default variant for that provider."))
+        self._model_dd = Gtk.DropDown()
+        self._model_dd.set_valign(Gtk.Align.CENTER)
+        self._populate_model_dd(current)
+        self._model_dd.connect("notify::selected", self._on_default_model_changed)
+        mrow.set_control(self._model_dd)
+        card.append(mrow)
+        return card
+
+    def _populate_model_dd(self, engine):
+        from ai_config import current_engine_model, engine_model_options
+
+        self._model_engine = engine
+        opts = engine_model_options({}, engine)
+        self._model_values = [v for v, _label in opts]
+        self._model_dd.set_model(Gtk.StringList.new([label for _v, label in opts]))
+        cur = current_engine_model({"engine_model": _g("engine_model", default={})}, engine)
+        if cur in self._model_values:
+            self._model_dd.set_selected(self._model_values.index(cur))
+
+    def _on_default_engine_changed(self, dropdown, _param):
+        from ai_config import CLI_PRESETS
+
+        idx = dropdown.get_selected()
+        engine = self._engine_codes[idx] if 0 <= idx < len(self._engine_codes) else "claude"
+        _s("default_engine", engine)
+        if engine in ("claude", "gemini"):
+            _s("backend", "cli")
+            _s("cli", "provider", engine)
+            _s("cli", "command", list(CLI_PRESETS[engine]["command"]))
+            if hasattr(self, "_cli_cmd_entry"):
+                self._cli_cmd_entry.set_text(shlex.join(CLI_PRESETS[engine]["command"]))
+        elif engine == "chatgpt":
+            _s("backend", "openai")
+        self._populate_model_dd(engine)
+        self._update_engine_visibility(engine)
+
+    def _on_default_model_changed(self, dropdown, _param):
+        idx = dropdown.get_selected()
+        if not (0 <= idx < len(self._model_values)):
+            return
+        em = dict(_g("engine_model", default={}) or {})
+        em[self._model_engine] = self._model_values[idx]
+        _s("engine_model", em)
+
+    def _update_engine_visibility(self, engine):
+        is_cli = engine in ("claude", "gemini")
+        self._cli_card_w.set_visible(is_cli)
+        self._openai_card_w.set_visible(engine == "chatgpt")
+
+    def _on_language_changed(self, dropdown, _param):
+        idx = dropdown.get_selected()
+        code = self._lang_codes[idx] if 0 <= idx < len(self._lang_codes) else "auto"
+        _s("output_language", code)
+
+    # -- CLI card ----------------------------------------------------------
+
+    def _cli_card(self):
+        from ai_config import CLI_PRESETS
+
+        card = SettingsCard(_("Command-line backend (advanced)"))
+
+        cmd_list = _g("cli", "command", default=CLI_PRESETS["claude"]["command"])
+        # shlex.join preserves the empty `--allowedTools ""` argument (shown as '')
+        # so the round-trip through the entry is lossless.
+        cmd_str = shlex.join(cmd_list) if isinstance(cmd_list, list) else str(cmd_list)
+
+        cmd_row = SettingRow(
+            _("Command"),
+            _("{prompt} = instruction, {model} = model. Selection is piped to stdin."),
+        )
+        self._cli_cmd_entry = Gtk.Entry()
+        self._cli_cmd_entry.set_text(cmd_str)
+        self._cli_cmd_entry.set_hexpand(True)
+        self._cli_cmd_entry.set_width_chars(28)
+        self._cli_cmd_entry.connect("changed", self._on_cli_command_changed)
+        cmd_row.set_control(self._cli_cmd_entry)
+        card.append(cmd_row)
+        return card
+
+    def _on_cli_command_changed(self, entry):
+        text = entry.get_text().strip()
+        # shlex.split preserves quoted empty args, e.g. --allowedTools "".
+        try:
+            parts = shlex.split(text) if text else []
+        except ValueError:
+            return  # unbalanced quotes mid-edit; ignore until valid
+        _s("cli", "command", parts)
+
+    # -- API card (anthropic / openai) ------------------------------------
+
+    def _api_card(self, backend, title, default_model, env_name):
+        card = SettingsCard(title)
+
+        key_row = SettingRow(
+            _("API key"),
+            _("Stored in config.json. Leave empty to use the {env} variable.").format(env=env_name),
+        )
+        key_entry = Gtk.PasswordEntry()
+        key_entry.set_show_peek_icon(True)
+        key_entry.set_text(str(_g(backend, "api_key", default="")))
+        key_entry.set_hexpand(True)
+        key_entry.connect("changed", lambda e, b=backend: _s(b, "api_key", e.get_text()))
+        key_row.set_control(key_entry)
+        card.append(key_row)
+        return card
+
+    # -- Behavior card -----------------------------------------------------
+
+    def _behavior_card(self):
+        from ai_config import OUTPUT_LANGUAGES
+
+        card = SettingsCard(_("Behavior"))
+
+        lang_row = SettingRow(
+            _("Output language"),
+            _("Force the AI to answer in this language (Auto keeps the input language)."),
+        )
+        self._lang_codes = [code for code, _label in OUTPUT_LANGUAGES]
+        lang_model = Gtk.StringList.new([label for _code, label in OUTPUT_LANGUAGES])
+        lang_dd = Gtk.DropDown(model=lang_model)
+        current_lang = str(_g("output_language", default="auto"))
+        sel = self._lang_codes.index(current_lang) if current_lang in self._lang_codes else 0
+        lang_dd.set_selected(sel)
+        lang_dd.set_valign(Gtk.Align.CENTER)
+        lang_dd.connect("notify::selected", self._on_language_changed)
+        lang_row.set_control(lang_dd)
+        card.append(lang_row)
+
+        preserve_row = SettingRow(
+            _("Preserve clipboard"),
+            _("Restore your clipboard after capturing the selection and pasting."),
+        )
+        sw = Gtk.Switch()
+        sw.set_valign(Gtk.Align.CENTER)
+        sw.set_active(bool(_g("preserve_clipboard", default=True)))
+        sw.connect("state-set", lambda s, st: (_s("preserve_clipboard", bool(st)), False)[1])
+        preserve_row.set_control(sw)
+        card.append(preserve_row)
+
+        delay_row = SettingRow(
+            _("Capture delay (ms)"),
+            _("Wait after Ctrl+C before reading the clipboard. Raise if capture is flaky."),
+        )
+        adj = Gtk.Adjustment(
+            value=int(_g("capture_delay_ms", default=120)),
+            lower=0, upper=1000, step_increment=10, page_increment=50,
+        )
+        spin = Gtk.SpinButton(adjustment=adj)
+        spin.set_valign(Gtk.Align.CENTER)
+        spin.connect("value-changed", lambda s: _s("capture_delay_ms", int(s.get_value())))
+        delay_row.set_control(spin)
+        card.append(delay_row)
+        return card
+
+    # -- Recipes (editable) -----------------------------------------------
+
+    def _recipes_card(self):
+        import copy
+
+        from ai_config import DEFAULT_RECIPES
+
+        self._recipes = copy.deepcopy(_g("recipes", default=DEFAULT_RECIPES))
+        if not isinstance(self._recipes, list):
+            self._recipes = copy.deepcopy(DEFAULT_RECIPES)
+
+        card = SettingsCard(_("Recipes"))
+        hint = Gtk.Label()
+        hint.set_markup(
+            f'<span size="small">{_("One-click prompts shown in the builder. Edit the name and the instruction sent to the AI.")}</span>'
+        )
+        hint.set_halign(Gtk.Align.START)
+        hint.set_wrap(True)
+        hint.add_css_class("dim-label")
+        hint.set_margin_bottom(8)
+        card.append(hint)
+
+        self._recipes_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        card.append(self._recipes_box)
+
+        btn_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        btn_row.set_margin_top(8)
+        add_btn = Gtk.Button(label=_("Add recipe"))
+        add_btn.set_icon_name("list-add-symbolic")
+        add_btn.connect("clicked", self._on_add_recipe)
+        reset_btn = Gtk.Button(label=_("Reset to defaults"))
+        reset_btn.add_css_class("flat")
+        reset_btn.connect("clicked", self._on_reset_recipes)
+        btn_row.append(add_btn)
+        btn_row.append(reset_btn)
+        card.append(btn_row)
+
+        self._rebuild_recipes()
+        return card
+
+    def _rebuild_recipes(self):
+        child = self._recipes_box.get_first_child()
+        while child is not None:
+            nxt = child.get_next_sibling()
+            self._recipes_box.remove(child)
+            child = nxt
+
+        for i, recipe in enumerate(self._recipes):
+            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+
+            label_entry = Gtk.Entry()
+            label_entry.set_text(recipe.get("label", ""))
+            label_entry.set_width_chars(12)
+            label_entry.set_placeholder_text(_("Name"))
+            label_entry.connect(
+                "changed", lambda e, idx=i: self._update_recipe(idx, "label", e.get_text())
+            )
+            row.append(label_entry)
+
+            prompt_entry = Gtk.Entry()
+            prompt_entry.set_text(recipe.get("prompt", ""))
+            prompt_entry.set_hexpand(True)
+            prompt_entry.set_placeholder_text(_("Instruction sent to the AI"))
+            prompt_entry.connect(
+                "changed", lambda e, idx=i: self._update_recipe(idx, "prompt", e.get_text())
+            )
+            row.append(prompt_entry)
+
+            del_btn = Gtk.Button(icon_name="user-trash-symbolic")
+            del_btn.add_css_class("flat")
+            del_btn.set_valign(Gtk.Align.CENTER)
+            del_btn.set_tooltip_text(_("Remove recipe"))
+            del_btn.connect("clicked", lambda b, idx=i: self._remove_recipe(idx))
+            row.append(del_btn)
+
+            self._recipes_box.append(row)
+
+    @staticmethod
+    def _slug(text):
+        keep = [c.lower() if c.isalnum() else "_" for c in (text or "").strip()]
+        slug = "".join(keep).strip("_") or "recipe"
+        return slug
+
+    def _update_recipe(self, idx, key, value):
+        if not (0 <= idx < len(self._recipes)):
+            return
+        self._recipes[idx][key] = value
+        if key == "label" and not self._recipes[idx].get("id"):
+            self._recipes[idx]["id"] = self._slug(value)
+        _s("recipes", self._recipes)
+
+    def _on_add_recipe(self, _btn):
+        self._recipes.append(
+            {"id": self._slug(f"custom {len(self._recipes) + 1}"),
+             "label": _("New recipe"), "prompt": ""}
+        )
+        _s("recipes", self._recipes)
+        self._rebuild_recipes()
+
+    def _remove_recipe(self, idx):
+        if 0 <= idx < len(self._recipes):
+            self._recipes.pop(idx)
+            _s("recipes", self._recipes)
+            self._rebuild_recipes()
+
+    def _on_reset_recipes(self, _btn):
+        import copy
+
+        from ai_config import DEFAULT_RECIPES
+
+        self._recipes = copy.deepcopy(DEFAULT_RECIPES)
+        _s("recipes", self._recipes)
+        self._rebuild_recipes()


### PR DESCRIPTION
## Summary

Adds a **Logi AI Prompt Builder** equivalent to the Action Ring: select text anywhere, pick an AI engine from the ring submenu, and transform it with one-click recipes or a free-form prompt. Works with **both API and no-API backends**, and is the closest practical match to Logitech Options+ on Linux.

## Backends

- **No-API (default):** drives an installed agent CLI, reusing its own login — no API key. **Claude Code** (`claude -p`) and **Gemini CLI** are built in; any `stdin→stdout` command works (ollama, codex, …).
- **API:** OpenAI (ChatGPT). Key via settings or env var.

## Engine + model

- The AI ring submenu offers **Claude / ChatGPT / Gemini**; each opens the builder on that engine.
- Inside the builder, a segmented toggle picks the **model variant** of the active engine (Claude → Opus/Sonnet/Haiku, Gemini → 2.5 Pro/Flash/Flash-Lite, ChatGPT → GPT-4o/4o-mini/o4-mini), remembered per engine.
- **Output-language toggle** (Auto / English / Português-BR) forces the answer language across all backends.
- **Settings page:** default engine + default model per engine, editable recipes (add/remove/rename/reset), advanced CLI command, OpenAI key, behavior options.

## UX

- Selection capture reads the X11 **PRIMARY selection** (falls back to a simulated Ctrl+C), preserving the user's clipboard.
- Result panel: **Copy / Insert / Regenerate** (Insert pastes via xdotool/ydotool/wtype, else falls back to a manual Ctrl+V with a clear hint).
- Horizontal **two-column layout**: recipe actions in a 2-column grid on the left, text boxes on the right.

## Also included (independent fixes)

- **Ring tremble:** the KDE wallpaper-recomposite 1px micro-oscillation is now opt-out via `radial.kde_recomposite_workaround`, fixing the visible ring tremble for users without animated wallpapers (defaults preserve the old behavior).
- **Terminal icon:** `_draw_icon` had no `terminal` case (and no fallback), so the terminal slice rendered invisible. Added a terminal glyph plus a generic fallback so any unmapped icon is drawn.

## Files

New overlay modules: `ai_config.py`, `ai_backend.py`, `ai_selection.py`, `ai_prompt_builder.py`, `settings_page_ai.py`. 10 files changed, ~1.7k insertions.

## Testing

- CLI backend verified end-to-end (text transform, language forcing both directions).
- Builder UI rendered offscreen in both states (empty / with result) to verify framing; per-engine model toggles show the correct variants with the configured default selected.
- Settings page (GTK4) constructs; recipe editor add/remove/update/reset exercised.
- `py_compile` clean on all changed/added modules.
- USB/Bolt and existing radial behavior untouched (KDE workaround defaults unchanged).

## Notes

- The AI feature lives almost entirely in the PyQt6 overlay + GTK4 settings; **no daemon changes**.
- Auto-Insert needs a key injector (`xdotool` on X11, or a running `ydotoold`); without one, results still reach the user via clipboard + manual paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
