### PR TITLE
fix(launch): start the daemon reliably and install with numeric ownership (#52)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -430,16 +430,25 @@ install_dependencies() {
 clone_repo() {
     step "Fetching source"
 
-    if [ -d "$INSTALL_DIR" ]; then
+    # Use numeric IDs for ownership: the primary group is not always named after
+    # the user (issue #52 hit a chown failure on Arch where the group differs).
+    local uid gid
+    uid="$(id -u)"
+    gid="$(id -g)"
+
+    if [ -d "$INSTALL_DIR/.git" ]; then
         log_info "Updating existing installation..."
-        sudo chown -R "$USER:$USER" "$INSTALL_DIR"
+        sudo chown -R "$uid:$gid" "$INSTALL_DIR"
         git -C "$INSTALL_DIR" fetch origin
         git -C "$INSTALL_DIR" reset --hard origin/master
         git -C "$INSTALL_DIR" clean -fd
     else
         log_info "Cloning repository..."
-        sudo git clone "$REPO_URL" "$INSTALL_DIR"
-        sudo chown -R "$USER:$USER" "$INSTALL_DIR"
+        # A previous failed install can leave a partial, root-owned dir behind;
+        # clear it so the clone starts clean and ends up owned by the user.
+        [ -e "$INSTALL_DIR" ] && sudo rm -rf "$INSTALL_DIR"
+        sudo install -d -o "$uid" -g "$gid" "$INSTALL_DIR"
+        git clone "$REPO_URL" "$INSTALL_DIR"
     fi
 
     cd "$INSTALL_DIR"

--- a/scripts/juhradial-mx.sh
+++ b/scripts/juhradial-mx.sh
@@ -1,43 +1,117 @@
 #!/bin/bash
 # JuhRadial MX Launcher
-# Starts the daemon and overlay for the radial menu
+# Starts the daemon and overlay for the radial menu.
+#
+# Structured so the resolution helpers can be sourced and unit-tested without
+# launching anything (see tests/test_launcher.sh). All startup happens in
+# main(), guarded by the BASH_SOURCE==$0 check at the bottom.
 
-# Find script directory (works for both installed and dev mode)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -d "$SCRIPT_DIR/.git" ]; then
-    :
-elif [ -d "/usr/share/juhradial" ]; then
-    SCRIPT_DIR="/usr/share/juhradial"
-elif [ -d "/opt/juhradial-mx" ]; then
-    SCRIPT_DIR="/opt/juhradial-mx"
+# Locate the project tree (the one holding the overlay) from the launcher dir.
+# Works for a dev checkout (<repo>/scripts/..), an installed flat layout, and
+# the system install locations.
+resolve_project_root() {
+    local script_dir="$1" candidate
+    for candidate in \
+        "$script_dir/.." \
+        "$script_dir" \
+        /usr/share/juhradial \
+        /opt/juhradial-mx; do
+        candidate="$(cd "$candidate" 2>/dev/null && pwd || true)"
+        if [ -n "$candidate" ] && {
+            [ -f "$candidate/overlay/juhradial-overlay.py" ] ||
+            [ -f "$candidate/juhradial-overlay.py" ]
+        }; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+resolve_overlay() {
+    local root="$1" candidate
+    for candidate in "$root/overlay/juhradial-overlay.py" "$root/juhradial-overlay.py"; do
+        if [ -f "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Resolve the daemon binary. Defaults to the install locations; the dev build
+# path is derived from the project root (one level up from scripts/, which the
+# old SCRIPT_DIR-relative check got wrong). Returns non-zero when nothing is
+# found, so the caller can report it instead of pretending the daemon started.
+resolve_daemon() {
+    local root="$1"
+    local local_bin="${2:-/usr/local/bin/juhradiald}"
+    local system_bin="${3:-/usr/bin/juhradiald}"
+    local candidate
+    for candidate in "$local_bin" "$system_bin" "$root/daemon/target/release/juhradiald"; do
+        if [ -x "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# True when something (e.g. a systemd user service) already owns the daemon's
+# D-Bus name, so we should not start a second, unmanaged copy.
+daemon_name_owned() {
+    command -v gdbus >/dev/null 2>&1 || return 1
+    gdbus call --session \
+        --dest org.freedesktop.DBus \
+        --object-path /org/freedesktop/DBus \
+        --method org.freedesktop.DBus.NameHasOwner \
+        org.kde.juhradialmx 2>/dev/null | grep -q true
+}
+
+main() {
+    local script_dir root overlay daemon overlay_pid="" daemon_pid=""
+
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    root="$(resolve_project_root "$script_dir")" || {
+        echo "JuhRadial MX: overlay files not found (looked from $script_dir)" >&2
+        return 1
+    }
+    overlay="$(resolve_overlay "$root")" || {
+        echo "JuhRadial MX: overlay entry point not found under $root" >&2
+        return 1
+    }
+
+    # Start the overlay (it listens for D-Bus signals) unless one is already up.
+    if ! pgrep -f '[j]uhradial-overlay.py' >/dev/null 2>&1; then
+        python3 "$overlay" &
+        overlay_pid=$!
+    fi
+
+    # Start the daemon unless one already owns the D-Bus name (systemd, etc.).
+    if ! daemon_name_owned; then
+        if ! daemon="$(resolve_daemon "$root")"; then
+            [ -z "$overlay_pid" ] || kill "$overlay_pid" 2>/dev/null || true
+            echo "JuhRadial MX: daemon binary (juhradiald) not found." >&2
+            echo "  Build it:   (cd \"$root/daemon\" && cargo build --release)" >&2
+            echo "  or install: re-run install.sh so juhradiald lands in /usr/local/bin" >&2
+            return 1
+        fi
+        "$daemon" &
+        daemon_pid=$!
+    fi
+
+    echo "JuhRadial MX started"
+    [ -z "$overlay_pid" ] || echo "  Overlay PID: $overlay_pid"
+    [ -z "$daemon_pid" ] || echo "  Daemon PID:  $daemon_pid"
+
+    # Keep the launcher alive for whichever process it actually started.
+    if [ -n "$daemon_pid" ]; then
+        wait "$daemon_pid"
+    elif [ -n "$overlay_pid" ]; then
+        wait "$overlay_pid"
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
 fi
-
-# Kill any existing instances
-pkill -f "juhradiald" 2>/dev/null
-pkill -f "juhradial-overlay" 2>/dev/null
-sleep 0.3
-
-# Start the overlay first (it listens for D-Bus signals)
-if [ -f "$SCRIPT_DIR/overlay/juhradial-overlay.py" ]; then
-    python3 "$SCRIPT_DIR/overlay/juhradial-overlay.py" &
-elif [ -f "$SCRIPT_DIR/juhradial-overlay.py" ]; then
-    python3 "$SCRIPT_DIR/juhradial-overlay.py" &
-fi
-OVERLAY_PID=$!
-
-# Start the daemon
-if [ -x "/usr/local/bin/juhradiald" ]; then
-    /usr/local/bin/juhradiald &
-elif [ -x "/usr/bin/juhradiald" ]; then
-    /usr/bin/juhradiald &
-elif [ -x "$SCRIPT_DIR/daemon/target/release/juhradiald" ]; then
-    "$SCRIPT_DIR/daemon/target/release/juhradiald" &
-fi
-DAEMON_PID=$!
-
-echo "JuhRadial MX started"
-echo "  Overlay PID: $OVERLAY_PID"
-echo "  Daemon PID: $DAEMON_PID"
-
-# Keep running
-wait $DAEMON_PID

--- a/tests/distro_build_test.sh
+++ b/tests/distro_build_test.sh
@@ -31,6 +31,8 @@ echo "=== static install.sh checks ==="
 grep -q "ensure_rust_toolchain" "$SRC/install.sh" && echo "  ok: ensure_rust_toolchain present (#23)" || echo "  WARN: ensure_rust_toolchain missing (#23)"
 grep -q "python3-PyQt6" "$SRC/install.sh" && echo "  ok: python3-PyQt6 present (#24)" || echo "  WARN: python3-PyQt6 missing (#24)"
 grep -q "python3-qt6-svg" "$SRC/install.sh" && echo "  WARN: stale python3-qt6-svg still present (#24)" || echo "  ok: stale python3-qt6-svg gone (#24)"
+grep -q 'id -u' "$SRC/install.sh" && grep -q 'id -g' "$SRC/install.sh" && echo "  ok: installer uses numeric uid/gid (#52)" || echo "  WARN: installer not using numeric uid/gid (#52)"
+grep -q '\$USER:\$USER' "$SRC/install.sh" && echo "  WARN: installer still assumes username equals group name (#52)" || echo "  ok: no \$USER:\$USER group assumption (#52)"
 echo
 
 # Bootstrap a new-enough Rust (mirrors install.sh ensure_rust_toolchain) then

--- a/tests/test_launcher.sh
+++ b/tests/test_launcher.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression test for issue #52: the launcher must resolve the overlay/daemon
+# from any supported checkout layout, must be safe to source (so it can be
+# tested without launching anything), and must fail loudly when the daemon
+# binary is missing instead of silently reusing the overlay PID.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# The launcher must guard its startup behind a BASH_SOURCE==$0 check so this
+# file can source it for its functions without spawning any process.
+if ! grep -q 'BASH_SOURCE\[0\].*==.*\$0' scripts/juhradial-mx.sh; then
+    echo "FAIL: launcher is not safe to source (no BASH_SOURCE==\$0 guard)" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source scripts/juhradial-mx.sh
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Dev checkout: <repo>/scripts, <repo>/overlay, <repo>/daemon/target/release
+mkdir -p "$tmp/repo/scripts" "$tmp/repo/overlay" "$tmp/repo/daemon/target/release"
+touch "$tmp/repo/overlay/juhradial-overlay.py"
+touch "$tmp/repo/daemon/target/release/juhradiald"
+chmod +x "$tmp/repo/daemon/target/release/juhradiald"
+
+root="$(resolve_project_root "$tmp/repo/scripts")"
+[ "$root" = "$tmp/repo" ] || { echo "FAIL: project root = '$root' (want '$tmp/repo')" >&2; exit 1; }
+
+overlay="$(resolve_overlay "$root")"
+[ "$overlay" = "$tmp/repo/overlay/juhradial-overlay.py" ] \
+    || { echo "FAIL: overlay = '$overlay'" >&2; exit 1; }
+
+# Installed flat layout: overlay sits directly under the root.
+mkdir -p "$tmp/installed"
+touch "$tmp/installed/juhradial-overlay.py"
+[ "$(resolve_overlay "$tmp/installed")" = "$tmp/installed/juhradial-overlay.py" ] \
+    || { echo "FAIL: flat overlay layout not resolved" >&2; exit 1; }
+
+# Daemon resolves from the dev build path when no system binary exists.
+daemon="$(resolve_daemon "$root" "$tmp/absent-local" "$tmp/absent-system")"
+[ "$daemon" = "$tmp/repo/daemon/target/release/juhradiald" ] \
+    || { echo "FAIL: daemon = '$daemon' (want dev build path)" >&2; exit 1; }
+
+# resolve_daemon MUST fail (non-zero) when no binary exists anywhere, so the
+# launcher can report the error instead of reusing the overlay PID (#52).
+if resolve_daemon "$tmp/empty" "$tmp/absent-local" "$tmp/absent-system" >/dev/null; then
+    echo "FAIL: resolve_daemon should fail when no binary exists" >&2
+    exit 1
+fi
+
+echo "PASS: launcher path resolution tests"


### PR DESCRIPTION
Fixes the startup hang reported in #52, where the splash sits "waiting for the daemon" and the printed overlay and daemon PIDs are identical.

## Root cause

The launcher set `DAEMON_PID=$!` *after* the daemon `if/elif` block. When none of the daemon paths matched (for example after a partial install), no background job ran in that block, so `$!` still held the overlay PID. The script then printed two identical PIDs and `wait`ed on the overlay, so it never exited. The reporter's log shows exactly this (`Overlay PID: 125288` / `Daemon PID: 125288`), and the empty daemon journal confirms the daemon never started. It was not a Bluetooth problem.

The install failure in the same report came from `chown -R "$USER:$USER"`, which assumes the primary group is named after the user. On accounts where it is not (the reporter is on Arch), the chown fails and aborts the install before the daemon is in place.

## Changes

- Refactor the launcher into sourceable helpers (`resolve_project_root`, `resolve_overlay`, `resolve_daemon`) behind a `BASH_SOURCE==$0` guard, and capture each PID only inside the branch that launches that process.
- Fix the dev daemon path: it now looks in `../daemon/target/release` relative to the project root instead of `scripts/daemon/...`.
- Fail with a clear, actionable message when `juhradiald` is missing, instead of silently reusing the overlay PID and hanging.
- Stop the blanket `pkill`: skip restarting a daemon that already owns the D-Bus name (such as a systemd user service), and only start the overlay if one is not already running.
- `install.sh`: own the clone with numeric `id -u`/`id -g` instead of `"$USER:$USER"`, and create the target directory owned by the user rather than cloning as root and chowning afterwards.

## Verification

- New `tests/test_launcher.sh` sources the launcher and checks root/overlay/daemon resolution across dev and installed layouts, and that `resolve_daemon` fails when no binary exists.
- Static assertions in `tests/distro_build_test.sh` check the installer uses numeric IDs and no longer assumes username equals group name.
- Reproduced locally: the old mechanism yields identical PIDs; the new launcher yields distinct PIDs when the daemon is present, and a clear error plus non-zero exit (with the overlay cleaned up) when it is missing. The name-based chown fails on a group that is not named after the user while the numeric form succeeds.
- `bash -n` on both scripts passes.
