### PR TITLE
perf: dispatch overlay haptics asynchronously

### DIFF
--- a/overlay/juhradial-overlay.py
+++ b/overlay/juhradial-overlay.py
@@ -90,7 +90,12 @@ from PyQt6.QtGui import (
     QFont,
     QRadialGradient,
 )
-from PyQt6.QtDBus import QDBusConnection, QDBusInterface
+from PyQt6.QtDBus import (
+    QDBusConnection,
+    QDBusInterface,
+    QDBusPendingCallWatcher,
+    QDBusPendingReply,
+)
 
 from overlay_constants import (
     MENU_RADIUS,
@@ -531,6 +536,8 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             "org.kde.juhradialmx.Daemon",
             bus,
         )
+        self._haptic_watchers = set()
+        self._pending_haptic_events = set()
         print(
             f"[DBUS] D-Bus interface created - isValid: {self.daemon_iface.isValid()}"
         )
@@ -950,7 +957,7 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
         return hover_gate(self._hover_anchors, self._hover_armed, source, dx, dy)
 
     def _trigger_haptic(self, event):
-        """Trigger haptic feedback via D-Bus call to daemon.
+        """Trigger haptic feedback without blocking the GUI thread.
 
         Args:
             event: One of "menu_appear", "slice_change", "confirm", "invalid"
@@ -959,17 +966,39 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             f"[HAPTIC] _trigger_haptic called: event={event}, iface_valid={self.daemon_iface.isValid()}"
         )
         if self.daemon_iface.isValid():
-            reply = self.daemon_iface.call("TriggerHaptic", event)
-            if reply.type() == reply.MessageType.ErrorMessage:
-                print(
-                    f"[HAPTIC] D-Bus call failed: {reply.errorName()} - {reply.errorMessage()}"
+            if event in self._pending_haptic_events:
+                print(f"[HAPTIC] Coalescing pending {event} event")
+                return
+
+            pending_call = self.daemon_iface.asyncCall("TriggerHaptic", event)
+            watcher = QDBusPendingCallWatcher(pending_call, self)
+            self._pending_haptic_events.add(event)
+            self._haptic_watchers.add(watcher)
+            watcher.finished.connect(
+                lambda finished_watcher, haptic_event=event: self._on_haptic_finished(
+                    finished_watcher, haptic_event
                 )
-            else:
-                print(f"[HAPTIC] D-Bus call succeeded for {event}")
+            )
         else:
             print(
                 f"[HAPTIC] ERROR: daemon_iface is INVALID - cannot send haptic signal"
             )
+
+    def _on_haptic_finished(self, watcher, event):
+        """Log an asynchronous haptic reply and release its watcher."""
+        try:
+            reply = QDBusPendingReply(watcher)
+            if reply.isError():
+                error = reply.error()
+                print(
+                    f"[HAPTIC] D-Bus call failed: {error.name()} - {error.message()}"
+                )
+            else:
+                print(f"[HAPTIC] D-Bus call succeeded for {event}")
+        finally:
+            self._pending_haptic_events.discard(event)
+            self._haptic_watchers.discard(watcher)
+            watcher.deleteLater()
 
     def _apply_ring_scale(self, mon):
         """Scale the ring window to the monitor it is shown on.

--- a/tests/test_async_haptics.py
+++ b/tests/test_async_haptics.py
@@ -1,0 +1,194 @@
+"""Behavioral regressions for non-blocking overlay haptic calls."""
+
+import ast
+from pathlib import Path
+
+
+OVERLAY_PATH = Path(__file__).resolve().parents[1] / "overlay" / "juhradial-overlay.py"
+
+
+def _radial_menu_method(name: str, namespace: dict):
+    module = ast.parse(OVERLAY_PATH.read_text(encoding="utf-8"))
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "RadialMenu":
+            for statement in node.body:
+                if isinstance(statement, ast.FunctionDef) and statement.name == name:
+                    exec(
+                        compile(
+                            ast.Module(body=[statement], type_ignores=[]),
+                            f"<RadialMenu.{name}>",
+                            "exec",
+                        ),
+                        namespace,
+                    )
+                    return namespace[name]
+    raise AssertionError(f"RadialMenu.{name} not found")
+
+
+class _Signal:
+    def __init__(self):
+        self.callback = None
+
+    def connect(self, callback):
+        self.callback = callback
+
+    def emit(self, watcher):
+        assert self.callback is not None
+        self.callback(watcher)
+
+
+class _Watcher:
+    created = []
+
+    def __init__(self, pending_call, parent):
+        self.pending_call = pending_call
+        self.parent = parent
+        self.finished = _Signal()
+        self.error = None
+        self.deleted = False
+        self.created.append(self)
+
+    def deleteLater(self):
+        self.deleted = True
+
+
+class _PendingReply:
+    def __init__(self, watcher):
+        self._watcher = watcher
+
+    def isError(self):
+        return self._watcher.error is not None
+
+    def error(self):
+        return self._watcher.error
+
+
+class _Error:
+    def __init__(self, name="org.example.Error", message="failed"):
+        self._name = name
+        self._message = message
+
+    def name(self):
+        return self._name
+
+    def message(self):
+        return self._message
+
+
+class _SyncReply:
+    class MessageType:
+        ErrorMessage = object()
+
+    def type(self):
+        return object()
+
+
+class _Interface:
+    def __init__(self, valid=True):
+        self.valid = valid
+        self.async_calls = []
+        self.sync_calls = []
+
+    def isValid(self):
+        return self.valid
+
+    def asyncCall(self, method, event):
+        self.async_calls.append((method, event))
+        return (method, event)
+
+    def call(self, method, event):
+        self.sync_calls.append((method, event))
+        return _SyncReply()
+
+
+_NAMESPACE = {
+    "QDBusPendingCallWatcher": _Watcher,
+    "QDBusPendingReply": _PendingReply,
+}
+_ON_HAPTIC_FINISHED = _radial_menu_method("_on_haptic_finished", _NAMESPACE)
+_TRIGGER_HAPTIC = _radial_menu_method("_trigger_haptic", _NAMESPACE)
+
+
+class _MenuHarness:
+    _on_haptic_finished = _ON_HAPTIC_FINISHED
+    _trigger_haptic = _TRIGGER_HAPTIC
+
+    def __init__(self, valid=True):
+        self.daemon_iface = _Interface(valid=valid)
+        self._haptic_watchers = set()
+        self._pending_haptic_events = set()
+
+
+def setup_function():
+    _Watcher.created.clear()
+
+
+def test_haptic_uses_async_dbus_without_a_blocking_call():
+    menu = _MenuHarness()
+
+    menu._trigger_haptic("menu_appear")
+
+    assert menu.daemon_iface.async_calls == [("TriggerHaptic", "menu_appear")]
+    assert menu.daemon_iface.sync_calls == []
+    assert len(menu._haptic_watchers) == 1
+    assert menu._pending_haptic_events == {"menu_appear"}
+
+
+def test_duplicate_pending_event_is_coalesced():
+    menu = _MenuHarness()
+
+    menu._trigger_haptic("slice_change")
+    menu._trigger_haptic("slice_change")
+
+    assert menu.daemon_iface.async_calls == [("TriggerHaptic", "slice_change")]
+    assert len(menu._haptic_watchers) == 1
+
+
+def test_distinct_events_are_sent_in_order():
+    menu = _MenuHarness()
+
+    menu._trigger_haptic("menu_appear")
+    menu._trigger_haptic("slice_change")
+
+    assert menu.daemon_iface.async_calls == [
+        ("TriggerHaptic", "menu_appear"),
+        ("TriggerHaptic", "slice_change"),
+    ]
+    assert len(menu._haptic_watchers) == 2
+
+
+def test_successful_reply_releases_pending_state():
+    menu = _MenuHarness()
+    menu._trigger_haptic("confirm")
+    watcher = _Watcher.created[-1]
+
+    watcher.finished.emit(watcher)
+
+    assert menu._haptic_watchers == set()
+    assert menu._pending_haptic_events == set()
+    assert watcher.deleted
+
+
+def test_error_reply_releases_pending_state(capsys):
+    menu = _MenuHarness()
+    menu._trigger_haptic("invalid")
+    watcher = _Watcher.created[-1]
+    watcher.error = _Error()
+
+    watcher.finished.emit(watcher)
+
+    output = capsys.readouterr().out
+    assert "org.example.Error" in output
+    assert "failed" in output
+    assert menu._haptic_watchers == set()
+    assert menu._pending_haptic_events == set()
+    assert watcher.deleted
+
+
+def test_invalid_interface_does_not_create_a_pending_call():
+    menu = _MenuHarness(valid=False)
+
+    menu._trigger_haptic("menu_appear")
+
+    assert menu.daemon_iface.async_calls == []
+    assert _Watcher.created == []


### PR DESCRIPTION
## Summary

Dispatch overlay haptic feedback through asynchronous Qt D-Bus calls instead of blocking the GUI thread.

## Why

`TriggerHaptic` performs HID++ I/O in the daemon. The overlay previously waited synchronously for every menu-appear, slice-change, confirm, and invalid-event reply on the GUI thread. Slow hardware retries or multi-pulse patterns could stall pointer handling and animation.

## Measured impact

With the same fake daemon reply delayed by 20 ms:

- synchronous baseline trigger: 20.084 ms
- asynchronous candidate trigger: 0.011 ms
- candidate dispatch: one async call, zero synchronous calls

The measurement isolates GUI call-site blocking; daemon-side haptic timing is unchanged.

## Behavior

- use `QDBusInterface.asyncCall()` with `QDBusPendingCallWatcher`
- keep watchers alive until completion and clean them in `finally`
- log both successful and failed replies
- coalesce duplicate in-flight events of the same type, bounding pending calls
- preserve the send order of distinct event types on the same D-Bus connection

## Testing

- focused async-haptics regressions (6 passed)
- full overlay pytest suite (56 passed)
- real session-bus `QDBusPendingCallWatcher -> QDBusPendingReply` probe
- real watcher hashability probe
- `py_compile`
- `git diff --check`

## Scope

Only the overlay-side dispatch changes. Daemon haptic patterns and HID++ behavior are unchanged.

## Pull Request Checklist

- [x] Performance improvement
- [x] Code follows the project style and has been self-reviewed
- [x] Hard-to-understand lifecycle or concurrency behavior is documented in code where needed
- [x] The change introduces no new warnings
- [x] Regression tests cover the changed behavior
- [x] New and existing relevant unit tests pass locally
- [x] No dependent changes need to be merged first

Documentation was updated where the externally visible compositor contract changed; otherwise no user-facing documentation change is required. Tests used deterministic fakes/mocks or the offscreen platform and do not require a physical MX Master 4 or a live KDE session.
