### PR TITLE
perf: stop battery warmup polling after first success

### DIFF
--- a/daemon/src/battery.rs
+++ b/daemon/src/battery.rs
@@ -441,6 +441,27 @@ impl std::fmt::Display for BatteryError {
 
 impl std::error::Error for BatteryError {}
 
+const BATTERY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+const BATTERY_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[derive(Default)]
+struct BatteryPollCadence {
+    has_successful_sample: bool,
+}
+
+impl BatteryPollCadence {
+    fn record_query_result(&mut self, succeeded: bool) {
+        self.has_successful_sample |= succeeded;
+    }
+
+    fn next_interval(&self) -> std::time::Duration {
+        if self.has_successful_sample {
+            BATTERY_POLL_INTERVAL
+        } else {
+            BATTERY_RETRY_INTERVAL
+        }
+    }
+}
 
 /// Start a periodic battery update task (legacy - uses its own hidraw handle)
 #[deprecated(note = "Use start_battery_updater_shared instead to share hidraw with haptic")]
@@ -484,45 +505,43 @@ pub async fn start_battery_updater(state: SharedBatteryState) {
     }
 }
 
-/// Start a periodic battery update task using shared HapticManager
+/// Run one shared battery query outside the async worker pool.
 ///
-/// This version shares the HidppDevice with haptic feedback to avoid
-/// conflicts when both need to access the same hidraw device.
-pub async fn start_battery_updater_shared(
-    state: SharedBatteryState,
+/// The HID++ query polls hidraw with std::thread::sleep(10ms) up to 100 times
+/// (~1s worst case). Holding its std::sync::Mutex on a tokio worker would starve
+/// unrelated tasks, so every production query goes through `spawn_blocking`.
+async fn query_battery_shared(
     haptic_manager: crate::hidpp::SharedHapticManager,
-) {
+) -> Result<(u8, bool), crate::hidpp::HapticError> {
+    tokio::task::spawn_blocking(move || {
+        let mut manager = haptic_manager.lock().unwrap();
+        manager.query_battery()
+    })
+    .await
+    .expect("battery query task panicked")
+}
+
+/// Shared updater loop with injectable query and timer boundaries.
+///
+/// Production supplies the blocking HID++ adapter and tokio sleep below. Tests
+/// supply deterministic futures, exercising this exact loop without a device or
+/// wall-clock delay. Returning `false` from the timer stops the test loop.
+async fn run_battery_updater_shared_with<Query, QueryFuture, Timer, TimerFuture, Error>(
+    state: SharedBatteryState,
+    mut query: Query,
+    mut timer: Timer,
+) where
+    Query: FnMut() -> QueryFuture,
+    QueryFuture: std::future::Future<Output = Result<(u8, bool), Error>>,
+    Timer: FnMut(std::time::Duration) -> TimerFuture,
+    TimerFuture: std::future::Future<Output = bool>,
+    Error: std::fmt::Display,
+{
     let mut consecutive_errors = 0u32;
+    let mut cadence = BatteryPollCadence::default();
 
-    // The HID++ battery query polls hidraw with std::thread::sleep(10ms) up to
-    // 100 times (~1s worst case). Holding a std::sync::Mutex across that
-    // blocking I/O while running on a tokio worker is the canonical recipe for
-    // task starvation. Run every query on the blocking thread pool instead.
-    async fn run_query(
-        haptic_manager: crate::hidpp::SharedHapticManager,
-    ) -> Result<(u8, bool), crate::hidpp::HapticError> {
-        tokio::task::spawn_blocking(move || {
-            let mut manager = haptic_manager.lock().unwrap();
-            manager.query_battery()
-        })
-        .await
-        .expect("battery query task panicked")
-    }
-
-    // Battery polling cadence is a tradeoff between charging-state freshness
-    // and cursor smoothness. Every HID++ write briefly pauses mouse forwarding
-    // on the receiver firmware (5-30ms), so a fast cadence produces visible
-    // cursor stutter. 60s matches Solaar's default and is well below the
-    // human "did the battery change?" threshold.
-    const POLL_INTERVAL_SECS: u64 = 60;
-    // For the first minute of uptime we tick faster so the UI populates
-    // quickly after launch, then settle to the steady cadence.
-    const WARMUP_INTERVAL_SECS: u64 = 5;
-    const WARMUP_DURATION_SECS: u64 = 60;
-
-    let started = std::time::Instant::now();
-
-    let initial_result = run_query(haptic_manager.clone()).await;
+    let initial_result = query().await;
+    cadence.record_query_result(initial_result.is_ok());
 
     match initial_result {
         Ok((percentage, charging)) => {
@@ -542,14 +561,15 @@ pub async fn start_battery_updater_shared(
     }
 
     loop {
-        let cadence = if started.elapsed().as_secs() < WARMUP_DURATION_SECS {
-            WARMUP_INTERVAL_SECS
-        } else {
-            POLL_INTERVAL_SECS
-        };
-        tokio::time::sleep(tokio::time::Duration::from_secs(cadence)).await;
+        // Every HID++ query pauses mouse forwarding for 5-30ms. Retry quickly
+        // only until the UI has received its first sample, then use Solaar's
+        // 60-second cadence without returning to aggressive polling.
+        if !timer(cadence.next_interval()).await {
+            return;
+        }
 
-        let result = run_query(haptic_manager.clone()).await;
+        let result = query().await;
+        cadence.record_query_result(result.is_ok());
 
         match result {
             Ok((percentage, charging)) => {
@@ -578,6 +598,25 @@ pub async fn start_battery_updater_shared(
     }
 }
 
+/// Start a periodic battery update task using shared HapticManager
+///
+/// This version shares the HidppDevice with haptic feedback to avoid
+/// conflicts when both need to access the same hidraw device.
+pub async fn start_battery_updater_shared(
+    state: SharedBatteryState,
+    haptic_manager: crate::hidpp::SharedHapticManager,
+) {
+    run_battery_updater_shared_with(
+        state,
+        || query_battery_shared(haptic_manager.clone()),
+        |duration| async move {
+            tokio::time::sleep(duration).await;
+            true
+        },
+    )
+    .await;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -588,5 +627,116 @@ mod tests {
         assert_eq!(state.percentage, 0);
         assert!(!state.charging);
         assert!(!state.available);
+    }
+
+    #[tokio::test]
+    async fn shared_updater_loop_uses_normal_cadence_after_initial_success() {
+        use std::collections::VecDeque;
+        use std::sync::{Arc, Mutex};
+
+        let state = new_shared_state();
+        let query_results = Arc::new(Mutex::new(VecDeque::<
+            Result<(u8, bool), &'static str>,
+        >::from([Ok((72, true)), Ok((91, false))])));
+        let sleeps = Arc::new(Mutex::new(Vec::new()));
+
+        let results_for_query = query_results.clone();
+        let sleeps_for_query = sleeps.clone();
+        let sleeps_for_timer = sleeps.clone();
+        run_battery_updater_shared_with(
+            state.clone(),
+            move || {
+                let mut results = results_for_query.lock().unwrap();
+                if results.len() == 1 {
+                    assert_eq!(
+                        *sleeps_for_query.lock().unwrap(),
+                        [BATTERY_POLL_INTERVAL],
+                        "initial success must select normal cadence before the second query",
+                    );
+                }
+                std::future::ready(
+                    results
+                        .pop_front()
+                        .expect("updater queried more often than expected"),
+                )
+            },
+            move |duration| {
+                let keep_running = {
+                    let mut recorded = sleeps_for_timer.lock().unwrap();
+                    recorded.push(duration);
+                    recorded.len() < 2
+                };
+                std::future::ready(keep_running)
+            },
+        )
+        .await;
+
+        assert!(query_results.lock().unwrap().is_empty());
+        assert_eq!(
+            *sleeps.lock().unwrap(),
+            [BATTERY_POLL_INTERVAL, BATTERY_POLL_INTERVAL],
+        );
+
+        let state = state.read().await;
+        assert_eq!(state.percentage, 91);
+        assert!(!state.charging);
+        assert!(state.available);
+        assert_eq!(state.error, None);
+    }
+
+    #[tokio::test]
+    async fn shared_updater_loop_retries_until_success_then_stays_on_normal_cadence() {
+        use std::collections::VecDeque;
+        use std::sync::{Arc, Mutex};
+
+        let state = new_shared_state();
+        let query_results = Arc::new(Mutex::new(VecDeque::<
+            Result<(u8, bool), &'static str>,
+        >::from([
+            Err("initial failure"),
+            Ok((87, true)),
+            Err("later failure"),
+        ])));
+        let sleeps = Arc::new(Mutex::new(Vec::new()));
+
+        let results_for_query = query_results.clone();
+        let sleeps_for_timer = sleeps.clone();
+        run_battery_updater_shared_with(
+            state.clone(),
+            move || {
+                std::future::ready(
+                    results_for_query
+                        .lock()
+                        .unwrap()
+                        .pop_front()
+                        .expect("updater queried more often than expected"),
+                )
+            },
+            move |duration| {
+                let keep_running = {
+                    let mut recorded = sleeps_for_timer.lock().unwrap();
+                    recorded.push(duration);
+                    recorded.len() < 3
+                };
+                std::future::ready(keep_running)
+            },
+        )
+        .await;
+
+        assert!(query_results.lock().unwrap().is_empty());
+        assert_eq!(
+            *sleeps.lock().unwrap(),
+            [
+                BATTERY_RETRY_INTERVAL,
+                BATTERY_POLL_INTERVAL,
+                BATTERY_POLL_INTERVAL,
+            ]
+        );
+
+        let state = state.read().await;
+        assert_eq!(state.percentage, 87);
+        assert!(state.charging);
+        assert!(!state.available);
+        assert_eq!(state.error.as_deref(), Some("later failure"));
     }
 }


### PR DESCRIPTION
## Summary

Stop the 5-second battery warm-up retry loop immediately after the first successful sample. Failed initial reads still retry every 5 seconds; after any success the updater keeps the normal 60-second cadence even if a later read fails.

## Why

Each HID++ battery query can temporarily stall mouse forwarding. The previous uptime-based warm-up continued querying every 5 seconds for the entire first minute even when the immediate startup query had already succeeded.

## Measured impact

For a healthy updater in the half-open first-minute window `[0, 60s)`:

- before: 12 queries at 0, 5, ..., 55 seconds
- after: 1 query at 0 seconds
- reduction: 11 queries (91.7%)
- the next normal query remains at 60 seconds

## Testing

- deterministic production-updater cadence regressions: 2 passed; no device I/O or real sleeps
- initial-success test selects 60 seconds before the second query
- failure → success → later failure test records 5, 60, and 60 second intervals
- `cargo test --locked --lib` (282 passed, 2 ignored)
- `cargo test --locked --bin juhradiald` (8 passed)
- `cargo clippy --locked --lib --bin juhradiald --tests -- -D warnings`
- independent mutation checks cover both the initial and post-initial result transitions
- `git diff --check`

## Scope

Only `daemon/src/battery.rs` changes. Battery state updates, logging, the immediate initial query, device access, and error handling are preserved.

## Pull Request Checklist

- [x] Performance improvement
- [x] Code follows the project style and has been self-reviewed
- [x] Hard-to-understand lifecycle or concurrency behavior is documented in code where needed
- [x] The change introduces no new warnings
- [x] Regression tests cover the changed behavior
- [x] New and existing relevant unit tests pass locally
- [x] No dependent changes need to be merged first

Documentation was updated where the externally visible compositor contract changed; otherwise no user-facing documentation change is required. Tests used deterministic fakes/mocks or the offscreen platform and do not require a physical MX Master 4 or a live KDE session.
