### PR TITLE
fix(cursor): radial menu position under fractional scaling (#25)

### DIFF
--- a/daemon/src/cursor.rs
+++ b/daemon/src/cursor.rs
@@ -5,6 +5,38 @@
 
 use std::process::Command;
 
+/// KWin script that reads the live cursor position, converts it from KWin
+/// logical coordinates into the Qt point space used by the XWayland overlay,
+/// and calls ShowMenuAtCursor.
+///
+/// KWin reports `workspace.cursorPos` in logical pixels. The overlay runs on
+/// the xcb (XWayland) platform where Qt high-DPI scaling is on, so its
+/// `QWidget.move()` expects point-space coordinates (point = logical / dpr).
+/// Dividing by the cursor screen's devicePixelRatio keeps the menu under the
+/// cursor at fractional scaling on Plasma 6. At 100% scaling dpr is 1.0 and
+/// this is the identity. Uniform scale (single or multi-monitor) is handled;
+/// mixed per-monitor scale factors are only approximate.
+pub const KWIN_SHOW_MENU_SCRIPT: &str = r#"
+var pos = workspace.cursorPos;
+var dpr = 1.0;
+var screens = workspace.screens;
+if (screens) {
+    for (var i = 0; i < screens.length; i++) {
+        var geo = screens[i].geometry;
+        if (pos.x >= geo.x && pos.x < geo.x + geo.width &&
+            pos.y >= geo.y && pos.y < geo.y + geo.height) {
+            var d = Number(screens[i].devicePixelRatio);
+            dpr = d > 0 ? d : 1.0;
+            break;
+        }
+    }
+}
+callDBus("org.kde.juhradialmx", "/org/kde/juhradialmx/Daemon",
+         "org.kde.juhradialmx.Daemon", "ShowMenuAtCursor",
+         Math.round(pos.x / dpr),
+         Math.round(pos.y / dpr));
+"#;
+
 /// Menu diameter in pixels (used for edge clamping)
 pub const MENU_DIAMETER: i32 = 280;
 

--- a/daemon/src/evdev.rs
+++ b/daemon/src/evdev.rs
@@ -812,13 +812,10 @@ impl EvdevHandler {
         use std::process::Command;
         use tempfile::Builder;
 
-        // Create KWin script that calls ShowMenuAtCursor with true cursor position
-        let script = r#"
-var pos = workspace.cursorPos;
-callDBus("org.kde.juhradialmx", "/org/kde/juhradialmx/Daemon",
-         "org.kde.juhradialmx.Daemon", "ShowMenuAtCursor",
-         pos.x, pos.y);
-"#;
+        // Shared cursor->menu script: converts the KWin logical cursor into the
+        // overlay's Qt point space (point = logical / devicePixelRatio). Defined
+        // once in cursor.rs so the fractional-scaling math has a single home.
+        let script = crate::cursor::KWIN_SHOW_MENU_SCRIPT;
 
         // Create a temporary file with .js suffix securely
         let mut temp_file = match Builder::new().suffix(".js").tempfile() {

--- a/daemon/src/hidraw.rs
+++ b/daemon/src/hidraw.rs
@@ -516,33 +516,10 @@ impl HidrawHandler {
         use std::process::Command;
         use tempfile::Builder;
 
-        // Create KWin script that calls ShowMenuAtCursor with cursor position
-        // converted from KWin logical coords to Qt XCB (XWayland) coords.
-        // On HiDPI screens, KWin logical coords differ from XWayland coords
-        // by the per-screen scale factor. We find which screen contains the
-        // cursor and multiply the local offset by that screen's DPR.
-        let script = r#"
-var pos = workspace.cursorPos;
-var dpr = 1.0;
-var sx = 0, sy = 0;
-var screens = workspace.screens;
-if (screens) {
-    for (var i = 0; i < screens.length; i++) {
-        var geo = screens[i].geometry;
-        if (pos.x >= geo.x && pos.x < geo.x + geo.width &&
-            pos.y >= geo.y && pos.y < geo.y + geo.height) {
-            dpr = screens[i].devicePixelRatio;
-            sx = geo.x;
-            sy = geo.y;
-            break;
-        }
-    }
-}
-callDBus("org.kde.juhradialmx", "/org/kde/juhradialmx/Daemon",
-         "org.kde.juhradialmx.Daemon", "ShowMenuAtCursor",
-         sx + Math.round((pos.x - sx) * dpr),
-         sy + Math.round((pos.y - sy) * dpr));
-"#;
+        // Shared cursor->menu script: converts the KWin logical cursor into the
+        // overlay's Qt point space (point = logical / devicePixelRatio). Defined
+        // once in cursor.rs so the fractional-scaling math has a single home.
+        let script = crate::cursor::KWIN_SHOW_MENU_SCRIPT;
 
         // Create a temporary file with .js suffix securely
         let mut temp_file = match Builder::new().suffix(".js").tempfile() {


### PR DESCRIPTION
Fixes #25.

## Problem
On KDE Plasma 6 Wayland with display scaling other than 100%, the radial menu opens offset down-right of the cursor, and the error grows the further the cursor is from the screen top-left. At 100% it is correct (the reporter confirmed setting both monitors to 100% fixes it).

KWin reports `workspace.cursorPos` and `screen.geometry` in **logical** pixels. The overlay runs on the `xcb` (XWayland) platform, where Qt high-DPI scaling is on, so `QWidget.move()` expects **Qt point space** (point = logical / devicePixelRatio). The two paths were wrong in different ways:
- `hidraw.rs` multiplied the in-screen offset by the screen DPR (`sx + (pos.x - sx) * dpr`), which overshoots in point space (worse at higher scale).
- `evdev.rs` sent raw logical coordinates with no conversion.

## Fix
Divide the logical cursor position by the cursor screen's `devicePixelRatio` to land in point space, and consolidate the script into one shared constant `cursor::KWIN_SHOW_MENU_SCRIPT` used by both the hidraw and evdev paths (previously two divergent inline copies, which is how `evdev.rs` ended up with no scaling handling at all).

At 100% scaling dpr is 1.0, so behaviour is unchanged. Uniform scale (single or multi-monitor) is handled; mixed per-monitor scale factors are improved but only approximate (noted in the constant's doc comment).

## Verification
- `cargo check`, `cargo test` (244 passing), and `cargo clippy` are clean (the one remaining clippy note is pre-existing and unrelated).
- **Needs a hardware check before merge** (I cannot test scaling here): on KDE Plasma 6 Wayland at 150%, open the menu at the screen center, each corner, and on a second monitor, and confirm it lands under the cursor. Please also re-confirm 100% is unaffected.

Thanks to @mc6415 for the clear reproduction and for narrowing it to display scaling.