### PR TITLE
perf: skip Flow status rewrites while disconnected

### DIFF
--- a/overlay/flow/juhflow_bridge.py
+++ b/overlay/flow/juhflow_bridge.py
@@ -173,14 +173,15 @@ class JuhFlowBridge:
             except OSError:
                 pass
         # Clear status file
+        status_path = os.path.join(
+            os.path.expanduser("~"), ".config", "juhradial", "flow_status.json"
+        )
         try:
-            status_path = os.path.join(
-                os.path.expanduser("~"), ".config", "juhradial", "flow_status.json"
-            )
-            if os.path.exists(status_path):
-                os.remove(status_path)
-        except OSError:
+            os.remove(status_path)
+        except FileNotFoundError:
             pass
+        except OSError as e:
+            logger.debug("Cannot clear Flow status file: %s", e)
 
     def send_edge_hit(self, edge, position, screen, ctrl_key=False,
                       relative_position=None):
@@ -382,40 +383,61 @@ class JuhFlowBridge:
 
         sock.close()
 
+    def _get_status_peers(self):
+        """Return peers from both JuhFlow and Logitech presence connections."""
+        peers = self.get_peers()
+
+        from . import get_presence_server
+        presence_server = get_presence_server()
+        if presence_server and hasattr(presence_server, 'active_connections'):
+            with presence_server._conn_lock:
+                for node_id, (_conn, name, _key) in (
+                    presence_server.active_connections.items()
+                ):
+                    peers.append({
+                        "id": node_id[:16],
+                        "hostname": name,
+                        "platform": "unknown",
+                        "ip": "",
+                        "connected_at": 0,
+                    })
+
+        return peers
+
+    def _publish_status(self, status_path):
+        """Publish connected peers atomically, or clear stale disconnected state."""
+        peers = self._get_status_peers()
+        if not peers:
+            if not os.path.exists(status_path):
+                return
+            try:
+                os.remove(status_path)
+            except FileNotFoundError:
+                pass  # Another cleanup won the existence-check race.
+            return
+
+        status = {"peers": peers, "updated_at": time.time()}
+        tmp = status_path + ".tmp"
+        with open(tmp, "w") as status_file:
+            json.dump(status, status_file)
+        os.replace(tmp, status_path)
+
+    def _heartbeat_once(self, status_path):
+        """Send and publish one heartbeat; deterministic seam for the loop."""
+        msg = {"type": MSG_HEARTBEAT, "ts": time.time()}
+        self._broadcast(msg)
+        self._publish_status(status_path)
+
     def _heartbeat_loop(self):
-        """Send periodic heartbeats to all peers and write status file."""
+        """Send periodic heartbeats to all peers and publish their status."""
         status_path = os.path.join(
             os.path.expanduser("~"), ".config", "juhradial", "flow_status.json"
         )
         while self.running:
-            msg = {"type": MSG_HEARTBEAT, "ts": time.time()}
-            self._broadcast(msg)
-            # Write status file so settings process can read peer info
             try:
-                peers = self.get_peers()
-                # Also include presence server connections (Logitech Flow protocol)
-                try:
-                    from . import get_presence_server
-                    ps = get_presence_server()
-                    if ps and hasattr(ps, 'active_connections'):
-                        with ps._conn_lock:
-                            for nid, (conn, name, key) in ps.active_connections.items():
-                                peers.append({
-                                    "id": nid[:16],
-                                    "hostname": name,
-                                    "platform": "unknown",
-                                    "ip": "",
-                                    "connected_at": 0,
-                                })
-                except Exception:
-                    pass
-                status = {"peers": peers, "updated_at": time.time()}
-                tmp = status_path + ".tmp"
-                with open(tmp, "w") as f:
-                    json.dump(status, f)
-                os.replace(tmp, status_path)
-            except Exception:
-                pass
+                self._heartbeat_once(status_path)
+            except OSError as e:
+                logger.debug("Cannot publish Flow status: %s", e)
             for _ in range(50):  # 5 seconds
                 if not self.running:
                     return

--- a/overlay/flow/test_juhflow_bridge.py
+++ b/overlay/flow/test_juhflow_bridge.py
@@ -7,9 +7,14 @@ clipboard sync, heartbeat keepalive, and reconnect after disconnect.
 import json
 import os
 import socket
+import tempfile
+import threading
 import time
 import unittest
+from typing import Any
+from unittest import mock
 
+from . import juhflow_bridge as bridge_module
 from .crypto import (
     build_encrypted_packet,
     decrypt_payload,
@@ -360,6 +365,152 @@ class TestJuhFlowBridgeMultiPeer(unittest.TestCase):
         finally:
             client1.close()
             client2.close()
+
+
+class TestJuhFlowBridgeStatusPublication(unittest.TestCase):
+    """Test status publication through the production heartbeat path."""
+
+    def _run_heartbeat(self, bridge, status_path, presence_server=None):
+        with mock.patch(
+            f"{bridge_module.__package__}.get_presence_server",
+            return_value=presence_server,
+        ):
+            bridge._heartbeat_once(status_path)
+
+    @staticmethod
+    def _bridge_with_peers(peers) -> Any:
+        bridge = object.__new__(JuhFlowBridge)
+        bridge.get_peers = mock.Mock(return_value=peers)
+        bridge._broadcast = mock.Mock()
+        return bridge
+
+    def test_repeated_empty_heartbeats_do_not_replace_status_file(self):
+        bridge = self._bridge_with_peers([])
+
+        with tempfile.TemporaryDirectory() as home:
+            status_path = os.path.join(home, "flow_status.json")
+            real_replace = os.replace
+
+            with (
+                mock.patch("builtins.open") as status_open,
+                mock.patch.object(
+                    bridge_module.os, "replace", wraps=real_replace
+                ) as replace,
+            ):
+                for _ in range(2):
+                    self._run_heartbeat(bridge, status_path)
+
+            status_open.assert_not_called()
+            self.assertEqual(replace.call_count, 0)
+            self.assertFalse(os.path.exists(status_path))
+
+    def test_existing_status_is_removed_once_when_peers_are_empty(self):
+        bridge = self._bridge_with_peers([])
+
+        with tempfile.TemporaryDirectory() as home:
+            status_path = os.path.join(home, "flow_status.json")
+            with open(status_path, "w") as status_file:
+                status_file.write("persisted")
+            real_remove = os.remove
+
+            with mock.patch.object(
+                bridge_module.os, "remove", wraps=real_remove
+            ) as remove:
+                self._run_heartbeat(bridge, status_path)
+                self._run_heartbeat(bridge, status_path)
+
+            remove.assert_called_once_with(status_path)
+            self.assertFalse(os.path.exists(status_path))
+
+    def test_empty_status_tolerates_file_disappearing_before_removal(self):
+        bridge = self._bridge_with_peers([])
+
+        with (
+            mock.patch.object(bridge_module.os.path, "exists", return_value=True),
+            mock.patch.object(
+                bridge_module.os, "remove", side_effect=FileNotFoundError
+            ) as remove,
+        ):
+            self._run_heartbeat(bridge, "/tmp/flow_status.json")
+
+        remove.assert_called_once_with("/tmp/flow_status.json")
+
+    def test_connected_peer_is_written_atomically_with_expected_status(self):
+        peer = {
+            "id": "peer-1",
+            "hostname": "test-mac",
+            "platform": "macos",
+            "ip": "192.0.2.10",
+            "connected_at": 100.0,
+        }
+        bridge = self._bridge_with_peers([peer])
+
+        with tempfile.TemporaryDirectory() as home:
+            status_path = os.path.join(home, "flow_status.json")
+            real_replace = os.replace
+
+            with (
+                mock.patch.object(bridge_module.time, "time", return_value=123.0),
+                mock.patch.object(
+                    bridge_module.os, "replace", wraps=real_replace
+                ) as replace,
+            ):
+                self._run_heartbeat(bridge, status_path)
+
+            replace.assert_called_once_with(status_path + ".tmp", status_path)
+            with open(status_path) as status_file:
+                status = json.load(status_file)
+            self.assertEqual(status, {"peers": [peer], "updated_at": 123.0})
+            bridge._broadcast.assert_called_once_with(
+                {"type": MSG_HEARTBEAT, "ts": 123.0}
+            )
+
+    def test_disconnect_removes_previously_written_status(self):
+        peer = {
+            "id": "peer-1",
+            "hostname": "test-mac",
+            "platform": "macos",
+            "ip": "192.0.2.10",
+            "connected_at": 100.0,
+        }
+        bridge = self._bridge_with_peers([peer])
+
+        with tempfile.TemporaryDirectory() as home:
+            status_path = os.path.join(home, "flow_status.json")
+            self._run_heartbeat(bridge, status_path)
+            self.assertTrue(os.path.exists(status_path))
+
+            bridge.get_peers.return_value = []
+            self._run_heartbeat(bridge, status_path)
+
+            self.assertFalse(os.path.exists(status_path))
+
+    def test_presence_peer_is_counted_as_connected(self):
+        bridge = self._bridge_with_peers([])
+        presence_server = mock.Mock()
+        presence_server._conn_lock = threading.Lock()
+        presence_server.active_connections = {
+            "0123456789abcdefcafebabe": (mock.Mock(), "office-mac", b"key")
+        }
+
+        with tempfile.TemporaryDirectory() as home:
+            status_path = os.path.join(home, "flow_status.json")
+            self._run_heartbeat(bridge, status_path, presence_server)
+
+            with open(status_path) as status_file:
+                status = json.load(status_file)
+            self.assertEqual(
+                status["peers"],
+                [
+                    {
+                        "id": "0123456789abcdef",
+                        "hostname": "office-mac",
+                        "platform": "unknown",
+                        "ip": "",
+                        "connected_at": 0,
+                    }
+                ],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Avoid rewriting `flow_status.json` every heartbeat while no Flow or presence peers are connected.

## Why

The bridge previously performed an atomic tempfile write plus `os.replace` every 5 seconds even in the disconnected state. Settings already treats a missing status file as disconnected, so these writes provided no user-visible information.

## Measured impact

With no peers connected:

- before: 17,280 atomic replacements per day
- after: 0 replacements per day
- reduction: 100%

On a transition from connected to disconnected, the existing status file is removed once. Active peers still refresh the file atomically every heartbeat.

## Testing

- status publication regressions (6 passed)
- `python3 -m unittest flow.test_juhflow_bridge -q` (18 passed)
- full overlay pytest suite (50 passed)
- `py_compile`
- `git diff --check`

Tests cover repeated empty heartbeats, one-time stale-file removal, JuhFlow peers, presence peers, atomic replacement, and disappearance races.

## Scope

Only the JuhFlow heartbeat/status publication seam and its integration tests change. Heartbeat network behavior and active-peer freshness are preserved.

## Pull Request Checklist

- [x] Performance improvement
- [x] Code follows the project style and has been self-reviewed
- [x] Hard-to-understand lifecycle or concurrency behavior is documented in code where needed
- [x] The change introduces no new warnings
- [x] Regression tests cover the changed behavior
- [x] New and existing relevant unit tests pass locally
- [x] No dependent changes need to be merged first

Documentation was updated where the externally visible compositor contract changed; otherwise no user-facing documentation change is required. Tests used deterministic fakes/mocks or the offscreen platform and do not require a physical MX Master 4 or a live KDE session.
