### PR TITLE
fix(install): bootstrap rustup when the distro Rust is too old (#23)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -447,8 +447,34 @@ clone_repo() {
 }
 
 # ── Build ────────────────────────────────────────────────────────────
+
+# Minimum cargo minor version (1.MIN) able to build the daemon: the committed
+# Cargo.lock is format v4 (needs cargo >= 1.78) and the toml_edit dependency
+# needs rustc >= 1.76. Distro toolchains are frequently older (Ubuntu 24.04
+# ships 1.75), so bootstrap rustup when the active cargo is too old or missing.
+MIN_CARGO_MINOR=78
+ensure_rust_toolchain() {
+    if command -v cargo &> /dev/null; then
+        local ver major minor
+        ver="$(cargo --version 2>/dev/null | awk '{print $2}')"
+        major="${ver%%.*}"
+        minor="$(printf '%s' "$ver" | cut -d. -f2)"
+        if [ "${major:-0}" -gt 1 ] || { [ "${major:-0}" -eq 1 ] && [ "${minor:-0}" -ge "$MIN_CARGO_MINOR" ]; }; then
+            return 0
+        fi
+        log_warning "cargo $ver is too old to build (need >= 1.$MIN_CARGO_MINOR); installing rustup"
+    else
+        log_info "Rust toolchain not found; installing rustup"
+    fi
+
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+    # shellcheck source=/dev/null
+    . "$HOME/.cargo/env"
+}
+
 build_project() {
     step "Building daemon"
+    ensure_rust_toolchain
     log_info "Compiling Rust daemon..."
     cd "$INSTALL_DIR"
 


### PR DESCRIPTION
Fixes #23.

## Problem
On Ubuntu 24.04 the one-line installer fails to build the daemon with two errors in sequence:
1. A Cargo lockfile-version parse error. `daemon/Cargo.lock` is format **v4**, which needs **cargo >= 1.78**, but Ubuntu 24.04 ships **1.75** from apt, so cargo aborts before resolving.
2. `package toml_edit v0.23.9 cannot be built because it requires rustc 1.76 or newer`. `toml_edit` (a transitive dep via `zbus` -> `proc-macro-crate`) declares `rust-version = 1.76`.

Both stem from one cause: the installer used the distro's apt/dnf/zypper Rust, which is too old on several mainstream distros.

## Fix
Add `ensure_rust_toolchain()`, called at the start of `build_project()`:
- If the active `cargo` is already >= 1.78, keep the distro toolchain (no change for Arch or current Fedora).
- Otherwise install `rustup` stable non-interactively and `. "$HOME/.cargo/env"` in the same shell so the build uses it (`~/.cargo/bin` takes precedence).

This clears both errors with one change and also covers older Fedora and openSUSE Leap toolchains. The distro Rust packages are left in place (they pull the C linker), so nothing regresses; rustup is only fetched when the toolchain is too old.

## Verification
- `bash -n install.sh` passes.
- On Ubuntu 24.04: the installer now provisions cargo >= 1.78 and `cargo build --release` succeeds.

Thanks to @kingfranz for reporting this with the exact error output.