### PR TITLE
fix(startup): reduce overlay and settings launch latency

### DIFF
--- a/daemon/src/hidpp/device.rs
+++ b/daemon/src/hidpp/device.rs
@@ -65,6 +65,71 @@ pub struct HidppDevice {
     device_path: PathBuf,
 }
 
+trait ButtonDivertIo {
+    fn short_request(&mut self, feature_index: u8, function: u8, params: &[u8]) -> Option<Vec<u8>>;
+    fn long_request(&mut self, feature_index: u8, function: u8, params: &[u8]) -> Option<Vec<u8>>;
+}
+
+impl ButtonDivertIo for HidppDevice {
+    fn short_request(&mut self, feature_index: u8, function: u8, params: &[u8]) -> Option<Vec<u8>> {
+        self.hidpp_request(feature_index, function, params)
+    }
+
+    fn long_request(&mut self, feature_index: u8, function: u8, params: &[u8]) -> Option<Vec<u8>> {
+        self.hidpp_long_request(feature_index, function, params)
+    }
+}
+
+fn set_button_diverts_with_io(
+    io: &mut impl ButtonDivertIo,
+    feature_index: u8,
+    cids: &[u16],
+    divert: bool,
+) -> Vec<u16> {
+    let requested: HashSet<u16> = cids.iter().copied().collect();
+    if requested.is_empty() {
+        return Vec::new();
+    }
+
+    let count = match io.short_request(feature_index, 0x00, &[]) {
+        Some(resp) if resp.len() >= 5 => resp[4],
+        _ => return Vec::new(),
+    };
+    let divert_flags: u8 = if divert { 0x03 } else { 0x02 };
+    let mut diverted = Vec::new();
+
+    for index in 0..count {
+        let resp = match io.short_request(feature_index, 0x01, &[index, 0, 0]) {
+            Some(response) if response.len() >= 9 => response,
+            _ => continue,
+        };
+        let cid = ((resp[4] as u16) << 8) | (resp[5] as u16);
+        let divertable = (resp[8] & 0x20) != 0;
+        if !requested.contains(&cid) || !divertable {
+            continue;
+        }
+
+        let params = [
+            (cid >> 8) as u8,
+            (cid & 0xFF) as u8,
+            divert_flags,
+            0x00,
+            0x00,
+        ];
+        if let Some(resp) = io.long_request(feature_index, 0x03, &params) {
+            tracing::info!(
+                cid = format!("0x{:04X}", cid),
+                divert,
+                response = format!("{:02X?}", &resp[4..resp.len().min(9)]),
+                "Button divert updated"
+            );
+            diverted.push(cid);
+        }
+    }
+
+    diverted
+}
+
 impl HidppDevice {
     /// Find a Logitech hidraw device suitable for HID++ communication
     ///
@@ -1042,48 +1107,12 @@ impl HidppDevice {
             Some(idx) => idx,
             None => return Ok(Vec::new()),
         };
-        let requested: HashSet<u16> = cids.iter().copied().collect();
-        if requested.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let count = match self.hidpp_request(feature_index, 0x00, &[]) {
-            Some(resp) if resp.len() >= 5 => resp[4],
-            _ => return Ok(Vec::new()),
-        };
-        let divert_flags: u8 = if divert { 0x03 } else { 0x02 };
-        let mut diverted = Vec::new();
-
-        for i in 0..count {
-            let resp = match self.hidpp_request(feature_index, 0x01, &[i, 0, 0]) {
-                Some(r) if r.len() >= 9 => r,
-                _ => continue,
-            };
-            let cid = ((resp[4] as u16) << 8) | (resp[5] as u16);
-            let divertable = (resp[8] & 0x20) != 0;
-            if !requested.contains(&cid) || !divertable {
-                continue;
-            }
-
-            let params: &[u8] = &[
-                (cid >> 8) as u8,
-                (cid & 0xFF) as u8,
-                divert_flags,
-                0x00,
-                0x00,
-            ];
-            if let Some(resp) = self.hidpp_long_request(feature_index, 0x03, params) {
-                tracing::info!(
-                    cid = format!("0x{:04X}", cid),
-                    divert,
-                    response = format!("{:02X?}", &resp[4..resp.len().min(9)]),
-                    "Button divert updated"
-                );
-                diverted.push(cid);
-            }
-        }
-
-        Ok(diverted)
+        Ok(set_button_diverts_with_io(
+            self,
+            feature_index,
+            cids,
+            divert,
+        ))
     }
 
     // =========================================================================
@@ -1921,5 +1950,140 @@ impl HidppDevice {
                 Ok(())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod button_divert_tests {
+    use std::collections::VecDeque;
+
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct Request {
+        feature_index: u8,
+        function: u8,
+        params: Vec<u8>,
+    }
+
+    #[derive(Default)]
+    struct MockButtonDivertIo {
+        short_responses: VecDeque<Option<Vec<u8>>>,
+        long_responses: VecDeque<Option<Vec<u8>>>,
+        short_requests: Vec<Request>,
+        long_requests: Vec<Request>,
+    }
+
+    impl ButtonDivertIo for MockButtonDivertIo {
+        fn short_request(
+            &mut self,
+            feature_index: u8,
+            function: u8,
+            params: &[u8],
+        ) -> Option<Vec<u8>> {
+            self.short_requests.push(Request {
+                feature_index,
+                function,
+                params: params.to_vec(),
+            });
+            self.short_responses.pop_front().flatten()
+        }
+
+        fn long_request(
+            &mut self,
+            feature_index: u8,
+            function: u8,
+            params: &[u8],
+        ) -> Option<Vec<u8>> {
+            self.long_requests.push(Request {
+                feature_index,
+                function,
+                params: params.to_vec(),
+            });
+            self.long_responses.pop_front().flatten()
+        }
+    }
+
+    fn count_response(count: u8) -> Vec<u8> {
+        let mut response = vec![0; 5];
+        response[4] = count;
+        response
+    }
+
+    fn control_response(cid: u16, flags: u8) -> Vec<u8> {
+        let mut response = vec![0; 9];
+        response[4] = (cid >> 8) as u8;
+        response[5] = (cid & 0xFF) as u8;
+        response[8] = flags;
+        response
+    }
+
+    #[test]
+    fn batch_divert_scans_controls_once_and_returns_only_successful_cids() {
+        let mut io = MockButtonDivertIo {
+            short_responses: VecDeque::from([
+                Some(count_response(4)),
+                Some(control_response(0x0050, 0x20)),
+                Some(control_response(0x0051, 0x20)),
+                Some(control_response(0x0052, 0x00)),
+                None,
+            ]),
+            long_responses: VecDeque::from([Some(vec![0; 9]), None]),
+            ..Default::default()
+        };
+
+        let diverted =
+            set_button_diverts_with_io(&mut io, 0x0A, &[0x0050, 0x0051, 0x0052, 0x0050], true);
+
+        assert_eq!(diverted, vec![0x0050]);
+        assert_eq!(io.short_requests.len(), 5);
+        assert_eq!(io.short_requests[0].function, 0x00);
+        assert_eq!(
+            io.short_requests[1..]
+                .iter()
+                .map(|request| request.params.clone())
+                .collect::<Vec<_>>(),
+            vec![vec![0, 0, 0], vec![1, 0, 0], vec![2, 0, 0], vec![3, 0, 0]]
+        );
+        assert_eq!(
+            io.long_requests,
+            vec![
+                Request {
+                    feature_index: 0x0A,
+                    function: 0x03,
+                    params: vec![0x00, 0x50, 0x03, 0x00, 0x00],
+                },
+                Request {
+                    feature_index: 0x0A,
+                    function: 0x03,
+                    params: vec![0x00, 0x51, 0x03, 0x00, 0x00],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn batch_divert_stops_when_control_count_is_unavailable() {
+        let mut io = MockButtonDivertIo {
+            short_responses: VecDeque::from([None]),
+            ..Default::default()
+        };
+
+        let diverted = set_button_diverts_with_io(&mut io, 0x0A, &[0x0050], true);
+
+        assert!(diverted.is_empty());
+        assert_eq!(io.short_requests.len(), 1);
+        assert!(io.long_requests.is_empty());
+    }
+
+    #[test]
+    fn batch_divert_skips_io_for_an_empty_request() {
+        let mut io = MockButtonDivertIo::default();
+
+        let diverted = set_button_diverts_with_io(&mut io, 0x0A, &[], true);
+
+        assert!(diverted.is_empty());
+        assert!(io.short_requests.is_empty());
+        assert!(io.long_requests.is_empty());
     }
 }

--- a/daemon/src/hidpp/device.rs
+++ b/daemon/src/hidpp/device.rs
@@ -4,6 +4,7 @@
 //! Handles device discovery, HID++ 2.0 protocol, feature enumeration,
 //! button divert, haptics, DPI, SmartShift, battery, and Easy-Switch.
 
+use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::fs::OpenOptionsExt;
@@ -1024,6 +1025,65 @@ impl HidppDevice {
         }
 
         Ok(false)
+    }
+
+    /// Enable or disable volatile diverts for multiple controls after one
+    /// REPROG_CONTROLS_V4 control scan.
+    ///
+    /// This is equivalent to calling [`Self::set_button_divert`] for every CID,
+    /// but avoids repeating `getCount` and `getCidInfo` for each macro during
+    /// startup. The returned CIDs are exactly those successfully updated.
+    pub fn set_button_diverts(
+        &mut self,
+        cids: &[u16],
+        divert: bool,
+    ) -> Result<Vec<u16>, HapticError> {
+        let feature_index = match self.reprog_controls_feature_index {
+            Some(idx) => idx,
+            None => return Ok(Vec::new()),
+        };
+        let requested: HashSet<u16> = cids.iter().copied().collect();
+        if requested.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let count = match self.hidpp_request(feature_index, 0x00, &[]) {
+            Some(resp) if resp.len() >= 5 => resp[4],
+            _ => return Ok(Vec::new()),
+        };
+        let divert_flags: u8 = if divert { 0x03 } else { 0x02 };
+        let mut diverted = Vec::new();
+
+        for i in 0..count {
+            let resp = match self.hidpp_request(feature_index, 0x01, &[i, 0, 0]) {
+                Some(r) if r.len() >= 9 => r,
+                _ => continue,
+            };
+            let cid = ((resp[4] as u16) << 8) | (resp[5] as u16);
+            let divertable = (resp[8] & 0x20) != 0;
+            if !requested.contains(&cid) || !divertable {
+                continue;
+            }
+
+            let params: &[u8] = &[
+                (cid >> 8) as u8,
+                (cid & 0xFF) as u8,
+                divert_flags,
+                0x00,
+                0x00,
+            ];
+            if let Some(resp) = self.hidpp_long_request(feature_index, 0x03, params) {
+                tracing::info!(
+                    cid = format!("0x{:04X}", cid),
+                    divert,
+                    response = format!("{:02X?}", &resp[4..resp.len().min(9)]),
+                    "Button divert updated"
+                );
+                diverted.push(cid);
+            }
+        }
+
+        Ok(diverted)
     }
 
     // =========================================================================

--- a/daemon/src/hidpp/manager.rs
+++ b/daemon/src/hidpp/manager.rs
@@ -191,6 +191,18 @@ impl HapticManager {
         }
     }
 
+    /// Divert multiple controls with one REPROG_CONTROLS_V4 control scan.
+    ///
+    /// Returns the CIDs which were found, divertable, and successfully updated.
+    /// The result is connection-scoped: callers must repeat it after reconnect
+    /// because button diverts are volatile.
+    pub fn divert_buttons_by_cid(&mut self, cids: &[u16]) -> Result<Vec<u16>, HapticError> {
+        match &mut self.device {
+            Some(device) => device.set_button_diverts(cids, true),
+            None => Ok(Vec::new()),
+        }
+    }
+
     /// Enable or disable the volatile divert for a single button by CID.
     pub fn set_button_divert(&mut self, cid: u16, divert: bool) -> Result<bool, HapticError> {
         match &mut self.device {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -6,6 +6,7 @@
 use clap::Parser;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::time::Instant;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, sleep};
 use tracing::{Level, debug, error, info, warn};
@@ -45,6 +46,16 @@ const DEVICE_POLL_INTERVAL_SECS: u64 = 60;
 /// found one, so a shorter cadence does not reintroduce the steady-state evdev
 /// scanning stutter that `DEVICE_POLL_INTERVAL_SECS` avoids.
 const HIDRAW_RECONNECT_POLL_INTERVAL_SECS: u64 = 5;
+
+/// Emit monotonic checkpoints so cold-start latency can be attributed to a
+/// concrete phase instead of inferring it from process activation.
+fn log_startup_phase(started_at: &Instant, phase: &'static str) {
+    info!(
+        phase,
+        elapsed_ms = started_at.elapsed().as_millis() as u64,
+        "Startup phase completed"
+    );
+}
 
 /// Spawn a background thread that watches /dev/input/ for device hotplug events
 /// using inotify. Returns a Notify that fires when event* devices appear or disappear.
@@ -173,6 +184,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::subscriber::set_global_default(subscriber)?;
 
     info!("JuhRadial MX Daemon starting...");
+    let startup_started_at = Instant::now();
 
     // Handle --list-devices flag
     if args.list_devices {
@@ -196,6 +208,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             juhradiald::config::new_shared_config()
         }
     };
+    log_startup_phase(&startup_started_at, "config");
 
     // Initialize haptic manager for MX4 haptic feedback
     let haptic_config = shared_config.read().unwrap().haptics.clone();
@@ -251,6 +264,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             info!(name = %name, "HID++ device name");
         }
     }
+    log_startup_phase(&startup_started_at, "hidpp_bootstrap");
 
     // Clone haptic_manager for battery updater before passing to D-Bus
     let haptic_manager_for_battery = haptic_manager.clone();
@@ -303,6 +317,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     };
+    log_startup_phase(&startup_started_at, "device_mode");
 
     // Initialize gaming mode and macro subsystem
     let gaming_mode = new_shared_gaming_mode(haptic_manager.clone());
@@ -332,37 +347,60 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 })
                 .collect();
         }
+        let initial_remapped_cids = shared_config
+            .read()
+            .map(|config| config.remapped_button_cids())
+            .unwrap_or_default();
 
-        macro_cids = if pending_cids.is_empty() {
+        macro_cids = if pending_cids.is_empty() && initial_remapped_cids.is_empty() {
             Vec::new()
         } else {
-            // Each divert sends an HID++ long_request and polls 10ms × up to 1s
-            // for the response. Run on the blocking pool so the runtime keeps
-            // servicing input events while macros are being registered.
+            // Scan REPROG_CONTROLS_V4 once, then send one long request per
+            // matching macro. Re-scanning every control for every macro could
+            // multiply cold-start I/O by the macro count.
             let manager_for_divert = haptic_manager.clone();
             tokio::task::spawn_blocking(move || {
                 let mut mgr = manager_for_divert.lock().unwrap();
+                let requested_cids: Vec<u16> = pending_cids
+                    .iter()
+                    .map(|(_, cid)| *cid)
+                    .chain(initial_remapped_cids.iter().copied())
+                    .collect();
+                let diverted_cids: HashSet<u16> = match mgr.divert_buttons_by_cid(&requested_cids) {
+                    Ok(cids) => cids.into_iter().collect(),
+                    Err(e) => {
+                        warn!(error = %e, "Failed to scan macro buttons for HID++ divert");
+                        HashSet::new()
+                    }
+                };
                 let mut cids = Vec::new();
                 for (evdev_code, cid) in pending_cids {
-                    match mgr.divert_single_button(cid) {
-                        Ok(true) => {
-                            info!(
-                                evdev_code = format!("0x{:04X}", evdev_code),
-                                cid = format!("0x{:04X}", cid),
-                                "Macro button diverted via HID++"
-                            );
-                            cids.push(cid);
-                        }
-                        Ok(false) => warn!(
+                    if diverted_cids.contains(&cid) {
+                        info!(
                             evdev_code = format!("0x{:04X}", evdev_code),
                             cid = format!("0x{:04X}", cid),
-                            "Could not divert macro button (not found or not divertable)"
-                        ),
-                        Err(e) => warn!(
+                            "Macro button diverted via HID++"
+                        );
+                        cids.push(cid);
+                    } else {
+                        warn!(
                             evdev_code = format!("0x{:04X}", evdev_code),
-                            error = %e,
-                            "Failed to divert macro button"
-                        ),
+                            cid = format!("0x{:04X}", cid),
+                            "Could not divert macro button (not found, not divertable, or HID++ update failed)"
+                        );
+                    }
+                }
+                for cid in initial_remapped_cids {
+                    if diverted_cids.contains(&cid) {
+                        info!(
+                            cid = format!("0x{:04X}", cid),
+                            "Reassigned button diverted via HID++"
+                        );
+                    } else {
+                        warn!(
+                            cid = format!("0x{:04X}", cid),
+                            "Could not divert reassigned button (not found, not divertable, or HID++ update failed)"
+                        );
                     }
                 }
                 cids
@@ -371,6 +409,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("macro divert task panicked")
         };
     }
+    log_startup_phase(&startup_started_at, "macro_diverts");
 
     // Clone trigger_map and macro_engine for event processing (macro trigger detection)
     // Must clone before D-Bus init which moves them
@@ -420,6 +459,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             return Err(e.into());
         }
     };
+    log_startup_phase(&startup_started_at, "dbus");
 
     // Detect KWin by D-Bus name ownership (not XDG_CURRENT_DESKTOP, which is
     // empty when systemd starts the daemon at cold boot, issue #32). The watcher
@@ -469,6 +509,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(mut map) => *map = profile_manager.hardware_profiles(),
         Err(e) => error!(error = %e, "Failed to seed shared hardware profiles"),
     }
+    log_startup_phase(&startup_started_at, "profiles");
 
     // Initialize window tracker for per-app HARDWARE profiles (Story 3.2/3.3).
     // The tracker pushes focused-window resource classes; the consumer below
@@ -548,7 +589,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let hidraw_handle = tokio::spawn(async move {
         run_hidraw_loop(
             hidraw_tx,
-            mx4_hidraw_path,
+            HidrawStartup {
+                preferred_path: mx4_hidraw_path,
+            },
             macro_cids,
             hidraw_config,
             hidraw_hotplug,
@@ -608,6 +651,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // TODO: Initialize remaining components
     // 4. Initialize HID++ haptic subsystem
 
+    log_startup_phase(&startup_started_at, "ready");
     info!("JuhRadial MX Daemon ready");
 
     // Wait for shutdown signal
@@ -695,6 +739,10 @@ fn list_logitech_devices() {
     }
 }
 
+struct HidrawStartup {
+    preferred_path: Option<PathBuf>,
+}
+
 /// Reconnect HID++ and re-apply volatile button diverts.
 ///
 /// Easy-Switch host changes reset temporary REPROG_CONTROLS_V4 diverts, so the
@@ -706,63 +754,54 @@ async fn refresh_hidpp_button_diverts(
 ) -> Option<PathBuf> {
     match tokio::task::spawn_blocking(move || {
         let mut manager = haptic_manager.lock().unwrap();
-        match manager.connect() {
-            Ok(true) => {
-                match manager.divert_buttons() {
-                    Ok(n) if n > 0 => info!(count = n, "HID++ gesture buttons diverted"),
-                    Ok(_) => warn!("No HID++ gesture buttons found to divert"),
-                    Err(e) => warn!(error = %e, "Failed to divert HID++ gesture buttons"),
-                }
-
-                for &cid in &macro_cids {
-                    match manager.divert_single_button(cid) {
-                        Ok(true) => debug!(
-                            cid = format!("0x{:04X}", cid),
-                            "HID++ macro button diverted"
-                        ),
-                        Ok(false) => debug!(
-                            cid = format!("0x{:04X}", cid),
-                            "HID++ macro button not divertable on this device"
-                        ),
-                        Err(e) => warn!(
-                            cid = format!("0x{:04X}", cid),
-                            error = %e,
-                            "Failed to divert HID++ macro button"
-                        ),
-                    }
-                }
-
-                // Divert buttons the user reassigned away from their native
-                // default so the daemon can apply the configured action.
-                for &cid in &remapped_cids {
-                    match manager.divert_single_button(cid) {
-                        Ok(true) => info!(
-                            cid = format!("0x{:04X}", cid),
-                            "HID++ reassigned button diverted"
-                        ),
-                        Ok(false) => debug!(
-                            cid = format!("0x{:04X}", cid),
-                            "Reassigned button not divertable on this device"
-                        ),
-                        Err(e) => warn!(
-                            cid = format!("0x{:04X}", cid),
-                            error = %e,
-                            "Failed to divert HID++ reassigned button"
-                        ),
-                    }
-                }
-
-                manager.device_path()
-            }
-            Ok(false) => {
-                debug!("No MX Master HID++ device available for button divert");
-                None
-            }
+        let connected = match manager.connect() {
+            Ok(connected) => connected,
             Err(e) => {
                 warn!(error = %e, "HID++ reconnect failed while refreshing button divert");
-                None
+                return None;
+            }
+        };
+        if !connected {
+            debug!("No MX Master HID++ device available for button divert");
+            return None;
+        }
+
+        match manager.divert_buttons() {
+            Ok(n) if n > 0 => info!(count = n, "HID++ gesture buttons diverted"),
+            Ok(_) => warn!("No HID++ gesture buttons found to divert"),
+            Err(e) => warn!(error = %e, "Failed to divert HID++ gesture buttons"),
+        }
+
+        // Macro and reassigned CIDs all use the same REPROG_CONTROLS_V4 table,
+        // so enumerate it once rather than once per configured control.
+        let requested_cids: Vec<u16> = macro_cids
+            .iter()
+            .chain(remapped_cids.iter())
+            .copied()
+            .collect();
+        let diverted_cids: HashSet<u16> = match manager.divert_buttons_by_cid(&requested_cids) {
+            Ok(cids) => cids.into_iter().collect(),
+            Err(e) => {
+                warn!(error = %e, "Failed to scan configured HID++ button diverts");
+                HashSet::new()
+            }
+        };
+        for cid in macro_cids {
+            if diverted_cids.contains(&cid) {
+                debug!(cid = format!("0x{:04X}", cid), "HID++ macro button diverted");
+            } else {
+                debug!(cid = format!("0x{:04X}", cid), "HID++ macro button not divertable on this device");
             }
         }
+        for cid in remapped_cids {
+            if diverted_cids.contains(&cid) {
+                info!(cid = format!("0x{:04X}", cid), "HID++ reassigned button diverted");
+            } else {
+                debug!(cid = format!("0x{:04X}", cid), "Reassigned button not divertable on this device");
+            }
+        }
+
+        manager.device_path()
     })
     .await
     {
@@ -829,13 +868,16 @@ async fn fetch_notification_indices(
 
 async fn run_hidraw_loop(
     event_tx: mpsc::Sender<GestureEvent>,
-    mut preferred_path: Option<PathBuf>,
+    startup: HidrawStartup,
     macro_cids: Vec<u16>,
     shared_config: juhradiald::config::SharedConfig,
     hotplug: Arc<tokio::sync::Notify>,
     haptic_manager: SharedHapticManager,
     kwin_availability: juhradiald::compositor::KWinAvailability,
 ) {
+    let HidrawStartup {
+        mut preferred_path,
+    } = startup;
     let mut handler = HidrawHandler::new(event_tx);
     let macro_cids_for_divert = macro_cids.clone();
     let config_for_thumbwheel = shared_config.clone();
@@ -1411,6 +1453,7 @@ mod tests {
         assert_eq!(DEVICE_POLL_INTERVAL_SECS, 60);
         assert_eq!(HIDRAW_RECONNECT_POLL_INTERVAL_SECS, 5);
     }
+
 
     #[test]
     fn test_args_default_config() {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -788,16 +788,28 @@ async fn refresh_hidpp_button_diverts(
         };
         for cid in macro_cids {
             if diverted_cids.contains(&cid) {
-                debug!(cid = format!("0x{:04X}", cid), "HID++ macro button diverted");
+                debug!(
+                    cid = format!("0x{:04X}", cid),
+                    "HID++ macro button diverted"
+                );
             } else {
-                debug!(cid = format!("0x{:04X}", cid), "HID++ macro button not divertable on this device");
+                debug!(
+                    cid = format!("0x{:04X}", cid),
+                    "HID++ macro button not divertable on this device"
+                );
             }
         }
         for cid in remapped_cids {
             if diverted_cids.contains(&cid) {
-                info!(cid = format!("0x{:04X}", cid), "HID++ reassigned button diverted");
+                info!(
+                    cid = format!("0x{:04X}", cid),
+                    "HID++ reassigned button diverted"
+                );
             } else {
-                debug!(cid = format!("0x{:04X}", cid), "Reassigned button not divertable on this device");
+                debug!(
+                    cid = format!("0x{:04X}", cid),
+                    "Reassigned button not divertable on this device"
+                );
             }
         }
 
@@ -875,9 +887,7 @@ async fn run_hidraw_loop(
     haptic_manager: SharedHapticManager,
     kwin_availability: juhradiald::compositor::KWinAvailability,
 ) {
-    let HidrawStartup {
-        mut preferred_path,
-    } = startup;
+    let HidrawStartup { mut preferred_path } = startup;
     let mut handler = HidrawHandler::new(event_tx);
     let macro_cids_for_divert = macro_cids.clone();
     let config_for_thumbwheel = shared_config.clone();
@@ -905,11 +915,8 @@ async fn run_hidraw_loop(
 
         // Re-apply thumb-wheel divert (volatile) and refresh the feature index
         // the reader uses to route rotation notifications.
-        let tw_index = apply_thumbwheel_reporting(
-            haptic_manager.clone(),
-            config_for_thumbwheel.clone(),
-        )
-        .await;
+        let tw_index =
+            apply_thumbwheel_reporting(haptic_manager.clone(), config_for_thumbwheel.clone()).await;
         handler.set_thumbwheel_feature_index(tw_index);
 
         // Refresh notification feature indices for live hardware readback. Like
@@ -1453,7 +1460,6 @@ mod tests {
         assert_eq!(DEVICE_POLL_INTERVAL_SECS, 60);
         assert_eq!(HIDRAW_RECONNECT_POLL_INTERVAL_SECS, 5);
     }
-
 
     #[test]
     fn test_args_default_config() {

--- a/overlay/juhradial-overlay.py
+++ b/overlay/juhradial-overlay.py
@@ -167,7 +167,10 @@ class SplashScreen(QWidget):
         self._timer.setInterval(16)  # ~60fps
         self._timer.start()
 
-    MIN_DISPLAY_MS = 2000  # show splash for at least 2 seconds
+    # Keep the branded transition perceptible without masking a ready daemon.
+    # Full overlay initialization is normally sub-second; a 2s floor made every
+    # fast launch look slow even when D-Bus was already available.
+    MIN_DISPLAY_MS = 250
 
     def _tick(self):
         import time
@@ -188,7 +191,7 @@ class SplashScreen(QWidget):
                 self.deleteLater()
                 return
         elif self._ready:
-            # App loading done - wait for minimum display time + daemon ready
+            # App loading done - wait for the short transition + daemon readiness.
             elapsed_ms = (time.time() - self._show_time) * 1000
             daemon_ok = (
                 self._daemon_iface is None

--- a/overlay/overlay_actions.py
+++ b/overlay/overlay_actions.py
@@ -321,32 +321,41 @@ def load_os_icons():
 # =============================================================================
 
 
+def _requires_settings_relaunch():
+    """Keep the legacy relaunch only outside KDE Plasma.
+
+    KDE Plasma reliably presents an existing Gtk.Application through its
+    single-instance D-Bus activation. Other desktops retain the established
+    kill-and-relaunch behavior until they are verified separately.
+    """
+    desktop = os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
+    return "kde" not in desktop and "plasma" not in desktop
+
+
 def open_settings():
     """Launch or refocus the settings dashboard.
 
-    On GNOME Wayland, present() from a D-Bus Activate can't raise the window
-    because the calling process (radial overlay) has already hidden itself.
-    So we check if the settings app is running and if so, kill and relaunch
-    to guarantee a focused window.
+    KDE's single-instance activation raises an existing window immediately.
+    Other desktops retain the existing kill-and-relaunch behavior, which works
+    around focus restrictions observed on GNOME Wayland.
     """
     settings_script = os.path.join(os.path.dirname(__file__), "settings_dashboard.py")
 
-    # Check if settings app is already running on D-Bus
-    try:
-        result = subprocess.run(
-            ["busctl", "--user", "status", "org.kde.juhradialmx.settings"],
-            capture_output=True, timeout=0.5,
-        )
-        if result.returncode == 0:
-            # Already running - kill it so the fresh launch gets focus
-            subprocess.run(
-                ["pkill", "-f", "settings_dashboard.py"],
-                capture_output=True, timeout=1,
+    if _requires_settings_relaunch():
+        try:
+            result = subprocess.run(
+                ["busctl", "--user", "status", "org.kde.juhradialmx.settings"],
+                capture_output=True, timeout=0.5,
             )
-            import time
-            time.sleep(0.15)
-    except (subprocess.SubprocessError, OSError):
-        pass  # Settings process may not be running
+            if result.returncode == 0:
+                subprocess.run(
+                    ["pkill", "-f", "settings_dashboard.py"],
+                    capture_output=True, timeout=1,
+                )
+                import time
+                time.sleep(0.15)
+        except (subprocess.SubprocessError, OSError):
+            pass  # Settings process may not be running
 
     subprocess.Popen(
         ["python3", settings_script],

--- a/overlay/settings_dashboard.py
+++ b/overlay/settings_dashboard.py
@@ -62,7 +62,6 @@ from settings_page_scroll import ScrollPage
 from settings_page_haptics import HapticsPage
 from settings_page_devices import DevicesPage
 from settings_page_easyswitch import EasySwitchPage
-from settings_page_flow import FlowPage
 from settings_page_settings import SettingsPage
 from settings_page_macros import MacrosPage
 from settings_page_gaming import GamingPage
@@ -760,8 +759,10 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
 
             self.content_stack.add_named(buttons_page, "buttons")
 
-        # Other pages
-        self.content_stack.add_named(ScrollPage(), "scroll")
+        # The first visible page is Buttons. Build Point & Scroll lazily because
+        # its hardware-state reads are independent of the initial screen.
+        self._scroll_page_placeholder = Gtk.Box()
+        self.content_stack.add_named(self._scroll_page_placeholder, "scroll")
         self.content_stack.add_named(DevicesPage(), "devices")
         self.content_stack.add_named(SettingsPage(), "settings")
 
@@ -844,6 +845,18 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
         for btn_id, btn in self.nav_buttons.items():
             btn.set_active(btn_id == item_id)
 
+        # Lazy-load Point & Scroll after the first frame. Its daemon reads can
+        # be slow while HID++ is reconnecting, but must not delay opening the
+        # default Buttons page.
+        if (
+            item_id == "scroll"
+            and hasattr(self, "_scroll_page_placeholder")
+            and self._scroll_page_placeholder is not None
+        ):
+            self.content_stack.remove(self._scroll_page_placeholder)
+            self._scroll_page_placeholder = None
+            self.content_stack.add_named(ScrollPage(), "scroll")
+
         # Lazy-load FlowPage on first navigation to avoid Zeroconf startup cost
         # (only in Logitech mode - flow tab is hidden in generic mode)
         if (
@@ -854,6 +867,7 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
         ):
             self.content_stack.remove(self._flow_page_placeholder)
             self._flow_page_placeholder = None
+            from settings_page_flow import FlowPage
             flow_page = FlowPage()
             self.content_stack.add_named(flow_page, "flow")
 

--- a/overlay/settings_page_scroll.py
+++ b/overlay/settings_page_scroll.py
@@ -250,6 +250,12 @@ class ScrollPage(Gtk.ScrolledWindow):
         super().__init__()
         self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
+        # Initial hardware state arrives asynchronously. Keep a generation so
+        # a delayed reply can never overwrite a choice made in this window.
+        self._scroll_state_generation = 0
+        self._initial_scroll_state_generation = 0
+        self._applying_initial_scroll_state = False
+
         self._device_mode = get_device_mode()
         self._is_generic = self._device_mode == "generic"
 
@@ -527,6 +533,9 @@ class ScrollPage(Gtk.ScrolledWindow):
     # ------------------------------------------------------------------
     def _on_mode_changed(self, mode):
         """Handle wheel mode change from segmented control."""
+        if self._applying_initial_scroll_state:
+            return
+        self._mark_scroll_state_user_edit()
         config.set("scroll", "mode", mode)
         # Show/hide sensitivity slider
         self.sensitivity_box.set_visible(mode == "smartshift")
@@ -544,6 +553,9 @@ class ScrollPage(Gtk.ScrolledWindow):
             self._apply_smartshift_to_device(True, device_threshold)
 
     def _on_sensitivity_changed(self, scale):
+        if self._applying_initial_scroll_state:
+            return
+        self._mark_scroll_state_user_edit()
         value = int(scale.get_value())
         config.set("scroll", "smartshift_threshold", value)
         self._update_sens_label(value)
@@ -636,6 +648,9 @@ class ScrollPage(Gtk.ScrolledWindow):
         return False
 
     def _on_smooth_changed(self, switch, state):
+        if self._applying_initial_scroll_state:
+            return False
+        self._mark_scroll_state_user_edit()
         config.set("scroll", "smooth", state)
         if not self._is_generic:
             self._apply_hiresscroll_to_device()
@@ -914,17 +929,41 @@ None,      Down, Button5, {lines}
     # ------------------------------------------------------------------
     # Load device state on startup
     # ------------------------------------------------------------------
+    def _mark_scroll_state_user_edit(self):
+        """Invalidate pending initial D-Bus reads after a local edit."""
+        self._scroll_state_generation += 1
+
+    def _has_local_scroll_state_edits(self):
+        return self._scroll_state_generation != self._initial_scroll_state_generation
+
+    def _apply_initial_scroll_state(self, *, mode=None, threshold=None, smooth=None):
+        """Update controls from the initial device read without firing setters."""
+        self._applying_initial_scroll_state = True
+        try:
+            if mode is not None:
+                self.mode_selector.set_mode(mode)
+                self.sensitivity_box.set_visible(mode == "smartshift")
+            if threshold is not None:
+                self.sens_scale.set_value(threshold)
+                self._update_sens_label(threshold)
+            if smooth is not None:
+                self.smooth_switch.set_active(smooth)
+        finally:
+            self._applying_initial_scroll_state = False
+
     def _apply_saved_scroll_mode(self):
         """Use persisted SmartShift state when the daemon is unavailable."""
+        if self._has_local_scroll_state_edits():
+            return
         mode = config.get("scroll", "mode", default="smartshift")
-        self.mode_selector.set_mode(mode)
-        self.sensitivity_box.set_visible(mode == "smartshift")
+        self._apply_initial_scroll_state(mode=mode)
 
     def _load_device_settings(self):
         """Start non-blocking SmartShift and HiResScroll reads from the daemon.
 
         In generic mode, skip all HID++ device queries - just use config values.
         """
+        self._initial_scroll_state_generation = self._scroll_state_generation
         if self._is_generic:
             # No HID++ device to query; use saved config for basic scroll settings
             return
@@ -998,6 +1037,9 @@ None,      Down, Button5, {lines}
             self._apply_saved_scroll_mode()
             return
 
+        if self._has_local_scroll_state_edits():
+            return
+
         if not supported or not supported.get_child_value(0).get_boolean():
             self.mode_selector.set_sensitive(False)
             self.sensitivity_box.set_visible(False)
@@ -1021,6 +1063,9 @@ None,      Down, Button5, {lines}
             self._apply_saved_scroll_mode()
             return
 
+        if self._has_local_scroll_state_edits():
+            return
+
         if not result:
             self._apply_saved_scroll_mode()
             return
@@ -1041,9 +1086,7 @@ None,      Down, Button5, {lines}
         ui_threshold = 100 - int(device_threshold / 2.55)
         ui_threshold = max(1, min(100, ui_threshold))
 
-        self.mode_selector.set_mode(mode)
-        self.sens_scale.set_value(ui_threshold)
-        self.sensitivity_box.set_visible(mode == "smartshift")
+        self._apply_initial_scroll_state(mode=mode, threshold=ui_threshold)
 
         config.set("scroll", "mode", mode)
         config.set("scroll", "smartshift_threshold", ui_threshold)
@@ -1051,9 +1094,11 @@ None,      Down, Button5, {lines}
     def _on_hiresscroll_loaded(self, proxy, async_result, _user_data):
         try:
             result = proxy.call_finish(async_result)
+            if self._has_local_scroll_state_edits():
+                return
             if result:
                 hires = result.get_child_value(0).get_boolean()
-                self.smooth_switch.set_active(hires)
+                self._apply_initial_scroll_state(smooth=hires)
                 config.set("scroll", "smooth", hires)
         except GLib.Error as e:
             logger.error("D-Bus error loading HiResScroll: %s", e.message)

--- a/overlay/settings_page_scroll.py
+++ b/overlay/settings_page_scroll.py
@@ -914,8 +914,14 @@ None,      Down, Button5, {lines}
     # ------------------------------------------------------------------
     # Load device state on startup
     # ------------------------------------------------------------------
+    def _apply_saved_scroll_mode(self):
+        """Use persisted SmartShift state when the daemon is unavailable."""
+        mode = config.get("scroll", "mode", default="smartshift")
+        self.mode_selector.set_mode(mode)
+        self.sensitivity_box.set_visible(mode == "smartshift")
+
     def _load_device_settings(self):
-        """Load SmartShift and HiResScroll settings from device.
+        """Start non-blocking SmartShift and HiResScroll reads from the daemon.
 
         In generic mode, skip all HID++ device queries - just use config values.
         """
@@ -923,64 +929,128 @@ None,      Down, Button5, {lines}
             # No HID++ device to query; use saved config for basic scroll settings
             return
 
-        proxy = self._get_dbus_proxy()
-        if not proxy:
-            # Fall back to config
-            mode = config.get("scroll", "mode", default="smartshift")
-            self.mode_selector.set_mode(mode)
-            self.sensitivity_box.set_visible(mode == "smartshift")
+        # Creating a D-Bus proxy synchronously may trigger introspection and
+        # block the first settings frame while the HID++ daemon is busy. Start
+        # the whole connection/proxy/read chain asynchronously instead.
+        try:
+            Gio.bus_get(
+                Gio.BusType.SESSION,
+                None,
+                self._on_startup_session_bus_ready,
+                None,
+            )
+        except GLib.Error as e:
+            logger.error("D-Bus error starting device settings load: %s", e.message)
+            self._apply_saved_scroll_mode()
+
+    def _on_startup_session_bus_ready(self, _source, async_result, _user_data):
+        try:
+            bus = Gio.bus_get_finish(async_result)
+            Gio.DBusProxy.new(
+                bus,
+                Gio.DBusProxyFlags.NONE,
+                None,
+                "org.kde.juhradialmx",
+                "/org/kde/juhradialmx/Daemon",
+                "org.kde.juhradialmx.Daemon",
+                None,
+                self._on_startup_proxy_ready,
+                None,
+            )
+        except GLib.Error as e:
+            logger.error("D-Bus error creating device settings proxy: %s", e.message)
+            self._apply_saved_scroll_mode()
+
+    def _on_startup_proxy_ready(self, _source, async_result, _user_data):
+        try:
+            proxy = Gio.DBusProxy.new_finish(async_result)
+        except GLib.Error as e:
+            logger.error("D-Bus error creating device settings proxy: %s", e.message)
+            self._apply_saved_scroll_mode()
             return
 
-        # Load SmartShift
+        # Do not use call_sync here: these callbacks run after the window is
+        # presented, and a busy HID++ daemon must not stall GTK's main loop.
         try:
-            supported = proxy.call_sync(
+            proxy.call(
                 "SmartShiftSupported", None,
                 Gio.DBusCallFlags.NONE, 2000, None,
+                self._on_smartshift_support_loaded, None,
             )
-            if supported and supported.get_child_value(0).get_boolean():
-                result = proxy.call_sync(
-                    "GetSmartShift", None,
-                    Gio.DBusCallFlags.NONE, 2000, None,
-                )
-                if result:
-                    enabled = result.get_child_value(0).get_boolean()
-                    device_threshold = result.get_child_value(1).get_byte()
-
-                    # Determine mode from device + saved config
-                    saved_mode = config.get("scroll", "mode", default=None)
-                    if saved_mode == "freespin":
-                        mode = "freespin"
-                    elif enabled:
-                        mode = "smartshift"
-                    else:
-                        mode = "ratchet"
-
-                    # Convert device threshold to UI percentage
-                    ui_threshold = 100 - int(device_threshold / 2.55)
-                    ui_threshold = max(1, min(100, ui_threshold))
-
-                    self.mode_selector.set_mode(mode)
-                    self.sens_scale.set_value(ui_threshold)
-                    self.sensitivity_box.set_visible(mode == "smartshift")
-
-                    config.set("scroll", "mode", mode)
-                    config.set("scroll", "smartshift_threshold", ui_threshold)
-            else:
-                # SmartShift not supported
-                self.mode_selector.set_sensitive(False)
-                self.sensitivity_box.set_visible(False)
         except GLib.Error as e:
-            logger.error("D-Bus error loading SmartShift: %s", e.message)
-            mode = config.get("scroll", "mode", default="smartshift")
-            self.mode_selector.set_mode(mode)
-            self.sensitivity_box.set_visible(mode == "smartshift")
+            logger.error("D-Bus error starting SmartShift load: %s", e.message)
+            self._apply_saved_scroll_mode()
 
-        # Load HiResScroll
         try:
-            result = proxy.call_sync(
+            proxy.call(
                 "GetHiresscrollMode", None,
                 Gio.DBusCallFlags.NONE, 2000, None,
+                self._on_hiresscroll_loaded, None,
             )
+        except GLib.Error as e:
+            logger.error("D-Bus error starting HiResScroll load: %s", e.message)
+
+    def _on_smartshift_support_loaded(self, proxy, async_result, _user_data):
+        try:
+            supported = proxy.call_finish(async_result)
+        except GLib.Error as e:
+            logger.error("D-Bus error loading SmartShift support: %s", e.message)
+            self._apply_saved_scroll_mode()
+            return
+
+        if not supported or not supported.get_child_value(0).get_boolean():
+            self.mode_selector.set_sensitive(False)
+            self.sensitivity_box.set_visible(False)
+            return
+
+        try:
+            proxy.call(
+                "GetSmartShift", None,
+                Gio.DBusCallFlags.NONE, 2000, None,
+                self._on_smartshift_loaded, None,
+            )
+        except GLib.Error as e:
+            logger.error("D-Bus error starting SmartShift read: %s", e.message)
+            self._apply_saved_scroll_mode()
+
+    def _on_smartshift_loaded(self, proxy, async_result, _user_data):
+        try:
+            result = proxy.call_finish(async_result)
+        except GLib.Error as e:
+            logger.error("D-Bus error loading SmartShift: %s", e.message)
+            self._apply_saved_scroll_mode()
+            return
+
+        if not result:
+            self._apply_saved_scroll_mode()
+            return
+
+        enabled = result.get_child_value(0).get_boolean()
+        device_threshold = result.get_child_value(1).get_byte()
+
+        # Determine mode from device + saved config.
+        saved_mode = config.get("scroll", "mode", default=None)
+        if saved_mode == "freespin":
+            mode = "freespin"
+        elif enabled:
+            mode = "smartshift"
+        else:
+            mode = "ratchet"
+
+        # Convert device threshold to UI percentage.
+        ui_threshold = 100 - int(device_threshold / 2.55)
+        ui_threshold = max(1, min(100, ui_threshold))
+
+        self.mode_selector.set_mode(mode)
+        self.sens_scale.set_value(ui_threshold)
+        self.sensitivity_box.set_visible(mode == "smartshift")
+
+        config.set("scroll", "mode", mode)
+        config.set("scroll", "smartshift_threshold", ui_threshold)
+
+    def _on_hiresscroll_loaded(self, proxy, async_result, _user_data):
+        try:
+            result = proxy.call_finish(async_result)
             if result:
                 hires = result.get_child_value(0).get_boolean()
                 self.smooth_switch.set_active(hires)

--- a/overlay/settings_widgets.py
+++ b/overlay/settings_widgets.py
@@ -17,25 +17,12 @@ from pathlib import Path
 import gi
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
+gi.require_version('GdkPixbuf', '2.0')
 
-from gi.repository import Gtk, Gdk
+from gi.repository import Gtk, Gdk, GdkPixbuf
 
 from i18n import _
 from settings_constants import MOUSE_BUTTONS
-
-
-def _texture_to_pixbuf(texture):
-    """Convert Gdk.Texture to GdkPixbuf for cairo rendering."""
-    try:
-        from gi.repository import GdkPixbuf
-        data = texture.save_to_png_bytes()
-        loader = GdkPixbuf.PixbufLoader.new_with_type('png')
-        loader.write(data.get_data())
-        loader.close()
-        return loader.get_pixbuf()
-    except Exception:
-        logging.debug("_texture_to_pixbuf failed", exc_info=True)
-        return None
 
 
 def _rounded_rect(cr, x, y, w, h, r):
@@ -142,13 +129,13 @@ class MouseVisualization(Gtk.DrawingArea):
             '/usr/share/juhradial/assets/devices/logitechmouse.png',
         ]
 
-        self._cached_pixbuf = None  # Cache pixbuf conversion (expensive)
+        self._cached_pixbuf = None
 
         for path in image_paths:
             if os.path.exists(path):
                 try:
-                    self.mouse_image = Gdk.Texture.new_from_filename(path)
-                    self._cached_pixbuf = _texture_to_pixbuf(self.mouse_image)
+                    self._cached_pixbuf = GdkPixbuf.Pixbuf.new_from_file(path)
+                    self.mouse_image = self._cached_pixbuf
                     break
                 except Exception as e:
                     logging.warning("Failed to load mouse image: %s", e)
@@ -445,8 +432,8 @@ class GenericMouseVisualization(Gtk.DrawingArea):
         for path in image_paths:
             if os.path.exists(path):
                 try:
-                    self.mouse_image = Gdk.Texture.new_from_filename(path)
-                    self._cached_pixbuf = _texture_to_pixbuf(self.mouse_image)
+                    self._cached_pixbuf = GdkPixbuf.Pixbuf.new_from_file(path)
+                    self.mouse_image = self._cached_pixbuf
                 except Exception as e:
                     logging.warning("Failed to load generic mouse image: %s", e)
                 break

--- a/tests/test_settings_startup.py
+++ b/tests/test_settings_startup.py
@@ -1,0 +1,108 @@
+"""Regression contracts for a responsive Settings window startup."""
+
+import ast
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCROLL_PAGE_PATH = REPO_ROOT / "overlay" / "settings_page_scroll.py"
+SETTINGS_DASHBOARD_PATH = REPO_ROOT / "overlay" / "settings_dashboard.py"
+SETTINGS_WIDGETS_PATH = REPO_ROOT / "overlay" / "settings_widgets.py"
+OVERLAY_ACTIONS_PATH = REPO_ROOT / "overlay" / "overlay_actions.py"
+
+
+def _load_device_settings_method() -> ast.FunctionDef:
+    module = ast.parse(SCROLL_PAGE_PATH.read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "ScrollPage":
+            continue
+        for statement in node.body:
+            if isinstance(statement, ast.FunctionDef) and statement.name == "_load_device_settings":
+                return statement
+    raise AssertionError("ScrollPage._load_device_settings must exist")
+
+
+def _settings_window_method(name: str) -> ast.FunctionDef:
+    module = ast.parse(SETTINGS_DASHBOARD_PATH.read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "SettingsWindow":
+            continue
+        for statement in node.body:
+            if isinstance(statement, ast.FunctionDef) and statement.name == name:
+                return statement
+    raise AssertionError(f"SettingsWindow.{name} must exist")
+
+
+def _calls_named(method: ast.FunctionDef, name: str) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == name
+    ]
+
+
+def test_initial_scroll_device_read_does_not_block_the_gtk_main_thread():
+    method = _load_device_settings_method()
+    calls = [
+        node.func.attr
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+    ]
+
+    assert "call_sync" not in calls
+    assert "_get_dbus_proxy" not in calls
+    assert "bus_get" in calls
+
+
+def test_scroll_page_is_created_only_when_the_user_navigates_to_it():
+    initializer = _settings_window_method("_create_pages")
+    navigator = _settings_window_method("_on_nav_clicked")
+
+    assert not _calls_named(initializer, "ScrollPage")
+    assert _calls_named(navigator, "ScrollPage")
+
+
+def test_mouse_visualization_decodes_the_png_only_once():
+    source = SETTINGS_WIDGETS_PATH.read_text(encoding="utf-8")
+
+    assert "Gdk.Texture.new_from_filename" not in source
+    assert "save_to_png_bytes" not in source
+    assert source.count("GdkPixbuf.Pixbuf.new_from_file(path)") == 2
+
+
+def test_flow_dependencies_are_imported_only_on_flow_navigation():
+    module = ast.parse(SETTINGS_DASHBOARD_PATH.read_text(encoding="utf-8"))
+    navigator = _settings_window_method("_on_nav_clicked")
+
+    assert not any(
+        isinstance(node, ast.ImportFrom) and node.module == "settings_page_flow"
+        for node in module.body
+    )
+    assert any(
+        isinstance(node, ast.ImportFrom) and node.module == "settings_page_flow"
+        for node in ast.walk(navigator)
+    )
+
+
+def test_only_kde_plasma_reuses_an_existing_settings_window(monkeypatch):
+    module = ast.parse(OVERLAY_ACTIONS_PATH.read_text(encoding="utf-8"))
+    helper = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_requires_settings_relaunch"
+    )
+    namespace: dict[str, object] = {"os": os}
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), "<helper>", "exec"), namespace)
+    requires_relaunch = cast(Callable[[], bool], namespace["_requires_settings_relaunch"])
+
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
+    assert requires_relaunch() is False
+
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "GNOME")
+    assert requires_relaunch() is True

--- a/tests/test_settings_startup.py
+++ b/tests/test_settings_startup.py
@@ -4,6 +4,7 @@ import ast
 import os
 from collections.abc import Callable
 from pathlib import Path
+from types import MethodType, SimpleNamespace
 from typing import cast
 
 
@@ -102,6 +103,86 @@ def test_initial_scroll_device_reads_never_overwrite_local_edits():
     assert method_calls(initial_apply, "set_value")
 
 
+def test_delayed_smartshift_reply_is_ignored_after_local_edit():
+    config_writes = []
+
+    class FakeConfig:
+        @staticmethod
+        def get(_section, key, default=None):
+            return "smartshift" if key == "mode" else default
+
+        @staticmethod
+        def set(section, key, value):
+            config_writes.append((section, key, value))
+
+    class FakeValue:
+        def __init__(self, value):
+            self.value = value
+
+        def get_boolean(self):
+            return self.value
+
+        def get_byte(self):
+            return self.value
+
+    class FakeResult:
+        def get_child_value(self, index):
+            return FakeValue((True, 64)[index])
+
+    class FakeProxy:
+        @staticmethod
+        def call_finish(_result):
+            return FakeResult()
+
+    class FakeControl:
+        def __init__(self):
+            self.calls = []
+
+        def set_mode(self, value):
+            self.calls.append(("mode", value))
+
+        def set_value(self, value):
+            self.calls.append(("value", value))
+
+        def set_visible(self, value):
+            self.calls.append(("visible", value))
+
+    namespace: dict[str, object] = {
+        "config": FakeConfig(),
+        "GLib": SimpleNamespace(Error=Exception),
+    }
+    method_names = [
+        "_mark_scroll_state_user_edit",
+        "_has_local_scroll_state_edits",
+        "_apply_initial_scroll_state",
+        "_apply_saved_scroll_mode",
+        "_on_smartshift_loaded",
+    ]
+    methods: list[ast.stmt] = [_scroll_page_method(name) for name in method_names]
+    exec(compile(ast.Module(body=methods, type_ignores=[]), "<scroll-page>", "exec"), namespace)
+
+    page = SimpleNamespace(
+        _scroll_state_generation=0,
+        _initial_scroll_state_generation=0,
+        _applying_initial_scroll_state=False,
+        mode_selector=FakeControl(),
+        sens_scale=FakeControl(),
+        sensitivity_box=FakeControl(),
+        smooth_switch=FakeControl(),
+        _update_sens_label=lambda _value: None,
+    )
+    for name in method_names:
+        setattr(page, name, MethodType(cast(Callable, namespace[name]), page))
+
+    page._mark_scroll_state_user_edit()
+    page._on_smartshift_loaded(FakeProxy(), object(), None)
+
+    assert page.mode_selector.calls == []
+    assert page.sens_scale.calls == []
+    assert page.sensitivity_box.calls == []
+    assert config_writes == []
+
+
 def test_scroll_page_is_created_only_when_the_user_navigates_to_it():
     initializer = _settings_window_method("_create_pages")
     navigator = _settings_window_method("_on_nav_clicked")
@@ -148,3 +229,49 @@ def test_only_kde_plasma_reuses_an_existing_settings_window(monkeypatch):
 
     monkeypatch.setenv("XDG_CURRENT_DESKTOP", "GNOME")
     assert requires_relaunch() is True
+
+
+def test_kde_settings_launch_activates_without_process_checks(monkeypatch):
+    module = ast.parse(OVERLAY_ACTIONS_PATH.read_text(encoding="utf-8"))
+    functions: list[ast.stmt] = [
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name in {"_requires_settings_relaunch", "open_settings"}
+    ]
+
+    class FakeSubprocess:
+        DEVNULL = object()
+
+        def __init__(self):
+            self.run_calls = []
+            self.popen_calls = []
+
+        def run(self, *args, **kwargs):
+            self.run_calls.append((args, kwargs))
+            return SimpleNamespace(returncode=0)
+
+        def Popen(self, *args, **kwargs):
+            self.popen_calls.append((args, kwargs))
+
+    fake_subprocess = FakeSubprocess()
+    namespace: dict[str, object] = {
+        "__file__": str(OVERLAY_ACTIONS_PATH),
+        "os": os,
+        "subprocess": fake_subprocess,
+    }
+    exec(compile(ast.Module(body=functions, type_ignores=[]), "<overlay-actions>", "exec"), namespace)
+    open_settings = cast(Callable[[], None], namespace["open_settings"])
+
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
+    open_settings()
+
+    assert fake_subprocess.run_calls == []
+    assert len(fake_subprocess.popen_calls) == 1
+    popen_args, popen_kwargs = fake_subprocess.popen_calls[0]
+    assert popen_args[0][0] == "python3"
+    assert popen_args[0][1].endswith("settings_dashboard.py")
+    assert popen_kwargs == {
+        "stdout": fake_subprocess.DEVNULL,
+        "stderr": fake_subprocess.DEVNULL,
+    }

--- a/tests/test_settings_startup.py
+++ b/tests/test_settings_startup.py
@@ -14,15 +14,19 @@ SETTINGS_WIDGETS_PATH = REPO_ROOT / "overlay" / "settings_widgets.py"
 OVERLAY_ACTIONS_PATH = REPO_ROOT / "overlay" / "overlay_actions.py"
 
 
-def _load_device_settings_method() -> ast.FunctionDef:
+def _scroll_page_method(name: str) -> ast.FunctionDef:
     module = ast.parse(SCROLL_PAGE_PATH.read_text(encoding="utf-8"))
     for node in module.body:
         if not isinstance(node, ast.ClassDef) or node.name != "ScrollPage":
             continue
         for statement in node.body:
-            if isinstance(statement, ast.FunctionDef) and statement.name == "_load_device_settings":
+            if isinstance(statement, ast.FunctionDef) and statement.name == name:
                 return statement
-    raise AssertionError("ScrollPage._load_device_settings must exist")
+    raise AssertionError(f"ScrollPage.{name} must exist")
+
+
+def _load_device_settings_method() -> ast.FunctionDef:
+    return _scroll_page_method("_load_device_settings")
 
 
 def _settings_window_method(name: str) -> ast.FunctionDef:
@@ -58,6 +62,44 @@ def test_initial_scroll_device_read_does_not_block_the_gtk_main_thread():
     assert "call_sync" not in calls
     assert "_get_dbus_proxy" not in calls
     assert "bus_get" in calls
+
+
+def test_initial_scroll_device_reads_never_overwrite_local_edits():
+    initial_load = _load_device_settings_method()
+    initial_apply = _scroll_page_method("_apply_initial_scroll_state")
+    saved_mode = _scroll_page_method("_apply_saved_scroll_mode")
+    handlers = [
+        _scroll_page_method("_on_smartshift_support_loaded"),
+        _scroll_page_method("_on_smartshift_loaded"),
+        _scroll_page_method("_on_hiresscroll_loaded"),
+    ]
+    local_edit_handlers = [
+        _scroll_page_method("_on_mode_changed"),
+        _scroll_page_method("_on_sensitivity_changed"),
+        _scroll_page_method("_on_smooth_changed"),
+    ]
+
+    def method_calls(method: ast.FunctionDef, name: str) -> bool:
+        return any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == name
+            for node in ast.walk(method)
+        )
+
+    assert any(
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Attribute)
+            and target.attr == "_initial_scroll_state_generation"
+            for target in node.targets
+        )
+        for node in ast.walk(initial_load)
+    )
+    assert all(method_calls(handler, "_has_local_scroll_state_edits") for handler in handlers)
+    assert all(method_calls(handler, "_mark_scroll_state_user_edit") for handler in local_edit_handlers)
+    assert method_calls(saved_mode, "_has_local_scroll_state_edits")
+    assert method_calls(initial_apply, "set_value")
 
 
 def test_scroll_page_is_created_only_when_the_user_navigates_to_it():

--- a/tests/test_startup_latency.py
+++ b/tests/test_startup_latency.py
@@ -1,0 +1,32 @@
+"""Regression contracts for user-visible startup latency."""
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OVERLAY_PATH = REPO_ROOT / "overlay" / "juhradial-overlay.py"
+
+
+def _splash_min_display_ms() -> int:
+    module = ast.parse(OVERLAY_PATH.read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "SplashScreen":
+            continue
+        for statement in node.body:
+            if (
+                isinstance(statement, ast.Assign)
+                and any(
+                    isinstance(target, ast.Name)
+                    and target.id == "MIN_DISPLAY_MS"
+                    for target in statement.targets
+                )
+                and isinstance(statement.value, ast.Constant)
+                and isinstance(statement.value.value, int)
+            ):
+                return statement.value.value
+    raise AssertionError("SplashScreen.MIN_DISPLAY_MS must be an integer constant")
+
+
+def test_splash_does_not_mask_a_ready_application_for_two_seconds():
+    assert _splash_min_display_ms() <= 350


### PR DESCRIPTION
## Description

Reduces cold-start work in the daemon and Settings UI, avoids rebuilding an already-open Settings window from the KDE Plasma tray menu, and preserves local Settings edits while initial asynchronous device reads finish.

## Related Issue

Fixes #65

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement

## Changes Made

- Batch configured macro/remapped HID++ button diverts behind one additional REPROG_CONTROLS_V4 table scan instead of rescanning per CID; the existing built-in gesture scan and reconnect/reapply behavior remain unchanged.
- Reduce the overlay splash minimum from 2 seconds to 250 ms and add monotonic daemon startup-phase telemetry.
- Defer Point & Scroll construction and Flow imports until navigation; load SmartShift and HiResScroll state through asynchronous D-Bus calls.
- Guard the initial asynchronous scroll-state reads with a local-edit generation, so delayed replies cannot revert a mode, threshold, or Smooth Scrolling choice made in the window.
- Decode mouse PNG assets directly to `GdkPixbuf` instead of serializing and decoding PNG a second time.
- On KDE Plasma, reuse the existing single-instance Settings window from the tray menu rather than killing and rebuilding it. Other desktops retain the established relaunch path.
- Add regression coverage for splash timing, Settings startup, lazy imports/pages, non-blocking D-Bus reads, delayed-reply preservation of local edits, direct image decoding, KDE tray activation, and mocked HID++ batch transport behavior.

## How Has This Been Tested?

- [x] Tested on KDE Plasma 6 with Wayland
- [ ] Tested with MX Master 4
- [ ] Ran `make test` (the repository has no `test` target)
- [x] Ran `cargo clippy` (no warnings)

**Test Configuration:**
- Linux Distribution: CachyOS, kernel `7.1.3-2-cachyos`
- Desktop Environment: KDE Plasma `6.7.2`, Wayland
- Mouse Model: MX Master 4 connected; read-only D-Bus capabilities verified. Physical gesture/macro reconnect and Easy-Switch verification remains manual.

Commands run:

```text
python3 -m pytest tests -q                # 28 passed
python3 -m compileall -q overlay
make build
cd daemon && cargo test                  # 283 passed, 3 ignored (including doctests)
cd daemon && cargo clippy --lib --bin juhradiald --tests -- -D warnings
```

Manual runtime verification on KDE Plasma:

- First Settings frame rendered in 370.7 ms in the active session probe.
- Reopening an existing Settings window through the KDE tray path returned in 0.3 ms and preserved the process PID.
- Mocked HID++ transport verifies one `getCount`, one `getCidInfo` per control, response failures, deduplicated input, and returning only successfully diverted CIDs.

`cargo fmt --check` is currently red on unchanged `upstream/master`; the same command fails in a clean worktree at `e777ce8`, so this PR does not add formatting drift.

## Screenshots (if applicable)

No visual design change. The initial Buttons page was smoke-tested after the lazy-loading changes.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: internal behavior only)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published