### PR TITLE
fix(daemon): detect KWin by D-Bus name ownership after cold boot (#32)

### DIFF
--- a/daemon/src/compositor.rs
+++ b/daemon/src/compositor.rs
@@ -1,0 +1,151 @@
+//! Compositor capability detection.
+//!
+//! Whether to query KWin for the cursor position is decided by whether the
+//! well-known `org.kde.KWin` name is owned on the session bus, NOT by the
+//! `XDG_CURRENT_DESKTOP` environment string. At cold boot the daemon is started
+//! by systemd without that variable in its environment, so the env check
+//! classified a live KDE session as non-KDE and the cursor query fell back to
+//! the screen centre, opening the menu in the wrong place until the app was
+//! restarted from the graphical session (issue #32). The bus name is present
+//! whenever KWin is running, and the watcher updates the flag live so a KWin
+//! restart is reflected without restarting the daemon.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tokio_stream::StreamExt;
+
+/// The well-known bus name KWin owns while it is running.
+const KWIN_BUS_NAME: &str = "org.kde.KWin";
+
+/// Shared, live "is KWin available?" flag. Cheap to clone (an `Arc`) and
+/// lock-free to read on the input hot path.
+#[derive(Clone, Default)]
+pub struct KWinAvailability(Arc<AtomicBool>);
+
+impl KWinAvailability {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    pub fn set_owned(&self, owned: bool) {
+        self.0.store(owned, Ordering::Release);
+    }
+
+    pub fn is_owned(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+/// Cursor backend chosen for a gesture press.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CursorBackend {
+    /// Query KWin (accurate multi-monitor Wayland cursor) via its D-Bus script.
+    KWin,
+    /// Direct cursor-query cascade (GNOME/Hyprland/Sway/COSMIC/X11/fallback).
+    Fallback,
+}
+
+/// Pure routing decision, kept out of the D-Bus code so it is unit-testable.
+pub fn cursor_backend(kwin_owned: bool) -> CursorBackend {
+    if kwin_owned {
+        CursorBackend::KWin
+    } else {
+        CursorBackend::Fallback
+    }
+}
+
+/// Keep `availability` in sync with `org.kde.KWin` ownership for the life of the
+/// connection. Initializes from `NameHasOwner`, then follows `NameOwnerChanged`
+/// (filtered to KWin) and re-queries on each change so a KWin restart is
+/// reflected. Best-effort: on a D-Bus error it logs and keeps the last known
+/// state rather than forcing the flag to false.
+pub async fn run_kwin_watcher(connection: zbus::Connection, availability: KWinAvailability) {
+    let proxy = match zbus::fdo::DBusProxy::new(&connection).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, "KWin watcher: could not create DBusProxy; KWin detection disabled");
+            return;
+        }
+    };
+
+    let kwin = match zbus::names::BusName::try_from(KWIN_BUS_NAME) {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!(error = %e, "KWin watcher: invalid bus name");
+            return;
+        }
+    };
+
+    match proxy.name_has_owner(kwin.clone()).await {
+        Ok(owned) => {
+            availability.set_owned(owned);
+            tracing::info!(
+                kwin_owned = owned,
+                "Initial KWin availability (D-Bus capability)"
+            );
+        }
+        Err(e) => tracing::warn!(error = %e, "KWin watcher: initial NameHasOwner failed"),
+    }
+
+    // Server-side filter to NameOwnerChanged where arg0 (the name) is KWin.
+    let mut stream = match proxy
+        .receive_name_owner_changed_with_args(&[(0u8, KWIN_BUS_NAME)])
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "KWin watcher: could not watch NameOwnerChanged; KWin state is point-in-time only");
+            return;
+        }
+    };
+
+    while stream.next().await.is_some() {
+        match proxy.name_has_owner(kwin.clone()).await {
+            Ok(owned) => {
+                availability.set_owned(owned);
+                tracing::info!(kwin_owned = owned, "KWin availability changed");
+            }
+            Err(e) => tracing::warn!(error = %e, "KWin watcher: NameHasOwner re-query failed"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kwin_owner_selects_kwin_backend() {
+        assert_eq!(cursor_backend(true), CursorBackend::KWin);
+    }
+
+    #[test]
+    fn no_owner_uses_fallback() {
+        assert_eq!(cursor_backend(false), CursorBackend::Fallback);
+    }
+
+    #[test]
+    fn availability_defaults_to_not_owned() {
+        assert!(!KWinAvailability::new().is_owned());
+    }
+
+    #[test]
+    fn owner_loss_and_recovery_update_state() {
+        let a = KWinAvailability::new();
+        a.set_owned(true);
+        assert!(a.is_owned());
+        a.set_owned(false);
+        assert!(!a.is_owned());
+        a.set_owned(true);
+        assert!(a.is_owned());
+    }
+
+    #[test]
+    fn clones_share_one_flag() {
+        let a = KWinAvailability::new();
+        let b = a.clone();
+        a.set_owned(true);
+        assert!(b.is_owned());
+    }
+}

--- a/daemon/src/evdev.rs
+++ b/daemon/src/evdev.rs
@@ -111,6 +111,9 @@ pub struct EvdevHandler {
     shared_config: Option<crate::config::SharedConfig>,
     /// The action triggered on button press (for release handling)
     active_button_action: Option<crate::config::ButtonAction>,
+    /// Live KWin availability (D-Bus name ownership), used to pick the cursor
+    /// backend on KDE instead of the XDG_CURRENT_DESKTOP env var (issue #32).
+    kwin_available: Option<crate::compositor::KWinAvailability>,
 }
 
 impl EvdevHandler {
@@ -130,6 +133,7 @@ impl EvdevHandler {
             suppressed_keys: HashSet::new(),
             shared_config: None,
             active_button_action: None,
+            kwin_available: None,
         }
     }
 
@@ -149,12 +153,19 @@ impl EvdevHandler {
             suppressed_keys: HashSet::new(),
             shared_config: None,
             active_button_action: None,
+            kwin_available: None,
         }
     }
 
     /// Set the shared configuration for button action lookup
     pub fn set_shared_config(&mut self, config: crate::config::SharedConfig) {
         self.shared_config = Some(config);
+    }
+
+    /// Share the live KWin availability flag so the gesture handler can pick the
+    /// cursor backend by D-Bus capability rather than an environment string.
+    pub fn set_kwin_availability(&mut self, kwin: crate::compositor::KWinAvailability) {
+        self.kwin_available = Some(kwin);
     }
 
     /// Set which key codes should be suppressed (eaten) from the OS.
@@ -723,15 +734,20 @@ impl EvdevHandler {
                     self.cursor_x = 0;
                     self.cursor_y = 0;
 
-                    let is_kde = std::env::var("XDG_CURRENT_DESKTOP")
-                        .map(|d| {
-                            let u = d.to_uppercase();
-                            u.contains("KDE") || u.contains("PLASMA")
-                        })
+                    // Pick the cursor backend by whether KWin owns its D-Bus
+                    // name, not by XDG_CURRENT_DESKTOP, which is empty when
+                    // systemd starts the daemon at cold boot (issue #32).
+                    let kwin_owned = self
+                        .kwin_available
+                        .as_ref()
+                        .map(|k| k.is_owned())
                         .unwrap_or(false);
 
-                    if is_kde {
+                    if crate::compositor::cursor_backend(kwin_owned)
+                        == crate::compositor::CursorBackend::KWin
+                    {
                         tracing::info!(
+                            kwin_owned,
                             "Gesture button pressed (radial_menu) - triggering KWin cursor query"
                         );
                         if !Self::trigger_kwin_cursor_script() {
@@ -751,6 +767,7 @@ impl EvdevHandler {
                         tracing::info!(
                             x = pos.x,
                             y = pos.y,
+                            kwin_owned,
                             "Gesture button pressed (radial_menu) - cursor query"
                         );
                         let _ = self

--- a/daemon/src/hidraw.rs
+++ b/daemon/src/hidraw.rs
@@ -77,6 +77,9 @@ pub struct HidrawHandler {
     /// Feature indices for device-originated hardware notifications (battery,
     /// host, DPI, ratchet), used for live hardware readback.
     notification_indices: crate::hidpp::notifications::NotificationIndices,
+    /// Live KWin availability (D-Bus name ownership), used to pick the cursor
+    /// backend on KDE instead of the XDG_CURRENT_DESKTOP env var (issue #32).
+    kwin_available: Option<crate::compositor::KWinAvailability>,
 }
 
 /// Map HID++ CID to evdev key code for macro trigger forwarding
@@ -115,7 +118,14 @@ impl HidrawHandler {
             active_button_action: None,
             thumbwheel_feature_index: None,
             notification_indices: Default::default(),
+            kwin_available: None,
         }
+    }
+
+    /// Share the live KWin availability flag so the gesture handler can pick the
+    /// cursor backend by D-Bus capability rather than an environment string.
+    pub fn set_kwin_availability(&mut self, kwin: crate::compositor::KWinAvailability) {
+        self.kwin_available = Some(kwin);
     }
 
     /// Register CIDs that are diverted for macro triggers (not gesture buttons)
@@ -581,25 +591,29 @@ impl HidrawHandler {
             // Desktop-aware cursor query:
             // - KDE: KWin script for accurate multi-monitor Wayland cursor
             // - Others (GNOME, Hyprland, Sway, COSMIC): direct query cascade
-            let is_kde = std::env::var("XDG_CURRENT_DESKTOP")
-                .map(|d| {
-                    let u = d.to_uppercase();
-                    u.contains("KDE") || u.contains("PLASMA")
-                })
+            // Pick the cursor backend by whether KWin owns its D-Bus name, not
+            // by XDG_CURRENT_DESKTOP, which is empty when systemd starts the
+            // daemon at cold boot and made KDE look non-KDE (issue #32).
+            let kwin_owned = self
+                .kwin_available
+                .as_ref()
+                .map(|k| k.is_owned())
                 .unwrap_or(false);
-
-            if is_kde {
-                tracing::info!("Gesture button PRESSED - triggering KWin cursor query");
-                if !Self::trigger_kwin_cursor_script() {
+            match crate::compositor::cursor_backend(kwin_owned) {
+                crate::compositor::CursorBackend::KWin => {
+                    tracing::info!(kwin_owned, "Gesture button PRESSED - triggering KWin cursor query");
+                    if !Self::trigger_kwin_cursor_script() {
+                        let (x, y) = Self::get_cursor_position();
+                        tracing::warn!(x, y, "KWin script failed, using fallback cursor position");
+                        let _ = self.event_tx.send(GestureEvent::Pressed { x, y }).await;
+                    }
+                    // If KWin script succeeded, it calls ShowMenuAtCursor via D-Bus
+                }
+                crate::compositor::CursorBackend::Fallback => {
                     let (x, y) = Self::get_cursor_position();
-                    tracing::warn!(x, y, "KWin script failed, using fallback cursor position");
+                    tracing::info!(x, y, kwin_owned, "Gesture button PRESSED - cursor query");
                     let _ = self.event_tx.send(GestureEvent::Pressed { x, y }).await;
                 }
-                // If KWin script succeeded, it calls ShowMenuAtCursor via D-Bus
-            } else {
-                let (x, y) = Self::get_cursor_position();
-                tracing::info!(x, y, "Gesture button PRESSED - cursor query");
-                let _ = self.event_tx.send(GestureEvent::Pressed { x, y }).await;
             }
         } else {
             // Button released

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -6,6 +6,7 @@ pub mod accessibility;
 pub mod actions;
 pub mod battery;
 pub mod bundled_themes;
+pub mod compositor;
 pub mod config;
 pub mod cursor;
 pub mod dbus;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -421,6 +421,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
+    // Detect KWin by D-Bus name ownership (not XDG_CURRENT_DESKTOP, which is
+    // empty when systemd starts the daemon at cold boot, issue #32). The watcher
+    // seeds the flag and follows KWin restarts on the same session connection.
+    let kwin_availability = juhradiald::compositor::KWinAvailability::new();
+    {
+        let conn = dbus_connection.clone();
+        let kwin = kwin_availability.clone();
+        tokio::spawn(async move { juhradiald::compositor::run_kwin_watcher(conn, kwin).await });
+    }
+
     let haptic_manager_for_hidraw = haptic_manager_for_battery.clone();
 
     // Live battery notifications update the same shared state the active poller
@@ -534,6 +544,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let hidraw_tx = event_tx.clone();
     let hidraw_config = shared_config.clone();
     let hidraw_hotplug = hotplug_notify.clone();
+    let hidraw_kwin = kwin_availability.clone();
     let hidraw_handle = tokio::spawn(async move {
         run_hidraw_loop(
             hidraw_tx,
@@ -542,6 +553,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             hidraw_config,
             hidraw_hotplug,
             haptic_manager_for_hidraw,
+            hidraw_kwin,
         )
         .await
     });
@@ -560,20 +572,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let hotplug_for_mx = hotplug_notify.clone();
     let evdev_config = shared_config.clone();
+    let evdev_kwin = kwin_availability.clone();
     let evdev_handle = tokio::spawn(async move {
-        run_evdev_loop(evdev_tx, suppressed_for_mx, hotplug_for_mx, evdev_config).await
+        run_evdev_loop(evdev_tx, suppressed_for_mx, hotplug_for_mx, evdev_config, evdev_kwin).await
     });
 
     let generic_evdev_tx = event_tx.clone();
     let suppressed_for_generic = macro_evdev_codes.clone();
     let hotplug_for_generic = hotplug_notify.clone();
     let generic_evdev_config = shared_config.clone();
+    let generic_evdev_kwin = kwin_availability.clone();
     let generic_evdev_handle = tokio::spawn(async move {
         run_generic_evdev_loop(
             generic_evdev_tx,
             suppressed_for_generic,
             hotplug_for_generic,
             generic_evdev_config,
+            generic_evdev_kwin,
         )
         .await
     });
@@ -819,6 +834,7 @@ async fn run_hidraw_loop(
     shared_config: juhradiald::config::SharedConfig,
     hotplug: Arc<tokio::sync::Notify>,
     haptic_manager: SharedHapticManager,
+    kwin_availability: juhradiald::compositor::KWinAvailability,
 ) {
     let mut handler = HidrawHandler::new(event_tx);
     let macro_cids_for_divert = macro_cids.clone();
@@ -826,6 +842,7 @@ async fn run_hidraw_loop(
     let config_for_divert = shared_config.clone();
     handler.set_macro_cids(macro_cids);
     handler.set_shared_config(shared_config);
+    handler.set_kwin_availability(kwin_availability);
 
     loop {
         // Re-read the reassigned buttons each cycle so a config change is
@@ -957,10 +974,12 @@ async fn run_evdev_loop(
     suppressed_keys: HashSet<u16>,
     hotplug: Arc<tokio::sync::Notify>,
     shared_config: juhradiald::config::SharedConfig,
+    kwin_availability: juhradiald::compositor::KWinAvailability,
 ) {
     let mut handler = EvdevHandler::new(event_tx.clone());
     handler.set_suppressed_keys(suppressed_keys);
     handler.set_shared_config(shared_config);
+    handler.set_kwin_availability(kwin_availability);
 
     let mut logged_waiting = false;
 
@@ -1063,6 +1082,7 @@ async fn run_generic_evdev_loop(
     suppressed_keys: HashSet<u16>,
     hotplug: Arc<tokio::sync::Notify>,
     shared_config: juhradiald::config::SharedConfig,
+    kwin_availability: juhradiald::compositor::KWinAvailability,
 ) {
     let trigger = read_trigger_button_from_config();
     if let Some(code) = trigger {
@@ -1071,6 +1091,7 @@ async fn run_generic_evdev_loop(
     let mut handler = EvdevHandler::new_generic(event_tx.clone(), trigger);
     handler.set_suppressed_keys(suppressed_keys);
     handler.set_shared_config(shared_config);
+    handler.set_kwin_availability(kwin_availability);
 
     let mut logged_waiting = false;
 


### PR DESCRIPTION
Fixes the cold-boot half of #32: after a full reboot the radial menu opens in a fixed wrong spot that does not follow the cursor, and restarting the app from the graphical session fixes it.

## Root cause

The daemon decided whether to use the KWin cursor query by reading `XDG_CURRENT_DESKTOP`. At cold boot it is started by the systemd user service, whose environment does not contain that variable, so a live KDE session was classified as non-KDE and the cursor query fell back to the screen centre. fab0912's boot log shows exactly this: `Could not query cursor position, using screen center (960, 540)` with no `triggering KWin cursor query` line, i.e. the KDE branch never ran.

## Change

Detect KWin by whether it owns the well-known `org.kde.KWin` name on the session bus, which is present whenever KWin is running regardless of how the daemon was launched.

- New `compositor` module: `KWinAvailability` (a shared atomic flag) plus a watcher that seeds it from `NameHasOwner` and follows `NameOwnerChanged`, so a KWin restart is reflected without restarting the daemon.
- The gesture handlers in `hidraw.rs` and `evdev.rs` read the flag instead of the env var. The env string is no longer used to choose the cursor backend.

## Verification

- `cargo test` (new compositor unit tests for owner present/absent and loss-then-recovery), clean `cargo build` and `cargo clippy -D warnings` on lib + bins.
- Live check on a KDE Plasma Wayland box: with `XDG_CURRENT_DESKTOP` unset (the cold-boot condition) the old env check selects the fallback, while the new D-Bus check still reports KWin owned and selects the KWin path; with the env set both agree.
- Remaining: a real cold-boot reboot on KDE Wayland to confirm end to end (the bug only appears at boot).
