### PR TITLE
CI: OpenSSF Scorecard + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @JuhLabs

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,37 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  push:
+    branches: [master]
+  schedule:
+    - cron: '30 1 * * 6'
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Adds two supply-chain hygiene files:

- `.github/workflows/scorecard.yml`: OpenSSF Scorecard analysis, run weekly (Saturday 01:30 UTC) and on every push to the default branch. All actions are SHA-pinned (checkout v6.0.2, scorecard-action v2.4.3, upload-artifact v7.0.1, codeql upload-sarif v4.35.3). Results publish to the OpenSSF REST API and upload as SARIF to code scanning.
- `.github/CODEOWNERS`: routes all review requests to @JuhLabs.

Note: the Scorecard workflow triggers on push/schedule/branch_protection_rule only, so it will NOT run on this PR; the first run happens after merge to the default branch.

Do not merge yet: part of the GitHub standards rollout pending owner review.
