### PR TITLE
perf: skip stable submenu repaints

### DIFF
--- a/overlay/juhradial-overlay.py
+++ b/overlay/juhradial-overlay.py
@@ -1356,8 +1356,9 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
                     self.update()
                 return
             if new_slice == self.submenu_slice or distance > MENU_RADIUS:
-                self.highlighted_subitem = -1
-                self.update()
+                if self.highlighted_subitem != -1:
+                    self.highlighted_subitem = -1
+                    self.update()
                 return
             else:
                 self.submenu_active = False
@@ -1385,8 +1386,6 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             self.highlighted_slice = new_slice
             if not self._anim_timer.isActive():
                 self._anim_timer.start()
-            self.update()
-        elif self.submenu_active:
             self.update()
 
     def _get_subitem_at_position(self, dx, dy):
@@ -1450,8 +1449,9 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
                     self.update()
                 return
             if new_slice == self.submenu_slice or distance > MENU_RADIUS:
-                self.highlighted_subitem = -1
-                self.update()
+                if self.highlighted_subitem != -1:
+                    self.highlighted_subitem = -1
+                    self.update()
                 return
             else:
                 self.submenu_active = False
@@ -1479,8 +1479,6 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             self.highlighted_slice = new_slice
             if not self._anim_timer.isActive():
                 self._anim_timer.start()
-            self.update()
-        elif self.submenu_active:
             self.update()
 
     def mousePressEvent(self, event):

--- a/tests/test_submenu_repaints.py
+++ b/tests/test_submenu_repaints.py
@@ -1,0 +1,162 @@
+"""Behavioral regressions for stable submenu repaint scheduling."""
+
+import ast
+import math
+from pathlib import Path
+from types import SimpleNamespace
+
+
+OVERLAY_PATH = Path(__file__).resolve().parents[1] / "overlay" / "juhradial-overlay.py"
+
+
+def _radial_menu_method(name: str):
+    module = ast.parse(OVERLAY_PATH.read_text(encoding="utf-8"))
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "RadialMenu":
+            for statement in node.body:
+                if isinstance(statement, ast.FunctionDef) and statement.name == name:
+                    namespace = {
+                        "math": math,
+                        "MENU_RADIUS": 100,
+                        "overlay_actions": SimpleNamespace(ACTIONS=[]),
+                        "get_cursor_pos": lambda: (0, -50),
+                        "_log": lambda _message: None,
+                    }
+                    exec(
+                        compile(
+                            ast.Module(body=[statement], type_ignores=[]),
+                            f"<RadialMenu.{name}>",
+                            "exec",
+                        ),
+                        namespace,
+                    )
+                    return namespace[name]
+    raise AssertionError(f"RadialMenu.{name} not found")
+
+
+class _Timer:
+    def __init__(self, active=True):
+        self.active = active
+        self.stop_calls = 0
+        self.start_calls = 0
+
+    def isActive(self):
+        return self.active
+
+    def start(self):
+        self.active = True
+        self.start_calls += 1
+
+    def stop(self):
+        self.active = False
+        self.stop_calls += 1
+
+
+class _MenuHarness:
+    def __init__(self, highlighted_subitem=-1, subitem_result=-1):
+        self.menu_center_x = 0
+        self.menu_center_y = 0
+        self.ring_scale = 1.0
+        self.win_px = 200
+        self.toggle_mode = False
+        self.submenu_active = True
+        self.submenu_slice = 0
+        self.submenu_progress = 1.0
+        self.highlighted_subitem = highlighted_subitem
+        self.highlighted_slice = 0
+        self.slice_highlights = [0.0] * 8
+        self.flash_progress = 0.0
+        self.flash_slice = -1
+        self.bloom_progress = 1.0
+        self.center_pulse = 1.0
+        self._anim_timer = _Timer()
+        self._subitem_result = subitem_result
+        self.update_calls = 0
+
+    def _hover_gate(self, *_args):
+        return True
+
+    def _get_center_radius(self):
+        return 10
+
+    def _get_subitem_at_position(self, *_args):
+        return self._subitem_result
+
+    def _update_kde_mask(self):
+        pass
+
+    def _trigger_haptic(self, _event):
+        pass
+
+    def update(self):
+        self.update_calls += 1
+
+
+class _Point:
+    def x(self):
+        return 100
+
+    def y(self):
+        return 50
+
+
+class _MouseEvent:
+    def position(self):
+        return _Point()
+
+
+def test_cursor_poll_does_not_repaint_an_already_clear_submenu_highlight():
+    menu = _MenuHarness(highlighted_subitem=-1, subitem_result=-1)
+
+    _radial_menu_method("_poll_cursor")(menu)
+
+    assert menu.highlighted_subitem == -1
+    assert menu.update_calls == 0
+
+
+def test_mouse_move_does_not_repaint_an_already_clear_submenu_highlight():
+    menu = _MenuHarness(highlighted_subitem=-1, subitem_result=-1)
+
+    _radial_menu_method("mouseMoveEvent")(menu, _MouseEvent())
+
+    assert menu.highlighted_subitem == -1
+    assert menu.update_calls == 0
+
+
+def test_clearing_a_real_submenu_highlight_repaints_once():
+    menu = _MenuHarness(highlighted_subitem=2, subitem_result=-1)
+
+    _radial_menu_method("_poll_cursor")(menu)
+
+    assert menu.highlighted_subitem == -1
+    assert menu.update_calls == 1
+
+
+def test_changing_the_highlighted_subitem_repaints_once():
+    menu = _MenuHarness(highlighted_subitem=1, subitem_result=2)
+
+    _radial_menu_method("_poll_cursor")(menu)
+
+    assert menu.highlighted_subitem == 2
+    assert menu.update_calls == 1
+
+
+def test_submenu_animation_keeps_repainting_until_settled():
+    menu = _MenuHarness()
+    menu.submenu_progress = 0.5
+
+    _radial_menu_method("_tick_animations")(menu)
+
+    assert menu.submenu_progress > 0.5
+    assert menu.update_calls == 1
+    assert menu._anim_timer.stop_calls == 0
+
+
+def test_settled_animation_stops_without_an_extra_repaint():
+    menu = _MenuHarness()
+    menu.highlighted_slice = -1
+
+    _radial_menu_method("_tick_animations")(menu)
+
+    assert menu.update_calls == 0
+    assert menu._anim_timer.stop_calls == 1


### PR DESCRIPTION
## Summary

Skip repaint requests when submenu hover state is already stable.

## Why

Both cursor input paths called `update()` on every sample while the cursor remained in the parent slice with no highlighted subitem. In toggle mode that can schedule approximately 60 identical paints per second even though animation has already settled.

## Measured impact

For 600 stable cursor samples:

- before: 600 repaint requests
- after: 0 repaint requests

A real highlight change or clear still repaints once. `_anim_timer` continues generating frames until submenu and highlight animations settle.

## Testing

- focused submenu repaint regressions (6 passed)
- full overlay pytest suite (56 passed)
- both `_poll_cursor` and `mouseMoveEvent`
- highlight change, highlight clear, active animation, and settled animation
- `py_compile`
- `git diff --check`

## Scope

Only redundant scheduling is removed; hit testing, selection, painting, and animation timing are unchanged.

## Pull Request Checklist

- [x] Performance improvement
- [x] Code follows the project style and has been self-reviewed
- [x] Hard-to-understand lifecycle or concurrency behavior is documented in code where needed
- [x] The change introduces no new warnings
- [x] Regression tests cover the changed behavior
- [x] New and existing relevant unit tests pass locally
- [x] No dependent changes need to be merged first

Documentation was updated where the externally visible compositor contract changed; otherwise no user-facing documentation change is required. Tests used deterministic fakes/mocks or the offscreen platform and do not require a physical MX Master 4 or a live KDE session.
