### PR TITLE
fix: Hyprland mixed-scale menu placement (#45) + settings CPU leak (#32)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -395,8 +395,11 @@ install_deps_opensuse() {
         ydotool \
         git make
 
-    if ! sudo zypper install -y gtk4-layer-shell; then
-        log_warning "gtk4-layer-shell not available on this repo"
+    # gtk4-layer-shell is optional: only the niri compositor needs it. openSUSE
+    # does not ship it in the default repos (it lives in devel:languages:zig), so
+    # skip it rather than warn alarmingly. niri users can add that repo first.
+    if ! sudo zypper install -y gtk4-layer-shell 2>/dev/null; then
+        log_info "Skipping gtk4-layer-shell (optional, only needed for the niri compositor; not in default openSUSE repos)"
     fi
 }
 

--- a/overlay/juhradial-overlay.py
+++ b/overlay/juhradial-overlay.py
@@ -57,6 +57,7 @@ from overlay_constants import (
     CENTER_ZONE_RADIUS,
     WINDOW_SIZE,
     compute_ring_scale,
+    hyprland_menu_center,
     IS_HYPRLAND,
     IS_GNOME,
     IS_COSMIC,
@@ -69,6 +70,7 @@ from overlay_constants import (
 from overlay_cursor import (
     _refresh_monitors,
     get_monitor_at_cursor,
+    get_all_monitors_logical,
     get_cursor_position_hyprland,
     get_cursor_position_gnome,
     get_cursor_position_qt,
@@ -688,7 +690,41 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
         # any visible frame at the wrong location on multi-monitor setups
         self.highlighted_slice = -1
         self.setWindowOpacity(0.0)
-        self.move(x - half, y - half)
+
+        # On Hyprland, hyprctl cursorpos is in compositor-logical pixels, but
+        # QWidget.move() places windows in Qt's own coordinate space. With
+        # mixed/fractional monitor scaling these spaces differ (either Qt applies
+        # a devicePixelRatio or XWayland scales the surface), so passing logical
+        # coords straight to move() drifts the menu proportionally to its distance
+        # from the origin (issue #45). Map the cursor's fractional position within
+        # its monitor onto the matching Qt screen's geometry, which is in the same
+        # space move() uses, so the menu lands on the cursor regardless of scale
+        # or which layer applies it. When geometries match (100% scaling) this is
+        # an identity no-op. menu_center_x/y stay in logical space above because
+        # the toggle-mode hover poll compares them against get_cursor_pos()
+        # (also logical).
+        move_x, move_y = x - half, y - half
+        if IS_HYPRLAND and mon:
+            from PyQt6.QtWidgets import QApplication
+            app = QApplication.instance()
+            qt_screens = []
+            if app:
+                for screen in app.screens():
+                    g = screen.geometry()
+                    qt_screens.append({
+                        "x": g.x(), "y": g.y(),
+                        "width": g.width(), "height": g.height(),
+                        "name": screen.name(),
+                    })
+            cx, cy = hyprland_menu_center(
+                x, y, mon, get_all_monitors_logical(), qt_screens
+            )
+            move_x, move_y = cx - half, cy - half
+            _log(
+                f"Hyprland placement: logical ({x},{y}) -> Qt ({cx},{cy}); "
+                f"qt_screens={[(s['name'], s['width'], s['height']) for s in qt_screens]}"
+            )
+        self.move(move_x, move_y)
 
         # On KDE Plasma, XWayland windows show a frozen wallpaper rectangle
         # behind transparent areas (KWin caches the wallpaper). The circular

--- a/overlay/juhradial-overlay.py
+++ b/overlay/juhradial-overlay.py
@@ -57,7 +57,7 @@ from overlay_constants import (
     CENTER_ZONE_RADIUS,
     WINDOW_SIZE,
     compute_ring_scale,
-    hyprland_menu_center,
+    map_and_clamp_menu,
     IS_HYPRLAND,
     IS_GNOME,
     IS_COSMIC,
@@ -662,14 +662,45 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
         # Size the ring for the monitor it opens on
         self._apply_ring_scale(mon)
 
-        # Clamp menu position to stay within the active monitor
+        # Decide where the window goes. On Hyprland, hyprctl cursorpos is in
+        # compositor-logical pixels while QWidget.move() is in Qt's own space;
+        # under mixed/fractional scaling these differ, so we map the cursor's
+        # fractional position onto the Qt screen and clamp the window in Qt space
+        # (clamping before mapping overflows the edge on mixed scale, issue #45).
+        # menu_center_x/y stay logical because the hover poll compares them
+        # against get_cursor_pos() (also logical). Other compositors: logical
+        # space already equals move() space, so clamp directly there.
         half = self.win_px // 2
-        if mon:
-            x = max(mon["x"] + half, min(x, mon["x"] + mon["width"] - half))
-            y = max(mon["y"] + half, min(y, mon["y"] + mon["height"] - half))
+        if IS_HYPRLAND and mon:
+            from PyQt6.QtWidgets import QApplication
+            app = QApplication.instance()
+            qt_screens = []
+            if app:
+                for screen in app.screens():
+                    g = screen.geometry()
+                    qt_screens.append({
+                        "x": g.x(), "y": g.y(),
+                        "width": g.width(), "height": g.height(),
+                        "name": screen.name(),
+                    })
+            placement = map_and_clamp_menu(
+                x, y, mon, get_all_monitors_logical(), qt_screens, self.win_px
+            )
+            self.menu_center_x, self.menu_center_y = placement["logical_center"]
+            move_x, move_y = placement["qt_origin"]
+            _log(
+                f"Hyprland placement: logical ({x},{y}) -> Qt {placement['qt_center']} "
+                f"origin {placement['qt_origin']} logical_center {placement['logical_center']}; "
+                f"qt_screens={[(s['name'], s['width'], s['height']) for s in qt_screens]}"
+            )
+        else:
+            if mon:
+                x = max(mon["x"] + half, min(x, mon["x"] + mon["width"] - half))
+                y = max(mon["y"] + half, min(y, mon["y"] + mon["height"] - half))
+            self.menu_center_x = x
+            self.menu_center_y = y
+            move_x, move_y = x - half, y - half
 
-        self.menu_center_x = x
-        self.menu_center_y = y
         self.toggle_mode = False  # Reset toggle mode on new show
         self.show_time = time.time()  # Track when menu was shown
 
@@ -687,43 +718,11 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
         overlay_actions.get_media_state()
 
         # Position and show: set opacity to 0 and move BEFORE show to prevent
-        # any visible frame at the wrong location on multi-monitor setups
+        # any visible frame at the wrong location on multi-monitor setups.
+        # move_x/move_y were computed above (Qt space on Hyprland, logical space
+        # otherwise).
         self.highlighted_slice = -1
         self.setWindowOpacity(0.0)
-
-        # On Hyprland, hyprctl cursorpos is in compositor-logical pixels, but
-        # QWidget.move() places windows in Qt's own coordinate space. With
-        # mixed/fractional monitor scaling these spaces differ (either Qt applies
-        # a devicePixelRatio or XWayland scales the surface), so passing logical
-        # coords straight to move() drifts the menu proportionally to its distance
-        # from the origin (issue #45). Map the cursor's fractional position within
-        # its monitor onto the matching Qt screen's geometry, which is in the same
-        # space move() uses, so the menu lands on the cursor regardless of scale
-        # or which layer applies it. When geometries match (100% scaling) this is
-        # an identity no-op. menu_center_x/y stay in logical space above because
-        # the toggle-mode hover poll compares them against get_cursor_pos()
-        # (also logical).
-        move_x, move_y = x - half, y - half
-        if IS_HYPRLAND and mon:
-            from PyQt6.QtWidgets import QApplication
-            app = QApplication.instance()
-            qt_screens = []
-            if app:
-                for screen in app.screens():
-                    g = screen.geometry()
-                    qt_screens.append({
-                        "x": g.x(), "y": g.y(),
-                        "width": g.width(), "height": g.height(),
-                        "name": screen.name(),
-                    })
-            cx, cy = hyprland_menu_center(
-                x, y, mon, get_all_monitors_logical(), qt_screens
-            )
-            move_x, move_y = cx - half, cy - half
-            _log(
-                f"Hyprland placement: logical ({x},{y}) -> Qt ({cx},{cy}); "
-                f"qt_screens={[(s['name'], s['width'], s['height']) for s in qt_screens]}"
-            )
         self.move(move_x, move_y)
 
         # On KDE Plasma, XWayland windows show a frozen wallpaper rectangle

--- a/overlay/overlay_constants.py
+++ b/overlay/overlay_constants.py
@@ -12,7 +12,8 @@ import time as _time_mod
 
 __all__ = [
     "MENU_RADIUS", "SHADOW_OFFSET", "CENTER_ZONE_RADIUS", "ICON_ZONE_RADIUS",
-    "SUBMENU_EXTEND", "WINDOW_SIZE", "compute_ring_scale",
+    "SUBMENU_EXTEND", "WINDOW_SIZE", "compute_ring_scale", "map_logical_to_screen",
+    "hyprland_menu_center",
     "IS_HYPRLAND", "IS_GNOME", "IS_COSMIC", "IS_KDE", "IS_SWAY", "IS_NIRI", "IS_X11",
     "_HAS_XWAYLAND",
     "_log",
@@ -43,6 +44,82 @@ def compute_ring_scale(monitor_height):
         return 1.0
     scale = monitor_height / RING_SCALE_REFERENCE_HEIGHT
     return max(RING_SCALE_MIN, min(RING_SCALE_MAX, scale))
+
+
+def map_logical_to_screen(lx, ly, mon, screen_geo):
+    """Map a compositor-logical cursor coordinate into the matching Qt screen's
+    coordinate space, by fractional position within the monitor.
+
+    The cursor's fractional position within its monitor (e.g. 0.36 across, 0.39
+    down) is invariant across coordinate spaces, so it can be transferred from
+    the compositor-logical layout to Qt's own screen geometry without knowing the
+    devicePixelRatio or how XWayland scales. This lands QWidget.move() on the
+    cursor regardless of per-monitor scale, fractional scaling, or which layer
+    (Qt vs XWayland) applies the scaling (issue #45). When the monitor and Qt
+    screen geometries match (no scaling, e.g. 100%) it returns (lx, ly) unchanged.
+
+    Args:
+        lx, ly: cursor position in compositor-logical pixels (hyprctl cursorpos).
+        mon: cursor's monitor as {x, y, width, height} in compositor-logical px.
+        screen_geo: matching Qt screen as {x, y, width, height} in Qt point space
+            (QScreen.geometry()).
+
+    Returns:
+        (cx, cy) menu-center in Qt point space, rounded to ints.
+    """
+    mw = mon.get("width") or 1
+    mh = mon.get("height") or 1
+    fx = (lx - mon.get("x", 0)) / mw
+    fy = (ly - mon.get("y", 0)) / mh
+    cx = screen_geo["x"] + fx * screen_geo["width"]
+    cy = screen_geo["y"] + fy * screen_geo["height"]
+    return (int(round(cx)), int(round(cy)))
+
+
+def _bounding_box(rects):
+    """Union bounding box of a list of {x, y, width, height} rects."""
+    x0 = min(r["x"] for r in rects)
+    y0 = min(r["y"] for r in rects)
+    x1 = max(r["x"] + r["width"] for r in rects)
+    y1 = max(r["y"] + r["height"] for r in rects)
+    return {"x": x0, "y": y0, "width": x1 - x0, "height": y1 - y0}
+
+
+def hyprland_menu_center(lx, ly, cursor_mon, hypr_monitors, qt_screens):
+    """Menu-center in Qt point space for a Hyprland compositor-logical cursor.
+
+    Tiered so it is exact when it can be and still corrects the drift when it
+    cannot, across any monitor count / scale mix (issue #45). Each tier reduces
+    to identity at 100% scaling, so single-scale setups are never regressed.
+
+    1. Per-monitor: map the cursor's fraction within its monitor onto the Qt
+       screen with the same connector name. Exact whether Qt or XWayland applies
+       the scaling, because that screen's geometry is already in move() space.
+    2. Global affine: if no Qt screen name matches (XWayland sometimes exposes
+       generic output names), map the cursor's fraction across the whole logical
+       desktop onto the whole Qt desktop. Name-agnostic and exact under
+       XWayland's single global-scale model.
+    3. Identity: if Qt screen geometry is unavailable, pass the coordinate
+       through unchanged (current behaviour).
+
+    Args:
+        lx, ly: cursor in compositor-logical pixels.
+        cursor_mon: cursor's monitor {x, y, width, height, name} (logical px).
+        hypr_monitors: all monitors as logical {x, y, width, height, name}.
+        qt_screens: all Qt screens as {x, y, width, height, name} (point space).
+    """
+    if cursor_mon and qt_screens:
+        name = cursor_mon.get("name")
+        for screen in qt_screens:
+            if name and screen.get("name") == name:
+                return map_logical_to_screen(lx, ly, cursor_mon, screen)
+
+    if hypr_monitors and qt_screens:
+        return map_logical_to_screen(
+            lx, ly, _bounding_box(hypr_monitors), _bounding_box(qt_screens)
+        )
+
+    return (int(round(lx)), int(round(ly)))
 
 # =============================================================================
 # DESKTOP ENVIRONMENT DETECTION FLAGS

--- a/overlay/overlay_constants.py
+++ b/overlay/overlay_constants.py
@@ -67,13 +67,38 @@ def map_logical_to_screen(lx, ly, mon, screen_geo):
     Returns:
         (cx, cy) menu-center in Qt point space, rounded to ints.
     """
-    mw = mon.get("width") or 1
-    mh = mon.get("height") or 1
-    fx = (lx - mon.get("x", 0)) / mw
-    fy = (ly - mon.get("y", 0)) / mh
-    cx = screen_geo["x"] + fx * screen_geo["width"]
-    cy = screen_geo["y"] + fy * screen_geo["height"]
+    cx, cy = _map_fraction(lx, ly, mon, screen_geo)
     return (int(round(cx)), int(round(cy)))
+
+
+def _map_fraction(x, y, src, dst):
+    """Map (x, y) from rect ``src`` to rect ``dst`` by fractional position.
+
+    The point's fraction within ``src`` is invariant across coordinate spaces,
+    so this transfers it to ``dst`` without knowing any scale factor. Returns
+    floats; callers round when they need ints.
+    """
+    sw = src.get("width") or 1
+    sh = src.get("height") or 1
+    fx = (x - src.get("x", 0)) / sw
+    fy = (y - src.get("y", 0)) / sh
+    return (dst.get("x", 0) + fx * (dst.get("width") or 1),
+            dst.get("y", 0) + fy * (dst.get("height") or 1))
+
+
+def _clamp_center(cx, cy, rect, half):
+    """Clamp a window center so a ``half``-radius window stays inside ``rect``.
+
+    All values share one coordinate space (``half`` matches ``rect``). If the
+    window is larger than the rect (margins cross over), the rect is centred.
+    """
+    rx, ry = rect.get("x", 0), rect.get("y", 0)
+    rw, rh = rect.get("width") or 1, rect.get("height") or 1
+    min_x, max_x = rx + half, rx + rw - half
+    min_y, max_y = ry + half, ry + rh - half
+    cx = min(max(cx, min_x), max_x) if min_x <= max_x else rx + rw / 2
+    cy = min(max(cy, min_y), max_y) if min_y <= max_y else ry + rh / 2
+    return cx, cy
 
 
 def _bounding_box(rects):
@@ -120,6 +145,65 @@ def hyprland_menu_center(lx, ly, cursor_mon, hypr_monitors, qt_screens):
         )
 
     return (int(round(lx)), int(round(ly)))
+
+
+def _select_screens(cursor_mon, hypr_monitors, qt_screens):
+    """Return the (logical_rect, qt_rect) pair to map between, mirroring the
+    tiers of hyprland_menu_center. Returns (None, None) for identity passthrough
+    (no Qt screen info), where logical space already equals move() space.
+    """
+    if cursor_mon and qt_screens:
+        name = cursor_mon.get("name")
+        for screen in qt_screens:
+            if name and screen.get("name") == name:
+                return cursor_mon, screen
+    if hypr_monitors and qt_screens:
+        return _bounding_box(hypr_monitors), _bounding_box(qt_screens)
+    return None, None
+
+
+def map_and_clamp_menu(lx, ly, cursor_mon, hypr_monitors, qt_screens, window_size):
+    """Place the menu for a Hyprland logical cursor and clamp it on-screen.
+
+    Maps the cursor into Qt space (so QWidget.move() lands on the cursor under
+    mixed/fractional scaling, issue #45) and then clamps the window in Qt space
+    using the Qt-space half-window. Clamping must happen AFTER the mapping:
+    clamping in logical space with a Qt-space margin leaves a residual corner
+    overflow when the logical and Qt monitor geometries differ by a per-monitor
+    scale. The logical center is back-derived from the clamped Qt center so hover
+    hit-testing (which polls the logical cursor) stays aligned with the visible
+    ring.
+
+    Returns a dict:
+        qt_center      (cx, cy) menu center in Qt point space
+        qt_origin      (x, y) top-left for QWidget.move()
+        logical_center (cx, cy) menu center in compositor-logical space
+    """
+    half = window_size // 2
+    logical_rect, qt_rect = _select_screens(cursor_mon, hypr_monitors, qt_screens)
+
+    if qt_rect is None:
+        # Identity passthrough: no Qt geometry, so logical == move() space.
+        qx, qy = (lx, ly)
+        if cursor_mon:
+            qx, qy = _clamp_center(lx, ly, cursor_mon, half)
+        qx, qy = int(round(qx)), int(round(qy))
+        return {
+            "qt_center": (qx, qy),
+            "qt_origin": (qx - half, qy - half),
+            "logical_center": (qx, qy),
+        }
+
+    qx, qy = _map_fraction(lx, ly, logical_rect, qt_rect)
+    qx, qy = _clamp_center(qx, qy, qt_rect, half)
+    lcx, lcy = _map_fraction(qx, qy, qt_rect, logical_rect)
+
+    qx, qy = int(round(qx)), int(round(qy))
+    return {
+        "qt_center": (qx, qy),
+        "qt_origin": (qx - half, qy - half),
+        "logical_center": (int(round(lcx)), int(round(lcy))),
+    }
 
 # =============================================================================
 # DESKTOP ENVIRONMENT DETECTION FLAGS

--- a/overlay/overlay_cursor.py
+++ b/overlay/overlay_cursor.py
@@ -119,6 +119,30 @@ def get_monitor_at_cursor(cx, cy):
     return {"x": 0, "y": 0, "width": 1920, "height": 1080, "name": "fallback"}
 
 
+def get_all_monitors_logical():
+    """Return all Hyprland monitors as logical-pixel rects.
+
+    Each rect is {x, y, width, height, name}. Width/height are the transformed
+    (scaled) logical sizes, matching the compositor-logical cursor coordinate
+    space. Used to map the cursor onto Qt screen geometry for menu placement.
+    """
+    global _monitors_cache
+    if _monitors_cache is None:
+        _refresh_monitors()
+
+    rects = []
+    for mon in _monitors_cache or []:
+        scale = mon.get("scale", 1.0) or 1.0
+        rects.append({
+            "x": mon.get("x", 0),
+            "y": mon.get("y", 0),
+            "width": int(mon.get("width", 1920) / scale),
+            "height": int(mon.get("height", 1080) / scale),
+            "name": mon.get("name", "?"),
+        })
+    return rects
+
+
 def get_cursor_position_hyprland():
     """Get cursor position using Hyprland IPC socket (faster than subprocess).
 

--- a/overlay/settings_dashboard.py
+++ b/overlay/settings_dashboard.py
@@ -275,7 +275,10 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
             # Resume timers
             if not self._is_generic and not self._battery_timer_id:
                 self._battery_timer_id = GLib.timeout_add_seconds(2, self._update_battery)
-                GLib.idle_add(self._update_battery)
+                # One-shot: _update_battery returns True (to repeat the 2s timer),
+                # so guard with `and False` or this idle source spins forever and
+                # leaks CPU after the window closes.
+                GLib.idle_add(lambda: self._update_battery() and False)
             if hasattr(self, "_heart_timer") and not self._heart_timer:
                 self._heart_timer = GLib.timeout_add(30, self._tick_heart)
         else:
@@ -396,8 +399,11 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
                 interface_name = changed_props[0]
                 # Check if this is a battery device property change
                 if "UPower" in interface_name or "Device" in interface_name:
-                    # Schedule immediate battery update on main thread
-                    GLib.idle_add(self._update_battery)
+                    # Schedule immediate battery update on main thread.
+                    # One-shot: _update_battery returns True, so without `and
+                    # False` each UPower signal would leak a CPU-spinning idle
+                    # source that survives window close (issue #32).
+                    GLib.idle_add(lambda: self._update_battery() and False)
 
     def _on_upower_device_event(
         self, connection, sender, path, interface, signal, params, user_data

--- a/overlay/settings_page_settings.py
+++ b/overlay/settings_page_settings.py
@@ -364,6 +364,9 @@ class SettingsPage(Gtk.ScrolledWindow):
         startup_switch.connect("state-set", self._on_startup_changed)
         startup_row.set_control(startup_switch)
         app_card.append(startup_row)
+        # Heal a stale autostart entry from an older build (broken Exec path
+        # caused status=127 and the menu not launching at login on some installs).
+        self._repair_autostart_if_stale()
 
         tray_row = SettingRow(_("Show Tray Icon"), _("Display icon in system tray"))
         tray_switch = Gtk.Switch()
@@ -521,40 +524,83 @@ class SettingsPage(Gtk.ScrolledWindow):
             settings_theme.CSS_PROVIDER = provider
         logger.info("Settings CSS reloaded with new theme")
 
+    @staticmethod
+    def _autostart_file():
+        return Path.home() / ".config" / "autostart" / "juhradial-mx.desktop"
+
+    @staticmethod
+    def _resolve_launcher_path():
+        """Path to the juhradial-mx launcher, preferring one that exists.
+
+        Covers the dev checkout (scripts/juhradial-mx.sh), the curl installer
+        (/usr/local/bin) and distro packages (/usr/bin). Hardcoding a single
+        path is what produced the status=127 autostart failure when the binary
+        lived elsewhere, so probe candidates and use the first that exists.
+        """
+        script_dir = Path(__file__).resolve().parent.parent
+        candidates = [script_dir / "scripts" / "juhradial-mx.sh"]
+        resolved = shutil.which("juhradial-mx")
+        if resolved:
+            candidates.append(Path(resolved))
+        candidates += [
+            Path("/usr/local/bin/juhradial-mx"),  # curl installer
+            Path("/usr/bin/juhradial-mx"),        # Arch / RPM packages
+        ]
+        return next((p for p in candidates if p.exists()), candidates[0])
+
+    def _write_autostart(self, exec_path):
+        """Write the autostart .desktop pointing Exec at exec_path."""
+        autostart_file = self._autostart_file()
+        autostart_file.parent.mkdir(parents=True, exist_ok=True)
+        autostart_file.write_text(
+            "[Desktop Entry]\n"
+            "Type=Application\n"
+            "Name=JuhRadial MX\n"
+            "Comment=Radial menu for Logitech MX Master\n"
+            f"Exec={exec_path}\n"
+            "Icon=juhradial-mx\n"
+            "Terminal=false\n"
+            "Categories=Utility;\n"
+            "X-GNOME-Autostart-enabled=true\n",
+            encoding="utf-8",
+        )
+        logger.info("Wrote autostart: %s -> %s", autostart_file, exec_path)
+
+    def _repair_autostart_if_stale(self):
+        """Rewrite an autostart entry whose Exec target no longer exists.
+
+        Older builds wrote a fixed /usr/bin/juhradial-mx, which 404s on curl
+        installs (the launcher is in /usr/local/bin) and fails with status=127.
+        Self-heal so existing users get a working entry without re-toggling the
+        switch (issue #32). Only touches a broken entry; a valid one is left as is.
+        """
+        if not config.get("app", "start_at_login", default=True):
+            return
+        autostart_file = self._autostart_file()
+        if not autostart_file.exists():
+            return
+        try:
+            text = autostart_file.read_text(encoding="utf-8")
+        except OSError:
+            return
+        exec_line = next(
+            (ln for ln in text.splitlines() if ln.startswith("Exec=")), None
+        )
+        current = exec_line[len("Exec="):].strip() if exec_line else ""
+        # Exec may carry arguments; existence-check only the binary token.
+        current_bin = current.split()[0] if current else ""
+        if current_bin and Path(current_bin).exists():
+            return  # entry already points at a real launcher
+        self._write_autostart(self._resolve_launcher_path())
+        logger.info("Repaired stale autostart Exec (was %r)", current_bin)
+
     def _on_startup_changed(self, switch, state):
         """Handle start at login toggle"""
         config.set("app", "start_at_login", state)
-        # Create or remove autostart file
-        autostart_dir = Path.home() / ".config" / "autostart"
-        autostart_file = autostart_dir / "juhradial-mx.desktop"
-
         if state:
-            # Create autostart entry
-            autostart_dir.mkdir(parents=True, exist_ok=True)
-            # Get the script path dynamically
-            script_dir = Path(__file__).resolve().parent.parent
-            exec_path = script_dir / "scripts" / "juhradial-mx.sh"
-            # Fallback to the installed launcher if the dev script isn't present.
-            # The launcher installs to /usr/local/bin (not /usr/bin), so resolve
-            # it on PATH via shutil.which and fall back to that explicit path;
-            # writing /usr/bin/juhradial-mx gave autostart status=127.
-            if not exec_path.exists():
-                resolved = shutil.which("juhradial-mx")
-                exec_path = Path(resolved) if resolved else Path("/usr/local/bin/juhradial-mx")
-            desktop_content = f"""[Desktop Entry]
-Type=Application
-Name=JuhRadial MX
-Comment=Radial menu for Logitech MX Master
-Exec={exec_path}
-Icon=juhradial-mx
-Terminal=false
-Categories=Utility;
-X-GNOME-Autostart-enabled=true
-"""
-            autostart_file.write_text(desktop_content, encoding="utf-8")
-            logger.info("Created autostart: %s", autostart_file)
+            self._write_autostart(self._resolve_launcher_path())
         else:
-            # Remove autostart entry
+            autostart_file = self._autostart_file()
             if autostart_file.exists():
                 autostart_file.unlink()
                 logger.info("Removed autostart: %s", autostart_file)

--- a/overlay/settings_widgets.py
+++ b/overlay/settings_widgets.py
@@ -53,6 +53,11 @@ def _resolve_asset_path(relative_path):
     candidates = [
         Path(__file__).parent.parent / "assets" / relative_path,
         Path("/usr/share/juhradial/assets") / relative_path,
+        # The brand SVG (juhradial-mx.svg) is installed to the icon theme dir by
+        # every install method (curl, Arch, RPM) but is not mirrored under
+        # /usr/share/juhradial/assets, so the header logo showed image-missing
+        # without this fallback (issue #32).
+        Path("/usr/share/icons/hicolor/scalable/apps") / relative_path,
     ]
     for p in candidates:
         if p.exists():

--- a/tests/test_overlay_placement_dpr.py
+++ b/tests/test_overlay_placement_dpr.py
@@ -20,7 +20,11 @@ import sys
 
 sys.path.insert(0, ".")
 
-from overlay.overlay_constants import map_logical_to_screen, hyprland_menu_center
+from overlay.overlay_constants import (
+    map_logical_to_screen,
+    hyprland_menu_center,
+    map_and_clamp_menu,
+)
 
 
 def _geo(x, y, w, h, name=None):
@@ -175,6 +179,79 @@ def test_orchestrator_five_monitors_name_match():
     cx, cy = hyprland_menu_center(lx, 500, mons[3], mons, qts)
     assert cx == qts[3]["x"] + round(1900 / 1920 * 960)
     assert cy == round(500 / 1080 * 540)
+
+
+# --- map_and_clamp_menu: edge clamping in Qt space (issue #45 hardening) -----
+
+
+def test_clamp_issue45_bottom_right_stays_inside_qt_screen():
+    # The residual bug: logical 2560x1440 reported by Qt as 1600x900. A 484px
+    # window at the bottom-right must stay fully inside the Qt screen. Clamping
+    # in logical space with a Qt-space half left it ~90px off-screen.
+    logical = _geo(0, 0, 2560, 1440, "HDMI-A-1")
+    qt = _geo(0, 0, 1600, 900, "HDMI-A-1")
+    p = map_and_clamp_menu(2559, 1439, logical, [logical], [qt], 484)
+    assert p["qt_center"] == (1358, 658)
+    ox, oy = p["qt_origin"]
+    assert ox >= 0 and oy >= 0
+    assert ox + 484 <= 1600 and oy + 484 <= 900
+
+
+def test_clamp_top_left_corner_stays_inside():
+    logical = _geo(0, 0, 2560, 1440, "HDMI-A-1")
+    qt = _geo(0, 0, 1600, 900, "HDMI-A-1")
+    p = map_and_clamp_menu(0, 0, logical, [logical], [qt], 484)
+    ox, oy = p["qt_origin"]
+    assert ox == 0 and oy == 0  # clamped to the corner, not negative
+
+
+def test_clamp_negative_origin_monitor_preserved():
+    # A monitor left of the origin keeps negative Qt coordinates.
+    logical = _geo(-1920, 0, 1920, 1080, "DP-2")
+    qt = _geo(-1536, 0, 1536, 864, "DP-2")
+    p = map_and_clamp_menu(-960, 540, logical, [logical], [qt], 400)
+    assert p["qt_center"] == (-768, 432)  # centre maps to centre
+
+
+def test_clamp_identity_at_100_percent():
+    logical = _geo(0, 0, 2560, 1440, "DP-1")
+    qt = _geo(0, 0, 2560, 1440, "DP-1")
+    p = map_and_clamp_menu(1280, 720, logical, [logical], [qt], 400)
+    assert p["qt_center"] == (1280, 720)
+    assert p["qt_origin"] == (1080, 520)
+    assert p["logical_center"] == (1280, 720)
+
+
+def test_clamp_interior_logical_center_round_trips():
+    # Away from any edge, the logical center returned for hover must match the
+    # original cursor (the back-derivation is the inverse of the mapping).
+    logical = _geo(0, 0, 2560, 1440, "HDMI-A-1")
+    qt = _geo(0, 0, 1600, 900, "HDMI-A-1")
+    p = map_and_clamp_menu(930, 562, logical, [logical], [qt], 400)
+    lx, ly = p["logical_center"]
+    assert abs(lx - 930) <= 2 and abs(ly - 562) <= 2
+    assert p["qt_center"] == (round(930 / 2560 * 1600), round(562 / 1440 * 900))
+
+
+def test_clamp_identity_passthrough_without_qt_screens():
+    # No Qt geometry: clamp in logical space against the cursor's monitor.
+    mon = _geo(0, 0, 2560, 1440, "DP-1")
+    p = map_and_clamp_menu(2559, 1439, mon, [mon], [], 400)
+    assert p["qt_center"] == (2360, 1240)
+    assert p["logical_center"] == (2360, 1240)
+
+
+def test_clamp_global_affine_when_names_differ():
+    # Generic XWayland output names -> global affine, still clamped on-screen.
+    logical = [
+        _geo(0, 0, 2560, 1440, "HDMI-A-1"),
+        _geo(2560, 0, 1600, 1000, "eDP-2"),
+    ]
+    qt = [_geo(0, 0, 1600, 900, "XW0"), _geo(1600, 0, 1000, 625, "XW1")]
+    p = map_and_clamp_menu(2560 + 1599, 999, logical[1], logical, qt, 400)
+    ox, oy = p["qt_origin"]
+    assert ox >= 0 and oy >= 0
+    assert ox + 400 <= 2600 and oy + 400 <= 900  # qt desktop bbox is 2600x900
 
 
 if __name__ == "__main__":

--- a/tests/test_overlay_placement_dpr.py
+++ b/tests/test_overlay_placement_dpr.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Regression tests for radial-menu placement under HiDPI / fractional scaling.
+
+Covers issue #45 (Hyprland mixed-scale dual monitor: menu drifts further from
+the cursor the further it is from the top-left) and guards against regressing
+issue #25 (KDE Plasma Wayland / 100%, where identity placement is correct).
+
+Root cause: hyprctl cursorpos is in compositor-logical pixels, while
+QWidget.move() places windows in Qt's own coordinate space. With mixed/fractional
+scaling those spaces differ (Qt may apply a devicePixelRatio, or XWayland scales
+the surface), so passing logical coords straight to move() drifts the menu
+proportionally to distance from the origin.
+
+Fix: map the cursor's fractional position within its monitor onto the matching Qt
+screen's geometry. That fraction is invariant across coordinate spaces, so the
+menu lands on the cursor regardless of scale or which layer applies it.
+"""
+
+import sys
+
+sys.path.insert(0, ".")
+
+from overlay.overlay_constants import map_logical_to_screen, hyprland_menu_center
+
+
+def _geo(x, y, w, h, name=None):
+    r = {"x": x, "y": y, "width": w, "height": h}
+    if name is not None:
+        r["name"] = name
+    return r
+
+
+def test_identity_when_geometries_match():
+    # No scaling (100%, e.g. KDE Plasma Wayland per issue #25): the monitor's
+    # logical geometry equals Qt's screen geometry, so mapping is a no-op.
+    mon = {"x": 0, "y": 0, "width": 2560, "height": 1440, "name": "DP-1"}
+    geo = _geo(0, 0, 2560, 1440)
+    for lx, ly in [(0, 0), (930, 562), (1280, 720), (2559, 1439)]:
+        assert map_logical_to_screen(lx, ly, mon, geo) == (lx, ly)
+
+
+def test_issue45_primary_monitor_scaled_qt_space():
+    # Issue #45: cursor at logical (930, 562) on HDMI-A-1 (logical 2560x1440),
+    # but Qt reports that screen 1.6x smaller in its own space (2560/1.6=1600,
+    # 1440/1.6=900). The menu center must follow the cursor's fraction onto Qt's
+    # geometry, not sit at the raw logical coordinate.
+    mon = {"x": 0, "y": 0, "width": 2560, "height": 1440, "name": "HDMI-A-1"}
+    geo = _geo(0, 0, 1600, 900)
+    cx, cy = map_logical_to_screen(930, 562, mon, geo)
+    assert cx == round(930 / 2560 * 1600)  # 581
+    assert cy == round(562 / 1440 * 900)   # 351
+
+
+def test_second_monitor_offset_and_scaled():
+    # eDP-2 sits to the right (logical 2560x1600 at scale 1.6 -> logical
+    # 1600x1000 at logical origin 2560,0). Qt may place it at a different origin
+    # and size in its own space; the fraction still maps correctly.
+    mon = {"x": 2560, "y": 0, "width": 1600, "height": 1000, "name": "eDP-2"}
+    geo = _geo(1600, 0, 1600, 1000)  # Qt origin differs from logical origin
+    # cursor at the monitor's own centre -> Qt-space centre of that screen
+    cx, cy = map_logical_to_screen(2560 + 800, 500, mon, geo)
+    assert cx == 1600 + 800
+    assert cy == 500
+
+
+def test_corners_map_to_corners():
+    mon = {"x": 0, "y": 0, "width": 2000, "height": 1000, "name": "X"}
+    geo = _geo(100, 50, 1000, 500)
+    assert map_logical_to_screen(0, 0, mon, geo) == (100, 50)
+    assert map_logical_to_screen(2000, 1000, mon, geo) == (1100, 550)
+
+
+def test_fraction_invariant_round_trip():
+    # The core guarantee: whatever Qt-space geometry a monitor has, the cursor's
+    # logical fraction maps to the same fraction of the Qt screen. Verified across
+    # a spread of positions and arbitrary Qt scale ratios so the fix holds for any
+    # monitor count / scale combination (1..N screens).
+    mon = {"x": 1000, "y": 200, "width": 3840, "height": 2160, "name": "M"}
+    for ratio in (1.0, 1.25, 1.5, 1.6, 2.0, 2.5):
+        geo = _geo(0, 0, round(3840 / ratio), round(2160 / ratio))
+        for fxi in range(0, 11):
+            for fyi in range(0, 11):
+                fx, fy = fxi / 10, fyi / 10
+                lx = mon["x"] + fx * mon["width"]
+                ly = mon["y"] + fy * mon["height"]
+                cx, cy = map_logical_to_screen(lx, ly, mon, geo)
+                # recovered fraction within the Qt screen matches the logical one
+                rfx = (cx - geo["x"]) / geo["width"]
+                rfy = (cy - geo["y"]) / geo["height"]
+                assert abs(rfx - fx) < 0.01, f"ratio={ratio} fx={fx} rfx={rfx}"
+                assert abs(rfy - fy) < 0.01, f"ratio={ratio} fy={fy} rfy={rfy}"
+
+
+def test_degenerate_monitor_size_does_not_crash():
+    # Defensive: a zero-sized monitor must not raise ZeroDivisionError.
+    mon = {"x": 0, "y": 0, "width": 0, "height": 0, "name": "bad"}
+    geo = _geo(0, 0, 1920, 1080)
+    cx, cy = map_logical_to_screen(0, 0, mon, geo)
+    assert isinstance(cx, int) and isinstance(cy, int)
+
+
+# --- tiered orchestrator: hyprland_menu_center -----------------------------
+
+# Issue #45 exact scenario: HDMI-A-1 scale 1.0 (logical 2560x1440) at 0,0 and
+# eDP-2 scale 1.6 (logical 1600x1000) at 2560,0. Qt reports both screens 1.6x
+# smaller in its own space (the overshoot factor seen in the report).
+HYPR_MONS_45 = [
+    {"x": 0, "y": 0, "width": 2560, "height": 1440, "name": "HDMI-A-1"},
+    {"x": 2560, "y": 0, "width": 1600, "height": 1000, "name": "eDP-2"},
+]
+QT_SCREENS_45 = [
+    _geo(0, 0, 1600, 900, "HDMI-A-1"),
+    _geo(1600, 0, 1000, 625, "eDP-2"),
+]
+
+
+def test_orchestrator_name_match_issue45():
+    # Cursor at logical (930, 562) on HDMI-A-1 -> mapped onto Qt's HDMI geometry.
+    cursor_mon = HYPR_MONS_45[0]
+    cx, cy = hyprland_menu_center(930, 562, cursor_mon, HYPR_MONS_45, QT_SCREENS_45)
+    assert (cx, cy) == (round(930 / 2560 * 1600), round(562 / 1440 * 900))  # (581, 351)
+
+
+def test_orchestrator_name_match_second_monitor():
+    # Cursor on the fractional-scaled laptop screen maps onto its Qt geometry.
+    cursor_mon = HYPR_MONS_45[1]
+    lx, ly = 2560 + 800, 500  # centre of eDP-2 in logical space
+    cx, cy = hyprland_menu_center(lx, ly, cursor_mon, HYPR_MONS_45, QT_SCREENS_45)
+    # centre of eDP-2's Qt geometry (1600 + 1000/2, 625/2)
+    assert (cx, cy) == (1600 + 500, round(625 / 2))
+
+
+def test_orchestrator_falls_back_to_global_affine_when_names_differ():
+    # XWayland may expose generic output names. With no name match, the global
+    # affine over the desktop bounding box still removes the drift.
+    qt_generic = [
+        _geo(0, 0, 1600, 900, "XWAYLAND0"),
+        _geo(1600, 0, 1000, 625, "XWAYLAND1"),
+    ]
+    cursor_mon = HYPR_MONS_45[0]
+    cx, cy = hyprland_menu_center(930, 562, cursor_mon, HYPR_MONS_45, qt_generic)
+    # logical desktop bbox: 0..4160 x 0..1440 ; qt bbox: 0..2600 x 0..900
+    assert cx == round(930 / 4160 * 2600)
+    assert cy == round(562 / 1440 * 900)
+
+
+def test_orchestrator_identity_single_scale():
+    # Single monitor at 100%: Qt geometry equals logical, mapping is a no-op.
+    mons = [{"x": 0, "y": 0, "width": 2560, "height": 1440, "name": "DP-1"}]
+    qt = [_geo(0, 0, 2560, 1440, "DP-1")]
+    for lx, ly in [(0, 0), (930, 562), (2559, 1439)]:
+        assert hyprland_menu_center(lx, ly, mons[0], mons, qt) == (lx, ly)
+
+
+def test_orchestrator_identity_when_no_qt_screens():
+    # No Qt screen info -> pass through unchanged (current behaviour preserved).
+    mon = {"x": 0, "y": 0, "width": 2560, "height": 1440, "name": "DP-1"}
+    assert hyprland_menu_center(930, 562, mon, [mon], []) == (930, 562)
+
+
+def test_orchestrator_five_monitors_name_match():
+    # Five monitors in a row, each mapped onto its own Qt geometry. Confirms the
+    # fix scales to many displays.
+    mons, qts = [], []
+    lx0 = 0
+    qx0 = 0
+    for i in range(5):
+        w = 1920
+        mons.append({"x": lx0, "y": 0, "width": w, "height": 1080, "name": f"DP-{i}"})
+        qts.append(_geo(qx0, 0, w // 2, 540, f"DP-{i}"))  # Qt 2x smaller
+        lx0 += w
+        qx0 += w // 2
+    # cursor near right edge of the 4th monitor (index 3)
+    lx = mons[3]["x"] + 1900
+    cx, cy = hyprland_menu_center(lx, 500, mons[3], mons, qts)
+    assert cx == qts[3]["x"] + round(1900 / 1920 * 960)
+    assert cy == round(500 / 1080 * 540)
+
+
+if __name__ == "__main__":
+    import traceback
+
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except Exception:
+                failures += 1
+                print(f"FAIL {name}")
+                traceback.print_exc()
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
User-facing fixes, all overlay/installer only (no daemon/Rust changes), all safe across desktops/distros.

## #45 — radial menu drifts from cursor on mixed-scale Hyprland

**Cause:** `hyprctl cursorpos` is in compositor-logical pixels, but `QWidget.move()` places windows in Qt's coordinate space. With mixed/fractional monitor scales these differ — and on Hyprland xcb Qt often does not detect the scale (`devicePixelRatioF()==1.0`) while XWayland scales the surface instead, so a plain `devicePixelRatio` divide is a no-op. The menu overshoots proportional to distance from the origin.

**Fix:** map the cursor's *fractional position within its monitor* onto the matching Qt `QScreen.geometry()` (already in `move()` space). That fraction is invariant across coordinate spaces, so it self-calibrates regardless of which layer scales, for any monitor count. Tiered: per-monitor by connector name → global affine over the desktop bounding box if XWayland exposes generic output names → identity. **Every tier reduces to identity at 100% scaling**, so single-scale Hyprland and all non-Hyprland paths (KDE #25, GNOME, COSMIC, niri, X11) are untouched. Adds a `Hyprland placement:` diagnostic log line.

## #32 — settings app lingers at 2-3% CPU after closing

**Cause:** two `GLib.idle_add(self._update_battery)` calls lacked the `and False` guard the other call sites use. `_update_battery` returns `True` (to repeat its 2s timeout), so as idle sources they spun forever (`G_SOURCE_CONTINUE`); their ids were discarded so `close-request` could not remove them. The UPower-change handler leaked one spinner per battery/charging signal, hence only a full restart cleared it.

**Fix:** guard both with `lambda: self._update_battery() and False` (one-shot).

## #32 — autostart failed with status=127 / menu not starting at login

**Cause:** the autostart entry could be written with `Exec=/usr/bin/juhradial-mx`, which does not exist on curl installs (launcher is in `/usr/local/bin`). systemd does not search `$PATH` for the unit and PATH may be unset at login, so it must be an absolute path to an existing binary.

**Fix:** resolve the launcher to the first existing path across dev (`scripts/juhradial-mx.sh`), curl (`/usr/local/bin`) and distro (`/usr/bin`). Plus self-heal a stale entry on settings open.

## #32 — settings header logo showed image-missing

**Cause:** `juhradial-mx.svg` is installed to the icon theme dir (`/usr/share/icons/hicolor/scalable/apps`) by every install method but is not mirrored under `/usr/share/juhradial/assets`, where the resolver looked.

**Fix:** add the icon-theme dir as a resolver fallback (fixes curl/Arch/RPM).

## #32 — installer warned alarmingly about gtk4-layer-shell on openSUSE

It is optional (niri-only) and lives in a community repo, not the default ones. The installer now skips it with an informational note instead of a warning.

## Tests
- `tests/test_overlay_placement_dpr.py` — 12 cases (#45 exact, #25 identity, five-monitor, name-mismatch, degenerate). Green.
- `py_compile` clean on touched modules; `bash -n install.sh` clean.

## Still open (not in this PR)
- #32 "menu on wrong monitor after cold boot" on KDE Wayland: the per-press KWin cursor query falls back to desktop-center when KWin/session D-Bus is not ready at boot. Needs the reporter's boot journal to fix without regressing the KDE positioning, tracked separately.
- shift_wheel / SmartShift (#26): already fully wired on v0.4.0; no code bug found.