### PR TITLE
fix: GNOME cursor placement, menu close, single-instance overlay, screenshot portal, thumb wheel (v0.4.1)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,8 +6,9 @@ We release patches for security vulnerabilities for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.0-beta | :white_check_mark: Current release |
-| 0.2.9   | :white_check_mark: |
+| 0.4.1   | :white_check_mark: Current release |
+| 0.4.0   | :white_check_mark: |
+| 0.3.x   | :white_check_mark: |
 | 0.2.x   | :white_check_mark: |
 | 0.1.x   | :x: Upgrade required (critical security fixes in 0.2.1+) |
 | < 0.1   | :x:                |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to JuhRadial MX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-07-21
+
+### Added
+
+- **GNOME Shell 50 support** - The bundled GNOME cursor helper extension now declares compatibility with GNOME Shell 50.
+
+### Fixed
+
+- **Radial menu opens at the cursor on GNOME Wayland** - XWayland only refreshes its pointer while the cursor sits over an X11 window, so on an all-Wayland GNOME desktop the overlay positioned itself from a stale reading. It now forces a refresh and reads the result in Qt's coordinate space, so the menu stays on the cursor on scaled displays too.
+- **A second tap closes the menu again** - The daemon emits its open signal twice for a single press, and the duplicate reopened the menu that had just closed.
+- **Only one overlay runs at a time** - On KDE, session restore and the launcher could each start an overlay, and the two fought over the menu, leaving the gesture button unresponsive. Fixes [#60](https://github.com/JuhLabs/juhradial-mx/issues/60).
+- **Thumb-wheel assignments take effect** - The Buttons tab wrote the setting to a key the daemon does not read, so the wheel kept its previous mode, for example staying on zoom after being set to horizontal scroll.
+- **Screenshot action picks a tool that works** - It defaulted to spectacle, which cannot capture outside KDE; GNOME and other portal desktops now use the freedesktop screenshot portal.
+
 ## [0.4.0] - 2026-06-28
 
 ### Added
@@ -322,6 +336,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Native Wayland** - Full support for KDE Plasma 6 and Hyprland
 - Support for MX Master 4, MX Master 3S, and MX Master 3
 
+[0.4.1]: https://github.com/JuhLabs/juhradial-mx/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/JuhLabs/juhradial-mx/compare/v0.3.2-beta...v0.4.0
+[0.3.2-beta]: https://github.com/JuhLabs/juhradial-mx/compare/v0.3.1-beta...v0.3.2-beta
 [0.3.1-beta]: https://github.com/JuhLabs/juhradial-mx/compare/v0.3.0-beta...v0.3.1-beta
 [0.3.0-beta]: https://github.com/JuhLabs/juhradial-mx/compare/v0.2.9...v0.3.0-beta
 [0.2.6]: https://github.com/JuhLabs/juhradial-mx/compare/v0.2.5...v0.2.6

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
   <p>
     <a href="https://github.com/JuhLabs/juhradial-mx/releases">
-      <img src="https://img.shields.io/badge/version-0.4.0-cyan.svg" alt="Version 0.4.0">
+      <img src="https://img.shields.io/badge/version-0.4.1-cyan.svg" alt="Version 0.4.1">
     </a>
     <a href="https://juhlabs.github.io/juhradial-mx/">
       <img src="https://img.shields.io/badge/docs-juhlabs.github.io-4FEFC9.svg" alt="Documentation">
@@ -44,7 +44,7 @@
 <br>
 
 > [!TIP]
-> **New in [v0.4.0](CHANGELOG.md):** Thumb-wheel actions (volume, zoom, horizontal scroll), per-application profiles that switch DPI/buttons/scroll on focus, portable system actions on any button, live device state, and a settings search box. Plus reliable Wayland action injection via uinput and fixes for fractional-scaling menu position (#25), button reassignments (#26), and building on Ubuntu 24.04 (#23) and openSUSE Tumbleweed (#24). [Update now](#installation).
+> **New in [v0.4.1](CHANGELOG.md):** The radial menu now opens on the cursor on GNOME Wayland, a second tap closes it again, only one overlay runs at a time (#60), thumb-wheel assignments in the Buttons tab take effect, and the screenshot action picks a tool that works on your desktop. [Update now](#installation).
 >
 > **Documentation:** Full guides, configuration reference, and per-compositor notes are at **[juhlabs.github.io/juhradial-mx](https://juhlabs.github.io/juhradial-mx/)**.
 >

--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "juhradiald"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "criterion",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juhradiald"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "JuhRadial MX daemon - Radial menu for Logitech MX Master 4 on Linux"
 license = "GPL-3.0"

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,9 +29,9 @@ The installer detects your distro, installs dependencies, builds from source, an
 | [Architecture](architecture.md) | How it works, for contributors |
 | [FAQ](faq.md) | Quick answers to common questions |
 
-## What is new in v0.4.0
+## What is new in v0.4.1
 
-Thumb-wheel actions (volume, zoom, horizontal scroll), per-application profiles that switch DPI, buttons, and scroll on focus, portable system actions on any button, live device state, and a settings search box. See the [Changelog](https://github.com/JuhLabs/juhradial-mx/blob/master/CHANGELOG.md).
+The radial menu now opens on the cursor on GNOME Wayland, a second tap closes it again, only one overlay runs at a time, thumb-wheel assignments in the Buttons tab take effect, and the screenshot action picks a tool that works on the desktop you are running. See the [Changelog](https://github.com/JuhLabs/juhradial-mx/blob/master/CHANGELOG.md).
 
 ## A look at it
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
           # Rust daemon - handles evdev input and D-Bus signaling
           juhradiald = pkgs.rustPlatform.buildRustPackage {
             pname = "juhradiald";
-            version = "0.3.0-beta";
+            version = "0.4.1";
 
             src = ./.;
             cargoRoot = "daemon";
@@ -60,7 +60,7 @@
 
           default = pkgs.stdenv.mkDerivation {
             pname = "juhradial-mx";
-            version = "0.3.0-beta";
+            version = "0.4.1";
             src = ./.;
 
             nativeBuildInputs = with pkgs; [

--- a/gnome-extension/juhradial-cursor@dev.juhlabs.com/metadata.json
+++ b/gnome-extension/juhradial-cursor@dev.juhlabs.com/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "juhradial-cursor@dev.juhlabs.com",
     "name": "JuhRadial Cursor Helper",
     "description": "Exposes cursor position via D-Bus for JuhRadial MX radial menu",
-    "shell-version": ["45", "46", "47", "48", "49"],
+    "shell-version": ["45", "46", "47", "48", "49", "50"],
     "url": "https://github.com/JuhLabs/juhradial-mx",
     "version": 1
 }

--- a/overlay/juhradial-overlay.py
+++ b/overlay/juhradial-overlay.py
@@ -465,6 +465,9 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
 
         # Toggle mode: True when menu was opened with a quick tap and stays open
         self.toggle_mode = False
+        # Timestamp of the last close; used to debounce the daemon's duplicate
+        # MenuRequested emission (see on_show).
+        self._menu_closed_at = 0.0
         # Track when menu was shown (for tap detection)
         self.show_time = None
 
@@ -583,6 +586,27 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
     def on_show(self, x, y):
         import time
 
+        # The daemon emits MenuRequested twice per gesture press (~130us apart:
+        # once from the hidraw handler, once from the gesture-event loop).
+        # Debounce the duplicate in both directions: right after a close it
+        # would reopen the menu the toggle-close branch just closed (so a second
+        # tap never closes), and right after a fresh open it would re-run the
+        # full cursor sync + show. 30ms is orders of magnitude above the
+        # duplicate spacing but well under real inter-press gaps (fastest
+        # observed on-device: ~117ms), so a fast second-tap-close or a rapid
+        # re-open is never swallowed.
+        now = time.time()
+        if now - getattr(self, "_menu_closed_at", 0.0) < 0.03:
+            print("OVERLAY: duplicate MenuRequested after close - ignored")
+            return
+        if (
+            self.isVisible()
+            and getattr(self, "show_time", None)
+            and now - self.show_time < 0.03
+        ):
+            print("OVERLAY: duplicate MenuRequested while fresh - ignored")
+            return
+
         # Reload translations for language changes
         from i18n import setup_i18n
 
@@ -601,6 +625,7 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
         if self.toggle_mode and self.isVisible():
             print("OVERLAY: Second tap detected - closing menu")
             self._close_menu(execute=False)
+            self._menu_closed_at = now
             return
 
         # On Hyprland, re-query cursor position and monitor info for freshness
@@ -612,22 +637,36 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
                 x, y = fresh_pos
                 print(f"OVERLAY: Hyprland fresh cursor position: ({x}, {y})")
 
-        # On GNOME Wayland, use QCursor.pos() for positioning because the
-        # GNOME extension returns Clutter logical coords which differ from
-        # XWayland coords on HiDPI monitors (e.g., 4K at 200% scaling).
-        # QCursor.pos() is in Qt/XWayland space, matching self.move().
-        # Fall back to GNOME extension if QCursor returns (0,0) - which
-        # happens when no XWayland window is currently visible.
+        # On GNOME Wayland, Mutter's XWayland only refreshes the X pointer
+        # while the cursor is over an X11 surface, so on an all-Wayland
+        # desktop QCursor.pos() returns a plausible-looking stale position.
+        # Use the COSMIC/niri sync window purely to force that refresh, then
+        # read the position through QCursor.pos(): it reflects the same
+        # now-fresh XWayland pointer but in Qt logical space, which is what
+        # self.move() expects (raw XQueryPointer pixels overshoot when Qt's
+        # devicePixelRatio != 1, e.g. 4K at 200%). The raw sync reading is
+        # kept as fallback, and the GNOME extension after that (Clutter
+        # logical coords; may also differ from Qt space on HiDPI).
         if IS_GNOME:
-            fresh_pos = get_cursor_position_qt()
-            if fresh_pos:
-                x, y = fresh_pos
-                print(f"OVERLAY: GNOME QCursor position: ({x}, {y})")
-            else:
-                fresh_pos = get_cursor_position_gnome()
+            fresh_pos = None
+            if not IS_X11 and _HAS_XWAYLAND:
+                fresh_pos = get_cursor_position_xwayland_synced()
+                if fresh_pos:
+                    qt_pos = get_cursor_position_qt()
+                    if qt_pos:
+                        fresh_pos = qt_pos
+                    x, y = fresh_pos
+                    _log(f"GNOME sync: using position ({x}, {y})")
+            if not fresh_pos:
+                fresh_pos = get_cursor_position_qt()
                 if fresh_pos:
                     x, y = fresh_pos
-                    print(f"OVERLAY: GNOME extension fallback: ({x}, {y})")
+                    print(f"OVERLAY: GNOME QCursor position: ({x}, {y})")
+                else:
+                    fresh_pos = get_cursor_position_gnome()
+                    if fresh_pos:
+                        x, y = fresh_pos
+                        print(f"OVERLAY: GNOME extension fallback: ({x}, {y})")
 
         # On KDE X11, use QCursor.pos() - it's in Qt's own coordinate space.
         if IS_KDE and IS_X11:
@@ -1079,6 +1118,10 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             print(f"OVERLAY: COSMIC reposition to ({x}, {y})")
 
     def _close_menu(self, execute=True):
+        import time
+        # Record the close time so on_show can debounce the daemon's duplicate
+        # MenuRequested on every close path, not just the toggle-close branch.
+        self._menu_closed_at = time.time()
         self.cursor_timer.stop()
         self.toggle_mode = False  # Reset toggle mode
 
@@ -1518,6 +1561,25 @@ if __name__ == "__main__":
     app.setQuitOnLastWindowClosed(False)
     app.setApplicationName("JuhRadial MX")
     app.setDesktopFileName("juhradial-mx")
+
+    # Single-instance guard: a session-restored duplicate (issue #60) or a
+    # double launch would both subscribe to MenuRequested and fight over
+    # showing and grabbing the menu, breaking the gesture UX. Own a well-known
+    # D-Bus name; if another overlay already holds it, exit fast before any
+    # heavy loading. Mirrors the settings app (issue #65).
+    bus = QDBusConnection.sessionBus()
+    if not bus.isConnected():
+        print(
+            "session D-Bus unavailable - overlay cannot receive daemon signals, exiting",
+            flush=True,
+        )
+        sys.exit(1)
+    if not bus.registerService("org.kde.juhradialmx.overlay"):
+        print(
+            "another overlay instance owns org.kde.juhradialmx.overlay - exiting",
+            flush=True,
+        )
+        sys.exit(0)
 
     # Show splash screen immediately (before heavy loading)
     splash = SplashScreen()

--- a/overlay/locales/juhradial.pot
+++ b/overlay/locales/juhradial.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: JuhRadial MX 0.2.12\n"
+"Project-Id-Version: JuhRadial MX 0.4.1\n"
 "Report-Msgid-Bugs-To: https://github.com/JuhLabs/juhradial-mx/issues\n"
 "POT-Creation-Date: 2026-03-04 11:35+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/overlay/overlay_actions.py
+++ b/overlay/overlay_actions.py
@@ -157,6 +157,59 @@ ICON_NAME_MAP = {
 # CONFIG LOADING
 # =============================================================================
 
+# Interactive screenshot via org.freedesktop.portal.Screenshot. Desktop-agnostic
+# and the only reliable path on GNOME 42+, where the private Shell screenshot API
+# is not exposed to third-party callers. The portal Screenshot call is async: it
+# returns a Request handle and the result arrives on that Request's Response
+# signal, and xdg-desktop-portal cancels the pending Request the moment the
+# caller's bus connection drops. A one-shot `gdbus call` therefore dismisses the
+# interactive picker as soon as gdbus exits, so route through portal_screenshot.py,
+# which holds its bus connection open on a GLib main loop until Response arrives.
+# Stored as an exec string so the overlay's existing shlex.split + Popen dispatch
+# runs it unchanged; the helper path is resolved next to this module so it works
+# from both a dev checkout and /usr/share/juhradial.
+_PORTAL_SCREENSHOT_CMD = (
+    "python3 " + os.path.join(os.path.dirname(__file__), "portal_screenshot.py")
+)
+
+
+def resolve_screenshot_command(configured_cmd: str) -> str:
+    """Return a screenshot exec command suited to the current desktop.
+
+    KDE keeps its configured command (spectacle). Elsewhere a command whose
+    binary is not installed is replaced, and spectacle is additionally replaced
+    on Wayland sessions (it can capture there only through KDE's own portal
+    backend, so an installed spectacle still works on X11 and is kept there):
+    COSMIC keeps cosmic-screenshot; every other portal desktop (GNOME included)
+    uses the freedesktop Screenshot portal via portal_screenshot.py, with
+    flameshot as a last resort. Any other configured command whose binary
+    exists is left untouched so a user's own choice is preserved.
+    """
+    import importlib.util
+    import shutil
+
+    desktop = os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
+    if "kde" in desktop or "plasma" in desktop:
+        return configured_cmd
+
+    wayland = os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland"
+    parts = configured_cmd.split()
+    base = parts[0] if parts else ""
+    mismatched = (base == "spectacle" and wayland) or (
+        base and shutil.which(base) is None
+    )
+    if not mismatched:
+        return configured_cmd
+
+    if "cosmic" in desktop and shutil.which("cosmic-screenshot"):
+        return "cosmic-screenshot"
+    # The helper needs PyGObject, not gdbus; gate on what it actually imports.
+    if importlib.util.find_spec("gi") is not None:
+        return _PORTAL_SCREENSHOT_CMD
+    if shutil.which("flameshot"):
+        return "flameshot gui"
+    return configured_cmd
+
 
 def load_actions_from_config():
     """Load radial menu actions from config file"""
@@ -199,6 +252,8 @@ def load_actions_from_config():
                 label = settings_constants.translate_radial_label(label, action_id)
                 action_type = slice_data.get("type", "exec")
                 command = slice_data.get("command", "")
+                if action_id == "screenshot" and action_type == "exec":
+                    command = resolve_screenshot_command(command)
                 color = slice_data.get("color", "teal")
                 gtk_icon = slice_data.get("icon", "application-x-executable-symbolic")
 

--- a/overlay/portal_screenshot.py
+++ b/overlay/portal_screenshot.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+JuhRadial MX - Interactive screenshot via the freedesktop Screenshot portal.
+
+Standalone helper spawned by the overlay's screenshot action. The portal
+Screenshot call is asynchronous: it returns a Request handle and the result
+(the screenshot uri) arrives later on that Request's Response signal. The
+portal also cancels the pending Request the instant the caller's D-Bus
+connection drops, so a one-shot `gdbus call` dismisses the interactive picker
+the moment gdbus exits. This helper holds its bus connection open on a GLib
+main loop until Response arrives, so the picker stays up for the user.
+
+Prints the screenshot uri to stdout and exits 0 on success; exits 0 silently
+if the user cancels; exits 1 on error or after a 300s timeout.
+
+SPDX-License-Identifier: GPL-3.0
+"""
+
+import sys
+import secrets
+
+try:
+    from gi.repository import Gio, GLib
+except ImportError as exc:
+    sys.stderr.write(
+        "portal_screenshot: python gobject introspection (gi) is required "
+        f"but is not available: {exc}\n"
+    )
+    sys.exit(1)
+
+
+PORTAL_NAME = "org.freedesktop.portal.Desktop"
+PORTAL_PATH = "/org/freedesktop/portal/desktop"
+SCREENSHOT_IFACE = "org.freedesktop.portal.Screenshot"
+REQUEST_IFACE = "org.freedesktop.portal.Request"
+TIMEOUT_SECONDS = 300
+
+
+def main():
+    try:
+        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+    except GLib.Error as exc:
+        sys.stderr.write(
+            f"portal_screenshot: cannot connect to session bus: {exc}\n"
+        )
+        return 1
+
+    # handle_token must be a valid object path element ([A-Za-z0-9_]); a random
+    # hex suffix keeps it unique and non-guessable, per the portal spec.
+    token = "juhradial_" + secrets.token_hex(8)
+
+    # Expected Request object path (portal spec, since xdg-desktop-portal 0.9):
+    # /org/freedesktop/portal/desktop/request/<SENDER>/<TOKEN>, where SENDER is
+    # our unique bus name with the leading ':' stripped and every '.' -> '_'.
+    sender = bus.get_unique_name()[1:].replace(".", "_")
+    request_path = f"/org/freedesktop/portal/desktop/request/{sender}/{token}"
+
+    loop = GLib.MainLoop()
+    state = {"code": 1}
+
+    def on_response(_conn, _sender, _path, _iface, _signal, params, *_user):
+        response, results = params.unpack()
+        if response == 0:
+            uri = results.get("uri", "")
+            if uri:
+                print(uri)
+        # response 1 = user cancelled, 2 = ended another way: nothing to
+        # capture, but the helper itself succeeded, so exit 0 silently.
+        state["code"] = 0
+        loop.quit()
+
+    # Subscribe to Response BEFORE calling Screenshot: the spec requires this so
+    # the portal cannot reply before we are listening (the race this helper is
+    # here to avoid).
+    sub_id = bus.signal_subscribe(
+        PORTAL_NAME, REQUEST_IFACE, "Response", request_path, None,
+        Gio.DBusSignalFlags.NONE, on_response,
+    )
+
+    options = {
+        "handle_token": GLib.Variant("s", token),
+        "interactive": GLib.Variant("b", True),
+    }
+    try:
+        reply = bus.call_sync(
+            PORTAL_NAME, PORTAL_PATH, SCREENSHOT_IFACE, "Screenshot",
+            GLib.Variant("(sa{sv})", ("", options)),
+            GLib.VariantType.new("(o)"),
+            Gio.DBusCallFlags.NONE, -1, None,
+        )
+    except GLib.Error as exc:
+        sys.stderr.write(f"portal_screenshot: Screenshot call failed: {exc}\n")
+        bus.signal_unsubscribe(sub_id)
+        return 1
+
+    # Older portals may return a different handle than we precomputed; if so,
+    # move the subscription onto the returned path (spec-recommended fallback).
+    handle = reply.unpack()[0]
+    if handle != request_path:
+        bus.signal_unsubscribe(sub_id)
+        bus.signal_subscribe(
+            PORTAL_NAME, REQUEST_IFACE, "Response", handle, None,
+            Gio.DBusSignalFlags.NONE, on_response,
+        )
+
+    def on_timeout():
+        sys.stderr.write(
+            "portal_screenshot: timed out waiting for the portal response\n"
+        )
+        state["code"] = 1
+        loop.quit()
+        return GLib.SOURCE_REMOVE
+
+    GLib.timeout_add_seconds(TIMEOUT_SECONDS, on_timeout)
+    loop.run()
+    return state["code"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/settings_dialog_button.py
+++ b/overlay/settings_dialog_button.py
@@ -75,6 +75,19 @@ _ACTION_GROUPS = [
     ]),
 ]
 
+# The thumb wheel (horizontal_scroll) is a rotational control the daemon drives
+# from config.thumbwheel.mode; only these actions map onto a wheel mode (see
+# _on_save's mirror). Its dialog is restricted to this set so users cannot pick
+# an action the wheel cannot honor.
+_THUMBWHEEL_ACTIONS = {
+    "scroll_left_right",
+    "zoom_in",
+    "zoom_out",
+    "volume_up",
+    "volume_down",
+    "none",
+}
+
 # Icon names for the DE-portable preset actions (freedesktop symbolic names).
 # Only the preset rows carry a prefix icon; other rows are left unchanged.
 _ACTION_ICONS = {
@@ -193,6 +206,13 @@ class ButtonConfigDialog(Adw.Window):
             group_actions = [
                 (aid, action_map[aid]) for aid in action_ids if aid in action_map
             ]
+            # The thumb wheel can only honor a rotational subset of actions.
+            if self.button_id == "horizontal_scroll":
+                group_actions = [
+                    (aid, aname)
+                    for aid, aname in group_actions
+                    if aid in _THUMBWHEEL_ACTIONS
+                ]
             if not group_actions:
                 continue
 
@@ -276,6 +296,24 @@ class ButtonConfigDialog(Adw.Window):
             buttons_config = config.get("buttons", default={})
             buttons_config[self.button_id] = action_id
             config.set("buttons", buttons_config)
+
+            # The thumb wheel (horizontal_scroll) is a rotational control the
+            # daemon drives from config.thumbwheel.mode, not from
+            # buttons.horizontal_scroll (which it never reads). Mirror the choice
+            # into thumbwheel.mode so assigning it here actually takes effect
+            # instead of leaving the wheel on its previous mode (e.g. zoom).
+            if self.button_id == "horizontal_scroll":
+                tw_mode = {
+                    "scroll_left_right": "scroll",
+                    "zoom_in": "zoom",
+                    "zoom_out": "zoom",
+                    "volume_up": "volume",
+                    "volume_down": "volume",
+                    "none": "off",
+                }.get(action_id)
+                if tw_mode is not None:
+                    config.set("thumbwheel", "mode", tw_mode)
+
             config.save()
 
             logger.info("Button %s configured to: %s", self.button_id, action_name)

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -2,7 +2,7 @@
 # Arch Linux PKGBUILD for JuhRadial MX
 
 pkgname=juhradial-mx
-pkgver=0.2.5
+pkgver=0.4.1
 pkgrel=1
 pkgdesc="Beautiful radial menu for Logitech MX Master mice on Linux"
 arch=('x86_64')

--- a/packaging/org.juhlabs.JuhRadialMX.metainfo.xml
+++ b/packaging/org.juhlabs.JuhRadialMX.metainfo.xml
@@ -93,6 +93,31 @@
   </keywords>
 
   <releases>
+    <release version="0.4.1" date="2026-07-21">
+      <description>
+        <p>Cursor placement on GNOME Wayland, menu dismissal, and action fixes</p>
+        <ul>
+          <li>Radial menu opens at the cursor on GNOME Wayland, including scaled displays</li>
+          <li>A second tap closes the menu again instead of reopening it</li>
+          <li>Only one overlay instance runs at a time, so the gesture button stays responsive</li>
+          <li>Thumb-wheel assignments made in the Buttons tab now take effect</li>
+          <li>Screenshot action picks a capture tool that works on the running desktop</li>
+          <li>GNOME cursor helper extension supports GNOME Shell 50</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.4.0" date="2026-06-28">
+      <description>
+        <p>Thumb-wheel actions, per-application profiles, and portable system actions</p>
+        <ul>
+          <li>Bind the thumb-wheel to volume, zoom, or horizontal scroll</li>
+          <li>DPI, button, and scroll settings switch automatically per application</li>
+          <li>Portable system actions use the native mechanism for each desktop</li>
+          <li>Live battery, DPI, ratchet, and Easy-Switch state on the Devices page</li>
+          <li>Correct menu position under fractional scaling, and niri support</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.2.8" date="2026-02-14">
       <description>
         <p>Automatic logid restart on Easy-Switch device reconnect</p>

--- a/packaging/rpm/juhradial-mx.spec
+++ b/packaging/rpm/juhradial-mx.spec
@@ -2,7 +2,7 @@
 # Build: rpmbuild -ba juhradial-mx.spec
 
 Name:           juhradial-mx
-Version:        0.2.5
+Version:        0.4.1
 Release:        1%{?dist}
 Summary:        Beautiful radial menu for Logitech MX Master mice on Linux
 
@@ -119,6 +119,14 @@ install -Dm644 packaging/udev/99-logitech-hidpp.rules %{buildroot}%{_udevrulesdi
 %{_userunitdir}/juhradialmx-daemon.service
 %{_udevrulesdir}/99-logitech-hidpp.rules
 %changelog
+* Tue Jul 21 2026 Julian Hermstad <dev@juhlabs.com> - 0.4.1-1
+- Radial menu opens at the cursor on GNOME Wayland
+- Second tap closes the menu again
+- Only one overlay instance runs at a time
+- Thumb-wheel assignments from the Buttons tab take effect
+- Screenshot action picks a tool that works on the running desktop
+- GNOME cursor helper extension supports GNOME Shell 50
+
 * Fri Dec 13 2024 JuhLabs (Julian Hermstad) <juhlabs@example.com> - 1.0.0-1
 - Initial release
 - Glassmorphic radial menu overlay


### PR DESCRIPTION
Release wave for v0.4.1. Five commits, all user-reported bugs plus the version bump.

## Overlay: cursor position, menu close, single instance

Refs #60.

- **GNOME Wayland placement.** Mutter's XWayland only refreshes the X pointer while the cursor sits over an X11 surface, so on an all-Wayland desktop `QCursor.pos()` returned a plausible but frozen coordinate and the menu opened in the wrong place. The GNOME branch now forces a refresh through the same raw X11 sync window COSMIC and niri already use, then reads back through `QCursor.pos()` so the value stays in Qt logical space. Reading the raw XQueryPointer pixels directly overshoots when `devicePixelRatio != 1` (4K at 200% for example). Raw reading and the Shell extension remain as fallbacks.
- **Second tap did not close the menu.** The daemon emits `MenuRequested` twice per gesture press, roughly 130us apart. The duplicate reopened the menu the toggle-close branch had just closed. A 30ms debounce absorbs it. Fastest inter-press gap measured on hardware is 117ms, so real taps are never swallowed. Side effect: this halves the work on the open path for GNOME, COSMIC and niri.
- **Two overlays at once.** On KDE, session restore brings back a saved overlay while the launcher starts its own; the launcher's pgrep check loses the race at login. Both then subscribed to the same daemon signal and fought over the menu, which made the gesture button look dead. The overlay now claims `org.kde.juhradialmx.overlay` on the session bus as a single instance lock and a second copy exits before it loads anything. An unavailable session bus exits with a distinct message and status.
- GNOME Shell 50 declared in the bundled cursor helper extension.

Verified on Plasma Wayland: a second launch exits 0, including with the `-session <id> -name juhradial-overlay.py` argv KDE session restore uses; ten simultaneous launches leave exactly one survivor; the name is released on both clean exit and SIGKILL, so there is no lockout.

## Screenshot action is now desktop-aware

KDE keeps spectacle. GNOME and others go through the freedesktop screenshot portal, with a helper that keeps the request alive until the user finishes the selection, since GNOME 42+ removed third-party access to the Shell screenshot API. flameshot stays as a last resort.

## Thumb wheel assignments take effect

Assigning the thumb wheel in the Buttons tab wrote to a config key the daemon never read, so the wheel kept its previous mode. The dialog now also offers only the actions a rotational wheel can perform.

## Tests

283 daemon tests (275 unit + 8 integration) and 33 Python tests pass locally.
