### PR TITLE
fix(hidpp): gate long-request 0xFF error check on report type

### DIFF
--- a/daemon/src/hidpp/device.rs
+++ b/daemon/src/hidpp/device.rs
@@ -534,8 +534,16 @@ impl HidppDevice {
                         return Some(response[..len].to_vec());
                     }
 
-                    // Check for error response
-                    if response[2] == 0xFF {
+                    // Check for error response. A HID++ 2.0 error is a report
+                    // (0x10/0x11) for our device index with 0xFF in byte 2.
+                    // Gate on report type + device index so unrelated input
+                    // reports (e.g. mouse motion whose byte 2 can be 0xFF) are
+                    // not misread as protocol errors, which would abort feature
+                    // enumeration while the mouse is moving.
+                    if (response[0] == report_type::SHORT || response[0] == report_type::LONG)
+                        && response[1] == self.device_index
+                        && response[2] == 0xFF
+                    {
                         let error_code = response[5];
                         tracing::warn!(
                             error_code,


### PR DESCRIPTION
Open follow-up to PR #20. Improves HID++ reliability on shared receivers and unblocks reliable button divert (relevant to #26).

## Problem
`hidpp_long_request` treated any response whose byte 2 is `0xFF` as a HID++ error, unlike `hidpp_request`, which nests that check inside a report-type guard. On a shared receiver fd the daemon also reads mouse input reports (for example motion), whose byte 2 can be `0xFF`. Moving the mouse during feature enumeration was therefore misread as a protocol error, aborting enumeration. Symptoms: "Logitech device not connected", "No HID++ gesture buttons found", flaky battery reads, and gesture/button divert failing to apply.

This reproduces live: on a Bolt/Unifying receiver, a fresh daemon start while the mouse is moving fails to connect HID++, while a start with the mouse still succeeds.

## Fix
Gate the `0xFF` error check on report type (`0x10`/`0x11`) and device index, matching `hidpp_request`, so only genuine HID++ error reports are treated as errors.

## Verification
- `cargo check` and the existing suite pass.
- On a real Bolt receiver, the daemon now connects HID++ and diverts buttons reliably even when the mouse is moving at startup.