### PR TITLE
fix(packaging): don't pre-activate graphical-session.target (GDM login loop)

### DIFF
--- a/packaging/systemd/juhradialmx-daemon.service
+++ b/packaging/systemd/juhradialmx-daemon.service
@@ -18,8 +18,12 @@
 [Unit]
 Description=JuhRadial MX Daemon - Radial menu for Logitech MX Master 4
 Documentation=https://github.com/juhhally/juhradial-mx
+# NOTE: Do NOT use `Wants=graphical-session.target` here. Combined with
+# `WantedBy=default.target` it would activate graphical-session.target on every
+# login (even a text TTY), which makes gnome-session abort with "A graphical
+# session is already running!" -> GDM login loop. This service must only be
+# pulled BY a real graphical session, never push the target up itself.
 After=graphical-session.target
-Wants=graphical-session.target
 PartOf=graphical-session.target
 
 # D-Bus session is required for communication with KWin
@@ -57,4 +61,4 @@ MemoryMax=100M
 CPUQuota=50%
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
## Problem

`juhradialmx-daemon.service` causes an **unrecoverable GDM login loop** on systems with a recent `gnome-session` (seen after a GNOME 50 / systemd 261 update): the password is accepted, then the session immediately bounces back to the greeter.

Root cause is a systemd dependency antipattern in the unit:

- `[Install] WantedBy=default.target` → the daemon starts on **every** login, including plain text TTYs.
- `[Unit] Wants=graphical-session.target` → starting the daemon **activates `graphical-session.target`**.

Together they leave `graphical-session.target` active with **no compositor behind it** (e.g. after a text-TTY login, which keeps the per-user `systemd --user` manager alive). When the user then logs in graphically, `gnome-session-init-worker` checks that target, finds it already active, and aborts:

```
gnome-session-init-worker: A graphical session is already running!
gnome-session-i[…] terminated abnormally with signal 6/ABRT
gdm: GdmDisplay: Session never registered, failing
```

→ the session never registers → login loop. This matches the classic "existing user loops, fresh user is fine" signature, since a fresh user has no such service pre-activating the target.

## Fix

Use the correct graphical-session unit pattern:

- Drop `Wants=graphical-session.target` (a session-scoped service must never pull the target up itself).
- Change `[Install]` to `WantedBy=graphical-session.target`, so the daemon is started **by** a real graphical session.
- Keep `After=` and `PartOf=` for ordering and teardown.

`install.sh` copies this same file and runs `systemctl --user enable`, so fresh installs pick up the corrected `[Install]` target automatically.

## Upgrade note for existing installs

The `[Install]` target changed, so already-enabled users must move the symlink:

```bash
systemctl --user daemon-reload
systemctl --user reenable juhradialmx-daemon.service   # -> graphical-session.target.wants/
systemctl --user stop graphical-session.target          # clear any stale/stuck target
```

## Testing

- Reproduced the loop on Manjaro (GNOME 50.3 / mutter 50.3 / gnome-session 50.1 / systemd 261): `coredumpctl` showed repeated `SIGABRT` of `gnome-session-init-worker`, journal `"A graphical session is already running!"`, and `graphical-session.target` `active` on a text-TTY-only login with no `gnome-shell` process.
- After the fix: on a text-TTY-only login `systemctl --user is-active graphical-session.target` returns `inactive` (was `active`); GDM login reaches the desktop and the daemon starts correctly inside the real graphical session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
