### PR TITLE
fix(install): use python3-PyQt6 on openSUSE Tumbleweed (#24)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -387,7 +387,7 @@ install_deps_opensuse() {
     sudo zypper install -y \
         rust cargo \
         python3 python3-pip \
-        python3-qt6 python3-qt6-svg \
+        python3-PyQt6 \
         python3-gobject gtk4 libadwaita-devel \
         python3-cryptography \
         dbus-1-devel systemd-devel \


### PR DESCRIPTION
Fixes #24.

## Problem
On openSUSE Tumbleweed the one-line installer aborts in `install_deps_opensuse()` because zypper cannot find `python3-qt6-svg`. That package name does not exist on openSUSE: PyQt6 is shipped monolithically, with `QtSvg`/`QtSvgWidgets` built into the main binding package rather than a separate `-svg` subpackage. The overlay needs QtSvg at runtime (`overlay/overlay_actions.py` imports `QSvgRenderer`).

## Fix
Replace `python3-qt6 python3-qt6-svg` with `python3-PyQt6` in the zypper list.

`python3-PyQt6` exists on openSUSE Factory/Tumbleweed today, bundles QtSvg and QtSvgWidgets, and auto-pulls the C++ runtime `libQt6Svg6` through its RPM `Requires: libQt6Svg.so.6`. No separate svg token is needed.

## Verification
On a Tumbleweed system: `sudo zypper install -y python3-PyQt6` resolves, and the overlay's `from PyQt6.QtSvg import QSvgRenderer` import works at runtime.

Thanks to @fab0912 for the clear report.