### PR TITLE
feat(buttons): apply reassigned back/forward/middle/shift-wheel actions (#26)

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -429,6 +429,41 @@ impl Config {
             _ => ButtonAction::None,
         }
     }
+
+    /// CIDs of the non-gesture buttons (back, forward, middle, shift-wheel) the
+    /// user has reassigned away from their native default. Only these are
+    /// HID++-diverted so the daemon can apply the chosen action; buttons left at
+    /// their native default are not diverted and keep hardware behaviour intact.
+    pub fn remapped_button_cids(&self) -> Vec<u16> {
+        use crate::hidraw::button_cid;
+        let mut cids = Vec::new();
+        if self.buttons.back != ButtonAction::Back {
+            cids.push(button_cid::BACK_BUTTON);
+        }
+        if self.buttons.forward != ButtonAction::Forward {
+            cids.push(button_cid::FORWARD_BUTTON);
+        }
+        if self.buttons.middle != ButtonAction::MiddleClick {
+            cids.push(button_cid::MIDDLE_BUTTON);
+        }
+        if self.buttons.shift_wheel != ButtonAction::Smartshift {
+            cids.push(button_cid::SMART_SHIFT);
+        }
+        cids
+    }
+
+    /// The full set of non-gesture button CIDs the daemon may divert. Used on
+    /// config reload to clear the divert for any button returned to its native
+    /// default so its hardware behaviour comes back without a reconnect.
+    pub fn managed_button_cids() -> [u16; 4] {
+        use crate::hidraw::button_cid;
+        [
+            button_cid::BACK_BUTTON,
+            button_cid::FORWARD_BUTTON,
+            button_cid::MIDDLE_BUTTON,
+            button_cid::SMART_SHIFT,
+        ]
+    }
 }
 
 // ============================================================================
@@ -745,5 +780,31 @@ mod tests {
             ButtonAction::Smartshift
         );
         assert_eq!(config.action_for_cid(9999), ButtonAction::None); // Unknown CID
+    }
+
+    #[test]
+    fn test_remapped_button_cids() {
+        use crate::hidraw::button_cid;
+
+        // Defaults are all native, so nothing is diverted.
+        assert!(Config::default().remapped_button_cids().is_empty());
+
+        // Reassigning non-gesture buttons away from their default marks them.
+        let mut config = Config::default();
+        config.buttons.back = ButtonAction::PlayPause;
+        config.buttons.middle = ButtonAction::None;
+        let cids = config.remapped_button_cids();
+        assert!(cids.contains(&button_cid::BACK_BUTTON));
+        assert!(cids.contains(&button_cid::MIDDLE_BUTTON));
+        assert!(!cids.contains(&button_cid::FORWARD_BUTTON));
+        assert!(!cids.contains(&button_cid::SMART_SHIFT));
+
+        // Returning a button to its native default clears it.
+        config.buttons.back = ButtonAction::Back;
+        assert!(
+            !config
+                .remapped_button_cids()
+                .contains(&button_cid::BACK_BUTTON)
+        );
     }
 }

--- a/daemon/src/dbus/interface.rs
+++ b/daemon/src/dbus/interface.rs
@@ -172,16 +172,23 @@ impl JuhRadialService {
                 // Re-apply non-gesture button diverts so a newly reassigned
                 // button takes effect immediately, and a button returned to its
                 // native default has its divert cleared, without a reconnect.
-                let manager = self.haptic_manager.clone();
-                tokio::task::spawn_blocking(move || {
-                    if let Ok(mut mgr) = manager.lock() {
+                // Done synchronously under the manager lock to match the other
+                // device calls in this interface (this runs on the zbus executor,
+                // not a Tokio runtime, so spawn_blocking is not available). The
+                // HID++ calls are quick when the device is connected and return
+                // immediately when it is not.
+                match self.haptic_manager.lock() {
+                    Ok(mut manager) => {
                         let remapped: std::collections::HashSet<u16> =
                             remapped_cids.into_iter().collect();
                         for cid in Config::managed_button_cids() {
-                            let _ = mgr.set_button_divert(cid, remapped.contains(&cid));
+                            let _ = manager.set_button_divert(cid, remapped.contains(&cid));
                         }
                     }
-                });
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Failed to lock haptic manager for button divert");
+                    }
+                }
 
                 Ok(())
             }

--- a/daemon/src/dbus/interface.rs
+++ b/daemon/src/dbus/interface.rs
@@ -133,6 +133,7 @@ impl JuhRadialService {
         match Config::load_default() {
             Ok(new_config) => {
                 let haptic_config = new_config.haptics.clone();
+                let remapped_cids = new_config.remapped_button_cids();
 
                 match self.config.write() {
                     Ok(mut config) => {
@@ -167,6 +168,20 @@ impl JuhRadialService {
                         return Err(fdo::Error::Failed(format!("Haptic manager lock error: {}", e)));
                     }
                 }
+
+                // Re-apply non-gesture button diverts so a newly reassigned
+                // button takes effect immediately, and a button returned to its
+                // native default has its divert cleared, without a reconnect.
+                let manager = self.haptic_manager.clone();
+                tokio::task::spawn_blocking(move || {
+                    if let Ok(mut mgr) = manager.lock() {
+                        let remapped: std::collections::HashSet<u16> =
+                            remapped_cids.into_iter().collect();
+                        for cid in Config::managed_button_cids() {
+                            let _ = mgr.set_button_divert(cid, remapped.contains(&cid));
+                        }
+                    }
+                });
 
                 Ok(())
             }

--- a/daemon/src/hidpp/device.rs
+++ b/daemon/src/hidpp/device.rs
@@ -900,6 +900,18 @@ impl HidppDevice {
     /// This prevents the OS from seeing the button event. Instead, it arrives
     /// as a HID++ notification that the hidraw handler forwards as MacroTriggered.
     pub fn divert_single_button(&mut self, cid: u16) -> Result<bool, HapticError> {
+        self.set_button_divert(cid, true)
+    }
+
+    /// Enable or disable the volatile HID++ divert for a single control by CID.
+    ///
+    /// With `divert` true the button's events arrive as HID++ notifications
+    /// instead of normal input; with `divert` false the divert is cleared and
+    /// the button returns to its native hardware behaviour. The divert is
+    /// volatile and is reset by the device on disconnect / Easy-Switch host
+    /// change. Returns `Ok(true)` when the control was found and the request
+    /// succeeded, `Ok(false)` when the CID is absent or not divertable.
+    pub fn set_button_divert(&mut self, cid: u16, divert: bool) -> Result<bool, HapticError> {
         let feature_index = match self.reprog_controls_feature_index {
             Some(idx) => idx,
             None => return Ok(false),
@@ -922,7 +934,9 @@ impl HidppDevice {
             let divertable = (flags & 0x20) != 0;
 
             if found_cid == cid && divertable {
-                let divert_flags: u8 = 0x03; // TemporaryDiverted | ChangeTemporaryDivert
+                // ChangeTemporaryDivert (0x02) is the change gate; OR in
+                // TemporaryDiverted (0x01) to enable, leave it clear to disable.
+                let divert_flags: u8 = if divert { 0x03 } else { 0x02 };
                 let params: &[u8] = &[
                     (cid >> 8) as u8,
                     (cid & 0xFF) as u8,
@@ -934,8 +948,9 @@ impl HidppDevice {
                 if let Some(resp) = self.hidpp_long_request(feature_index, 0x03, params) {
                     tracing::info!(
                         cid = format!("0x{:04X}", cid),
+                        divert,
                         response = format!("{:02X?}", &resp[4..resp.len().min(9)]),
-                        "Macro button diverted"
+                        "Button divert updated"
                     );
                     return Ok(true);
                 }

--- a/daemon/src/hidpp/manager.rs
+++ b/daemon/src/hidpp/manager.rs
@@ -190,6 +190,14 @@ impl HapticManager {
         }
     }
 
+    /// Enable or disable the volatile divert for a single button by CID.
+    pub fn set_button_divert(&mut self, cid: u16, divert: bool) -> Result<bool, HapticError> {
+        match &mut self.device {
+            Some(device) => device.set_button_divert(cid, divert),
+            None => Ok(false),
+        }
+    }
+
     /// Handle device disconnection gracefully
     fn handle_disconnect(&mut self) {
         let now = SystemTime::now()

--- a/daemon/src/hidraw.rs
+++ b/daemon/src/hidraw.rs
@@ -135,6 +135,22 @@ impl HidrawHandler {
         }
     }
 
+    /// Whether a diverted CID should be dispatched as a configured button
+    /// action. Gesture and haptic buttons always are; the other reprogrammable
+    /// buttons (back/forward/middle/shift-wheel) only when the user reassigned
+    /// them away from their native default, which matches what divert applies.
+    fn is_action_button(&self, cid: u16) -> bool {
+        if cid == button_cid::GESTURE_BUTTON || cid == button_cid::HAPTIC {
+            return true;
+        }
+        if let Some(ref config) = self.shared_config {
+            if let Ok(cfg) = config.read() {
+                return cfg.remapped_button_cids().contains(&cid);
+            }
+        }
+        false
+    }
+
     /// Find the Logitech hidraw device for HID++ button events
     ///
     /// Supports multiple receiver types:
@@ -350,8 +366,9 @@ impl HidrawHandler {
         // A CID of 0 means all buttons released
         let pressed = cid != 0;
 
-        // Check if this is the gesture button OR haptic button (both can trigger radial menu)
-        let is_known = cid == button_cid::GESTURE_BUTTON || cid == button_cid::HAPTIC || cid == 0;
+        // Whether this CID maps to a configured action (gesture/haptic, or a
+        // reassigned back/forward/middle/shift-wheel) or is the release marker.
+        let is_known = self.is_action_button(cid) || cid == 0;
 
         if is_known {
             tracing::info!(
@@ -369,7 +386,7 @@ impl HidrawHandler {
             );
         }
 
-        if cid == button_cid::GESTURE_BUTTON || cid == button_cid::HAPTIC {
+        if self.is_action_button(cid) {
             // Look up configured action for this button
             let action = self.get_action_for_cid(cid);
             tracing::info!(cid, %action, "Button pressed - config action lookup");

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -608,6 +608,7 @@ fn list_logitech_devices() {
 async fn refresh_hidpp_button_diverts(
     haptic_manager: SharedHapticManager,
     macro_cids: Vec<u16>,
+    remapped_cids: Vec<u16>,
 ) -> Option<PathBuf> {
     match tokio::task::spawn_blocking(move || {
         let mut manager = haptic_manager.lock().unwrap();
@@ -633,6 +634,26 @@ async fn refresh_hidpp_button_diverts(
                             cid = format!("0x{:04X}", cid),
                             error = %e,
                             "Failed to divert HID++ macro button"
+                        ),
+                    }
+                }
+
+                // Divert buttons the user reassigned away from their native
+                // default so the daemon can apply the configured action.
+                for &cid in &remapped_cids {
+                    match manager.divert_single_button(cid) {
+                        Ok(true) => info!(
+                            cid = format!("0x{:04X}", cid),
+                            "HID++ reassigned button diverted"
+                        ),
+                        Ok(false) => debug!(
+                            cid = format!("0x{:04X}", cid),
+                            "Reassigned button not divertable on this device"
+                        ),
+                        Err(e) => warn!(
+                            cid = format!("0x{:04X}", cid),
+                            error = %e,
+                            "Failed to divert HID++ reassigned button"
                         ),
                     }
                 }
@@ -669,13 +690,23 @@ async fn run_hidraw_loop(
 ) {
     let mut handler = HidrawHandler::new(event_tx);
     let macro_cids_for_divert = macro_cids.clone();
+    let config_for_divert = shared_config.clone();
     handler.set_macro_cids(macro_cids);
     handler.set_shared_config(shared_config);
 
     loop {
-        if let Some(path) =
-            refresh_hidpp_button_diverts(haptic_manager.clone(), macro_cids_for_divert.clone())
-                .await
+        // Re-read the reassigned buttons each cycle so a config change is
+        // picked up on the next reconnect (live changes go through ReloadConfig).
+        let remapped_cids = config_for_divert
+            .read()
+            .map(|c| c.remapped_button_cids())
+            .unwrap_or_default();
+        if let Some(path) = refresh_hidpp_button_diverts(
+            haptic_manager.clone(),
+            macro_cids_for_divert.clone(),
+            remapped_cids,
+        )
+        .await
         {
             preferred_path = Some(path);
         }


### PR DESCRIPTION
Fixes #26.

## Problem
Reassigning the back/forward/middle/shift-wheel buttons in Settings (for example Back to Play/Pause) had no effect: the button kept doing its native action. The UI exposed the reassignment and `Config::action_for_cid` mapped these CIDs to actions, but `divert_buttons()` only ever diverted the gesture (`0x00C3`) and haptic (`0x01A0`) controls. The other buttons were never diverted, so the daemon never saw them as remappable and the OS handled them natively.

## Fix
- `Config::remapped_button_cids()` returns the CIDs of non-gesture buttons reassigned **away from their native default**; `managed_button_cids()` is the full set used to clear stale diverts.
- The hidraw handler now routes those reassigned CIDs through the existing button-action dispatch (the same path gesture/haptic already use, so actions like Play/Pause, Copy, etc. work identically).
- `HidppDevice::set_button_divert(cid, divert)` generalizes the single-button divert so it can also **clear** a divert; `divert_single_button` delegates to it.
- Diverts are re-applied on connect, reconnect, and live `ReloadConfig`. On reload the daemon converges the set: divert the reassigned buttons and clear the rest, so returning a button to its default restores native behaviour without a reconnect.

### Safety / no regression
A non-gesture button is diverted **only** when reassigned away from its native default. Users who have not changed back/forward/middle/shift-wheel get byte-for-byte the same behaviour as before (those CIDs are never diverted). This keeps the risky "re-emit native action" path out of the change entirely.

## Verification
- `cargo test` (245 passing, incl. a new `test_remapped_button_cids`), `cargo check`, and `cargo clippy` are clean (the one clippy note is pre-existing and unrelated).
- **Needs a hardware check before merge** (no MX Master 4 here): set Back to Play/Pause, Save, and confirm Play/Pause fires; confirm a button left at default still does its native action; reassign forward/middle/shift-wheel; revert one to default and confirm native behaviour returns without restart; unplug/replug and confirm the remap survives.

Thanks to @mc6415 for the detailed report and daemon logs.