### PR TITLE
deps: update crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
`cargo audit` flagged `crossbeam-epoch 0.9.18` (RUSTSEC-2026-0204), fixed in 0.9.20.

The crate reaches the tree only through `criterion`, a **dev-dependency** used for benchmarks, so the advisory never affected the shipped `juhradiald` binary. Updating anyway to keep `cargo audit` clean and close the Scorecard Vulnerabilities finding.

Dependency path: `crossbeam-epoch -> crossbeam-deque -> rayon-core -> rayon -> criterion -> juhradiald`

`cargo audit` now exits 0. 283 daemon tests and 33 Python tests pass.

Not included: the CodeQL `py/unused-global-variable` note on `overlay/overlay_cursor.py:217` is a false positive. The global `_kde_monitors_ts` is read on line 215 of the following call; the write on 217 is what advances the cache TTL. Removing it would make `kscreen-doctor` spawn on every menu open. Dismissed in the security tab rather than 'fixed'.