### PR TITLE
perf: adapt Flow edge polling cadence

### DIFF
--- a/overlay/flow/__init__.py
+++ b/overlay/flow/__init__.py
@@ -155,8 +155,8 @@ def start_flow_server(on_host_change: Callable[[int], None] = None) -> FlowServe
                     node_id, peer["aes_key_bytes"],
                 )
 
-        # Start edge detector and enable if config says so
-        _edge_detector.start()
+        # Apply config before publishing a worker. A retained detector may still
+        # be enabled from its prior owner, so false must be propagated too.
         try:
             import json
             from pathlib import Path
@@ -165,8 +165,8 @@ def start_flow_server(on_host_change: Callable[[int], None] = None) -> FlowServe
             edge_on = cfg.get("flow", {}).get("edge_trigger", True)
         except Exception:
             edge_on = True
-        if edge_on:
-            _edge_detector.set_enabled(True)
+        _edge_detector.set_enabled(edge_on)
+        _edge_detector.start()
     except Exception as e:
         logger.warning("Edge detector/handoff setup deferred: %s", e)
 
@@ -277,26 +277,34 @@ def update_indicator_direction(direction=None):
 
 
 def stop_flow_server():
-    """Stop all Flow servers"""
+    """Stop all Flow servers."""
     global _flow_server, _logi_flow_server, _logi_discovery, _presence_server
     global _handoff_manager, _edge_detector, _juhflow_bridge, _flow_indicator
 
-    if _flow_indicator:
-        _flow_indicator.hide()
-        _flow_indicator.deleteLater()
-        _flow_indicator = None
-
-    if _juhflow_bridge:
-        _juhflow_bridge.stop()
-        _juhflow_bridge = None
-
     if _edge_detector:
-        _edge_detector.stop()
+        # The detector callback can still be executing FlowHandoffManager code.
+        # Retain its complete dependency graph until the callback fence and poll
+        # generation are quiescent; restart then reuses the still-wired graph.
+        if not _edge_detector.stop():
+            return
         _edge_detector = None
 
     if _handoff_manager:
         _handoff_manager.stop()
         _handoff_manager = None
+
+    if _juhflow_bridge:
+        _juhflow_bridge.stop()
+        _juhflow_bridge = None
+
+    if _presence_server:
+        _presence_server.stop()
+        _presence_server = None
+
+    if _flow_indicator:
+        _flow_indicator.hide()
+        _flow_indicator.deleteLater()
+        _flow_indicator = None
 
     if _flow_server:
         _flow_server.stop()
@@ -305,10 +313,6 @@ def stop_flow_server():
     if _logi_flow_server:
         _logi_flow_server.stop()
         _logi_flow_server = None
-
-    if _presence_server:
-        _presence_server.stop()
-        _presence_server = None
 
     if _logi_discovery:
         _logi_discovery.stop()

--- a/overlay/flow/constants.py
+++ b/overlay/flow/constants.py
@@ -36,6 +36,10 @@ FLOW_TAG_LEN = 16
 EDGE_THRESHOLD_PX = 5
 EDGE_DWELL_MS = 350
 EDGE_POLL_INTERVAL_MS = 8
+# Poll less often while the cursor is far from the configured handoff edge.
+# The original 8 ms cadence is restored before entering the 5 px trigger zone.
+EDGE_IDLE_POLL_INTERVAL_MS = 32
+EDGE_NEAR_ZONE_PX = 64
 EDGE_COOLDOWN_MS = 1500
 
 # Velocity-based instant trigger: if cursor crosses this many px/s toward an edge,

--- a/overlay/flow/edge_detector.py
+++ b/overlay/flow/edge_detector.py
@@ -15,6 +15,8 @@ from .constants import (
     EDGE_THRESHOLD_PX,
     EDGE_DWELL_MS,
     EDGE_POLL_INTERVAL_MS,
+    EDGE_IDLE_POLL_INTERVAL_MS,
+    EDGE_NEAR_ZONE_PX,
     EDGE_COOLDOWN_MS,
     EDGE_VELOCITY_INSTANT_PX_PER_S,
     EDGE_INDICATOR_ZONE_PX,
@@ -34,6 +36,18 @@ class ScreenEdgeDetector:
         self._enabled = False
         self._running = False
         self._thread: Optional[threading.Thread] = None
+        self._restart_waiter: Optional[threading.Thread] = None
+        self._restart_pending = False
+        self._restart_generation: Optional[int] = None
+        self._pending_start_generation: Optional[int] = None
+        self._generation = 0
+        self._starting_generation: Optional[int] = None
+        self._active_generation: Optional[int] = None
+        self._lifecycle_lock = threading.Lock()
+        self._lifecycle_changed = threading.Condition(self._lifecycle_lock)
+        self._callback_fence = threading.RLock()
+        self._callback_depth = 0
+        self._wake_event = threading.Event()
 
         # Callback: on_edge_hit(edge: str, cx: int, cy: int, screen: dict)
         self.on_edge_hit: Optional[Callable] = None
@@ -66,6 +80,7 @@ class ScreenEdgeDetector:
         else:
             logger.info("Edge detection disabled")
             self._reset_dwell()
+        self._wake_event.set()
 
     def cache_monitor_geometry(self):
         """Cache flow monitor geometry from Qt (call from main thread only).
@@ -96,30 +111,186 @@ class ScreenEdgeDetector:
 
     def start(self):
         """Start the polling thread."""
-        if self._running:
+        with self._lifecycle_changed:
+            if self._running:
+                return
+            if self._starting_generation is not None:
+                # A stop may have invalidated a start while it was loading
+                # config. Preserve one later request until that stale
+                # reservation clears; concurrent requests coalesce onto it.
+                if (
+                    self._starting_generation != self._generation
+                    and self._pending_start_generation is None
+                ):
+                    self._generation += 1
+                    self._pending_start_generation = self._generation
+                return
+            self._generation += 1
+            generation = self._generation
+            self._starting_generation = generation
+
+        while generation is not None:
+            try:
+                self._reload_config()  # Load direction/monitor before first poll
+                self.cache_monitor_geometry()  # Cache geometry while on main thread
+            except BaseException:
+                with self._lifecycle_changed:
+                    if self._starting_generation == generation:
+                        self._starting_generation = None
+                    next_generation = self._claim_pending_start_locked()
+                    self._lifecycle_changed.notify_all()
+                if next_generation is not None:
+                    generation = next_generation
+                    continue
+                raise
+
+            with self._lifecycle_changed:
+                if self._starting_generation == generation:
+                    self._starting_generation = None
+                next_generation = self._claim_pending_start_locked()
+                self._lifecycle_changed.notify_all()
+                if next_generation is not None:
+                    generation = next_generation
+                    continue
+                if generation != self._generation or self._running:
+                    return
+                thread = self._thread
+                if thread is not None and thread.is_alive():
+                    self._restart_pending = True
+                    self._restart_generation = generation
+                    waiter = self._restart_waiter
+                    if waiter is None or not waiter.is_alive():
+                        waiter = threading.Thread(
+                            target=self._restart_after,
+                            args=(thread,),
+                            daemon=True,
+                        )
+                        self._restart_waiter = waiter
+                        waiter.start()
+                    logger.warning("Edge detector thread is still stopping; restart queued")
+                    return
+                self._thread = None
+                self._start_thread_locked(generation)
+                return
+
+    def _claim_pending_start_locked(self) -> Optional[int]:
+        """Claim one queued start after an invalidated reservation clears."""
+        generation = self._pending_start_generation
+        self._pending_start_generation = None
+        if generation is None or generation != self._generation or self._running:
+            return None
+        self._starting_generation = generation
+        return generation
+
+    def _start_thread_locked(self, generation: int):
+        """Start one reserved poll generation with ``_lifecycle_lock`` held."""
+        if generation != self._generation:
             return
-        self._reload_config()  # Load direction/monitor before first poll
-        self.cache_monitor_geometry()  # Cache geometry while on main thread
+        # A prior worker may have resumed from a blocked cursor query and
+        # written sample state after stop() reset it. Every path here has
+        # already proved that worker terminal, so reset immediately before
+        # publishing the replacement generation.
+        self._reset_generation_state()
+        self._wake_event.clear()
         self._running = True
-        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._active_generation = generation
+        self._restart_pending = False
+        self._restart_generation = None
+        self._thread = threading.Thread(
+            target=self._poll_loop,
+            args=(generation,),
+            daemon=True,
+        )
         self._thread.start()
         logger.info("Edge detector started (poll: %dms, direction: %s, monitor: %s)",
                      EDGE_POLL_INTERVAL_MS, self._flow_direction, self._flow_monitor)
 
+    def _restart_after(self, previous: threading.Thread):
+        """Wait off the UI thread before replacing a stopping generation."""
+        previous.join()
+        with self._lifecycle_changed:
+            if self._thread is previous:
+                self._thread = None
+            self._restart_waiter = None
+            generation = self._restart_generation
+            if (
+                self._restart_pending
+                and generation is not None
+                and generation == self._generation
+            ):
+                self._start_thread_locked(generation)
+            else:
+                self._restart_pending = False
+                self._restart_generation = None
+            self._lifecycle_changed.notify_all()
+
     def stop(self):
-        """Stop the polling thread."""
-        self._running = False
+        """Invalidate callbacks, request stop, and report lifecycle quiescence."""
+        deadline = time.monotonic() + 0.2
+        with self._lifecycle_changed:
+            # Invalidate both a published worker and any start() that already
+            # reserved a generation but is still loading main-thread config.
+            self._generation += 1
+            self._active_generation = None
+            self._running = False
+            self._restart_pending = False
+            self._restart_generation = None
+            self._pending_start_generation = None
+            thread = self._thread
+
         self._reset_dwell()
+        self._wake_event.set()
+
+        # A callback that passed its generation check owns this fence until it
+        # returns. Spend only the remaining stop budget crossing it; arbitrary
+        # user callbacks must not turn the 200 ms lifecycle deadline into an
+        # unbounded wait. A re-entrant stop from inside the callback can acquire
+        # the RLock, so callback depth is part of the quiescence proof.
+        callback_quiescent = False
+        remaining = max(0.0, deadline - time.monotonic())
+        callback_fence_acquired = self._callback_fence.acquire(timeout=remaining)
+        if callback_fence_acquired:
+            try:
+                callback_quiescent = self._callback_depth == 0
+            finally:
+                self._callback_fence.release()
+
+        with self._lifecycle_changed:
+            while self._starting_generation is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._lifecycle_changed.wait(timeout=remaining)
+
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+
+        with self._lifecycle_changed:
+            if self._thread is thread and (thread is None or not thread.is_alive()):
+                self._thread = None
+            return (
+                callback_quiescent
+                and self._thread is None
+                and self._starting_generation is None
+            )
 
     def suppress_for(self, ms: int):
         """Suppress edge detection for ms milliseconds (prevents bounce-back)."""
         self._suppress_until = time.monotonic() + ms / 1000.0
         self._reset_dwell()
+        self._wake_event.set()
         logger.debug("Edge detection suppressed for %dms", ms)
 
     def _reset_dwell(self):
         self._dwell_start = None
         self._dwell_edge = None
+
+    def _reset_generation_state(self):
+        """Clear edge sample state owned by one polling generation."""
+        self._reset_dwell()
+        self._prev_pos = None
+        self._prev_time = 0.0
+        self._last_fire_time = 0.0
 
     def _reload_config(self):
         """Reload extend_edge_zone from config (checked periodically)."""
@@ -140,36 +311,87 @@ class ScreenEdgeDetector:
         except Exception:
             pass
 
-    def _poll_loop(self):
-        """Main polling loop - checks cursor position at EDGE_POLL_INTERVAL_MS."""
-        poll_interval = EDGE_POLL_INTERVAL_MS / 1000.0
-        config_check = 0
+    def _is_generation_running(self, generation: Optional[int]) -> bool:
+        if generation is None:
+            return self._running
+        with self._lifecycle_lock:
+            return (
+                self._running
+                and self._active_generation == generation
+                and self._generation == generation
+            )
 
-        while self._running:
-            if self._enabled:
-                # Reload config every ~2 seconds (250 polls at 8ms)
-                config_check += 1
-                if config_check >= 250:
-                    config_check = 0
-                    self._reload_config()
-                try:
-                    self._check_edge()
-                except Exception as e:
-                    logger.debug("Edge check error: %s", e)
+    def _poll_loop(self, generation: Optional[int] = None):
+        """Poll quickly near the edge and sleep until woken while disabled."""
+        next_config_check = time.monotonic() + 2.0
 
-            time.sleep(poll_interval)
+        while self._is_generation_running(generation):
+            if not self._enabled:
+                self._wake_event.wait()
+                self._wake_event.clear()
+                continue
 
-    def _check_edge(self):
+            now = time.monotonic()
+            if now >= next_config_check:
+                self._reload_config()
+                next_config_check = now + 2.0
+
+            near_edge = False
+            try:
+                if generation is None:
+                    near_edge = self._check_edge()
+                else:
+                    near_edge = self._check_edge(generation)
+            except Exception as e:
+                logger.debug("Edge check error: %s", e)
+
+            interval_ms = (
+                EDGE_POLL_INTERVAL_MS
+                if near_edge
+                else EDGE_IDLE_POLL_INTERVAL_MS
+            )
+            self._wake_event.wait(interval_ms / 1000.0)
+            self._wake_event.clear()
+
+    def _dispatch_edge_hit(
+        self,
+        generation: Optional[int],
+        edge: str,
+        cx: int,
+        cy: int,
+        screen: dict,
+    ) -> bool:
+        """Invoke the current callback only for a still-active poll generation."""
+        with self._callback_fence:
+            if generation is not None:
+                with self._lifecycle_lock:
+                    if (
+                        not self._running
+                        or self._active_generation != generation
+                        or self._generation != generation
+                    ):
+                        return False
+            callback = self.on_edge_hit
+            if callback is None:
+                return False
+            self._callback_depth += 1
+            try:
+                callback(edge, cx, cy, screen)
+            finally:
+                self._callback_depth -= 1
+            return True
+
+    def _check_edge(self, generation: Optional[int] = None):
         """Check if cursor is at a screen edge and handle dwell detection."""
         now = time.monotonic()
 
         # Suppression active (e.g., just received a handoff)
         if now < self._suppress_until:
-            return
+            return False
 
         # Cooldown after last fire
         if now - self._last_fire_time < EDGE_COOLDOWN_MS / 1000.0:
-            return
+            return False
 
         # Get cursor position and screen geometry
         try:
@@ -180,7 +402,7 @@ class ScreenEdgeDetector:
         if not pos:
             self._reset_dwell()
             self._prev_pos = None
-            return
+            return False
 
         cx, cy = pos
 
@@ -211,7 +433,19 @@ class ScreenEdgeDetector:
             if not (g["x"] == sx and g["y"] == sy
                     and g["width"] == sw and g["height"] == sh):
                 self._reset_dwell()
-                return
+                return False
+
+        # Keep the original 8 ms cadence while approaching the configured edge.
+        # Farther away, a 32 ms sample still detects fast slams from velocity.
+        if self._flow_direction == "left":
+            edge_distance = cx - sx
+        elif self._flow_direction == "right":
+            edge_distance = sx + sw - 1 - cx
+        elif self._flow_direction == "top":
+            edge_distance = cy - sy
+        else:
+            edge_distance = sy + sh - 1 - cy
+        near_edge = edge_distance <= EDGE_NEAR_ZONE_PX
 
         # Only check the configured flow direction edge, not all four edges.
         edge = None
@@ -227,7 +461,7 @@ class ScreenEdgeDetector:
 
         if edge is None:
             self._reset_dwell()
-            return
+            return near_edge
 
         # Restrict trigger zone to the indicator pill area only,
         # unless the user enabled "extend edge zone" for full-edge triggering.
@@ -237,12 +471,12 @@ class ScreenEdgeDetector:
                 center_y = sy + sh // 2
                 if abs(cy - center_y) > half_zone:
                     self._reset_dwell()
-                    return
+                    return near_edge
             else:  # top, bottom
                 center_x = sx + sw // 2
                 if abs(cx - center_x) > half_zone:
                     self._reset_dwell()
-                    return
+                    return near_edge
 
         # Velocity-based instant trigger: fast cursor slam fires immediately
         if velocity >= EDGE_VELOCITY_INSTANT_PX_PER_S:
@@ -250,15 +484,14 @@ class ScreenEdgeDetector:
             self._reset_dwell()
             logger.info("Edge slam: %s at (%d, %d) vel=%.0f px/s",
                         edge, cx, cy, velocity)
-            if self.on_edge_hit:
-                self.on_edge_hit(edge, cx, cy, screen)
-            return
+            self._dispatch_edge_hit(generation, edge, cx, cy, screen)
+            return False
 
         # Track dwell time
         if edge != self._dwell_edge:
             self._dwell_start = now
             self._dwell_edge = edge
-            return
+            return True
 
         # Check if dwell time exceeded. edge_sensitivity (0-100) scales the
         # required dwell: 100 = quick trigger (~0.2x), 0 = deliberate (~1.8x).
@@ -269,5 +502,7 @@ class ScreenEdgeDetector:
             self._reset_dwell()
 
             logger.info("Edge dwell: %s at (%d, %d)", edge, cx, cy)
-            if self.on_edge_hit:
-                self.on_edge_hit(edge, cx, cy, screen)
+            self._dispatch_edge_hit(generation, edge, cx, cy, screen)
+            return False
+
+        return True

--- a/tests/test_flow_edge_polling.py
+++ b/tests/test_flow_edge_polling.py
@@ -1,0 +1,1186 @@
+"""Behavioral regressions for adaptive Flow edge polling."""
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from types import ModuleType
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, os.fspath(REPO_ROOT / "overlay"))
+
+import flow as flow_module
+from flow import edge_detector as edge_module
+from flow.constants import EDGE_IDLE_POLL_INTERVAL_MS, EDGE_POLL_INTERVAL_MS
+from flow.edge_detector import ScreenEdgeDetector
+
+
+class _WakeEvent:
+    def __init__(self, detector):
+        self.detector = detector
+        self.waits = []
+        self.set_calls = 0
+
+    def wait(self, timeout=None):
+        self.waits.append(timeout)
+        self.detector._running = False
+        return True
+
+    def set(self):
+        self.set_calls += 1
+
+    def clear(self):
+        pass
+
+
+class _Thread:
+    def __init__(self):
+        self.join_calls = []
+
+    def join(self, timeout=None):
+        self.join_calls.append(timeout)
+
+    def is_alive(self):
+        return False
+
+
+def _wait_until(predicate, timeout=1.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+def _run_one_loop(monkeypatch, *, enabled, near_edge):
+    detector = ScreenEdgeDetector()
+    detector._enabled = enabled
+    detector._running = True
+    detector._check_edge = lambda: near_edge
+    wake = _WakeEvent(detector)
+    detector._wake_event = wake
+
+    # The old implementation sleeps directly; stop it after one iteration so
+    # this regression test fails rather than spinning forever on the baseline.
+    monkeypatch.setattr(
+        edge_module.time,
+        "sleep",
+        lambda _timeout: setattr(detector, "_running", False),
+    )
+
+    detector._poll_loop()
+    return wake
+
+
+def test_disabled_detector_waits_for_a_state_change_without_polling(monkeypatch):
+    wake = _run_one_loop(monkeypatch, enabled=False, near_edge=False)
+
+    assert wake.waits == [None]
+
+
+def test_far_cursor_uses_idle_poll_interval(monkeypatch):
+    wake = _run_one_loop(monkeypatch, enabled=True, near_edge=False)
+
+    assert wake.waits == [EDGE_IDLE_POLL_INTERVAL_MS / 1000.0]
+
+
+def test_near_cursor_keeps_the_existing_fast_poll_interval(monkeypatch):
+    wake = _run_one_loop(monkeypatch, enabled=True, near_edge=True)
+
+    assert wake.waits == [EDGE_POLL_INTERVAL_MS / 1000.0]
+
+
+def test_state_changes_wake_the_polling_thread():
+    detector = ScreenEdgeDetector()
+    wake = _WakeEvent(detector)
+    detector._wake_event = wake
+
+    detector.set_enabled(True)
+    detector.suppress_for(100)
+    detector.stop()
+
+    assert wake.set_calls == 3
+
+
+def test_stop_waits_for_the_woken_polling_thread():
+    detector = ScreenEdgeDetector()
+    thread = _Thread()
+    detector._thread = thread
+
+    detector.stop()
+
+    assert len(thread.join_calls) == 1
+    assert 0.0 < thread.join_calls[0] <= 0.2
+    assert detector._thread is None
+
+
+def test_stop_cancels_a_start_blocked_in_config_before_owner_discard(monkeypatch):
+    detector = ScreenEdgeDetector()
+    config_entered = threading.Event()
+    config_release = threading.Event()
+    config_loads = 0
+
+    def blocked_reload():
+        nonlocal config_loads
+        config_loads += 1
+        config_entered.set()
+        assert config_release.wait(timeout=2.0)
+
+    monkeypatch.setattr(detector, "_reload_config", blocked_reload)
+    monkeypatch.setattr(detector, "cache_monitor_geometry", lambda: None)
+    for name in (
+        "_flow_server",
+        "_logi_flow_server",
+        "_logi_discovery",
+        "_presence_server",
+        "_handoff_manager",
+        "_juhflow_bridge",
+        "_flow_indicator",
+    ):
+        monkeypatch.setattr(flow_module, name, None)
+    monkeypatch.setattr(flow_module, "_edge_detector", detector)
+
+    starter = threading.Thread(target=detector.start)
+    try:
+        starter.start()
+        assert config_entered.wait(timeout=1.0)
+
+        started = time.monotonic()
+        flow_module.stop_flow_server()
+        assert time.monotonic() - started < 0.75
+
+        # Queue a replacement behind the cancelled config load, then prove a
+        # later stop cancels that pending request before it can be consumed.
+        detector.start()
+        flow_module.stop_flow_server()
+
+        config_release.set()
+        starter.join(timeout=1.0)
+        assert not starter.is_alive()
+        assert config_loads == 1
+        assert detector._thread is None
+        assert flow_module.get_edge_detector() is detector
+
+        assert detector.stop() is True
+        flow_module.stop_flow_server()
+        assert flow_module.get_edge_detector() is None
+    finally:
+        config_release.set()
+        starter.join(timeout=1.0)
+        detector.stop()
+        thread = detector._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+
+def test_restart_requested_after_bounded_stop_replaces_cancelled_start(monkeypatch):
+    detector = ScreenEdgeDetector()
+    detector._enabled = True
+    first_config_entered = threading.Event()
+    first_config_release = threading.Event()
+    replacement_config_loaded = threading.Event()
+    worker_entered = threading.Event()
+    worker_release = threading.Event()
+    counter_lock = threading.Lock()
+    config_loads = 0
+    active_workers = 0
+    max_active_workers = 0
+    worker_calls = 0
+
+    def blocked_first_reload():
+        nonlocal config_loads
+        with counter_lock:
+            config_loads += 1
+            load = config_loads
+        if load == 1:
+            first_config_entered.set()
+            assert first_config_release.wait(timeout=2.0)
+        else:
+            replacement_config_loaded.set()
+
+    def blocked_check(_generation=None):
+        nonlocal active_workers, max_active_workers, worker_calls
+        with counter_lock:
+            worker_calls += 1
+            active_workers += 1
+            max_active_workers = max(max_active_workers, active_workers)
+        worker_entered.set()
+        assert worker_release.wait(timeout=2.0)
+        with counter_lock:
+            active_workers -= 1
+        return False
+
+    monkeypatch.setattr(detector, "_reload_config", blocked_first_reload)
+    monkeypatch.setattr(detector, "cache_monitor_geometry", lambda: None)
+    detector._check_edge = blocked_check
+    for name in (
+        "_flow_server",
+        "_logi_flow_server",
+        "_logi_discovery",
+        "_presence_server",
+        "_handoff_manager",
+        "_juhflow_bridge",
+        "_flow_indicator",
+    ):
+        monkeypatch.setattr(flow_module, name, None)
+    monkeypatch.setattr(flow_module, "_edge_detector", detector)
+
+    starter = threading.Thread(target=detector.start)
+    try:
+        starter.start()
+        assert first_config_entered.wait(timeout=1.0)
+
+        # The bounded stop invalidates the blocked reservation but retains its
+        # owner because that reservation has not yet cleared.
+        started = time.monotonic()
+        flow_module.stop_flow_server()
+        assert time.monotonic() - started < 0.75
+        assert flow_module.get_edge_detector() is detector
+
+        # A restart requested after stop returns must survive until the stale
+        # config load clears. Concurrent requests coalesce and must not publish
+        # before that release.
+        detector.start()
+        detector.start()
+        assert config_loads == 1
+        assert not worker_entered.is_set()
+
+        first_config_release.set()
+        starter.join(timeout=1.0)
+        assert not starter.is_alive()
+        assert replacement_config_loaded.wait(timeout=1.0)
+        assert worker_entered.wait(timeout=1.0)
+
+        with counter_lock:
+            assert config_loads == 2
+            assert worker_calls == 1
+            assert max_active_workers == 1
+        assert flow_module.get_edge_detector() is detector
+        assert detector._active_generation == detector._generation
+    finally:
+        first_config_release.set()
+        worker_release.set()
+        starter.join(timeout=1.0)
+        detector.stop()
+        thread = detector._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+
+def test_stop_fences_a_blocked_edge_check_before_handoff_teardown(monkeypatch):
+    detector = ScreenEdgeDetector()
+    detector._enabled = True
+    detector._extend_edge_zone = True
+    detector._flow_direction = "right"
+    detector._prev_pos = (0, 500)
+    detector._prev_time = time.monotonic()
+    monkeypatch.setattr(detector, "_reload_config", lambda: None)
+    monkeypatch.setattr(detector, "cache_monitor_geometry", lambda: None)
+
+    cursor_entered = threading.Event()
+    cursor_release = threading.Event()
+    hits = []
+
+    cursor_module = ModuleType("overlay_cursor")
+
+    def blocked_cursor_pos():
+        cursor_entered.set()
+        assert cursor_release.wait(timeout=2.0)
+        return (1_999_995, 500)
+
+    setattr(cursor_module, "get_cursor_pos", blocked_cursor_pos)
+    setattr(
+        cursor_module,
+        "get_screen_geometry",
+        lambda cursor_pos=None: {
+            "x": 0,
+            "y": 0,
+            "width": 2_000_000,
+            "height": 1000,
+        },
+    )
+    monkeypatch.setitem(sys.modules, "overlay_cursor", cursor_module)
+    monkeypatch.setitem(sys.modules, "overlay.overlay_cursor", cursor_module)
+
+    class _HandoffManager:
+        def __init__(self):
+            self.stopped = False
+
+        def on_edge_hit(self, *args):
+            hits.append((self.stopped, args))
+
+        def stop(self):
+            self.stopped = True
+
+    handoff = _HandoffManager()
+    detector.on_edge_hit = handoff.on_edge_hit
+    for name in (
+        "_flow_server",
+        "_logi_flow_server",
+        "_logi_discovery",
+        "_presence_server",
+        "_juhflow_bridge",
+        "_flow_indicator",
+    ):
+        monkeypatch.setattr(flow_module, name, None)
+    monkeypatch.setattr(flow_module, "_edge_detector", detector)
+    monkeypatch.setattr(flow_module, "_handoff_manager", handoff)
+
+    try:
+        detector.start()
+        assert cursor_entered.wait(timeout=1.0)
+        poll_thread = detector._thread
+
+        started = time.monotonic()
+        flow_module.stop_flow_server()
+        assert time.monotonic() - started < 0.75
+        assert poll_thread.is_alive()
+        assert flow_module.get_edge_detector() is detector
+        assert flow_module.get_handoff_manager() is handoff
+        assert handoff.stopped is False
+
+        cursor_release.set()
+        poll_thread.join(timeout=1.0)
+        assert not poll_thread.is_alive()
+        assert hits == []
+
+        flow_module.stop_flow_server()
+        assert flow_module.get_edge_detector() is None
+        assert flow_module.get_handoff_manager() is None
+        assert handoff.stopped is True
+    finally:
+        cursor_release.set()
+        detector.stop()
+        thread = detector._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+
+def test_stop_deadline_retains_handoff_during_a_blocked_callback(monkeypatch):
+    detector = ScreenEdgeDetector()
+    detector._enabled = True
+    monkeypatch.setattr(detector, "_reload_config", lambda: None)
+    monkeypatch.setattr(detector, "cache_monitor_geometry", lambda: None)
+
+    callback_entered = threading.Event()
+    callback_release = threading.Event()
+    callback_finished = threading.Event()
+    callback_observations = []
+
+    class _HandoffManager:
+        def __init__(self):
+            self.stopped = False
+
+        def on_edge_hit(self, *args):
+            callback_entered.set()
+            callback_release.wait(timeout=2.0)
+            callback_observations.append((self.stopped, args))
+            callback_finished.set()
+
+        def stop(self):
+            self.stopped = True
+
+    handoff = _HandoffManager()
+    detector.on_edge_hit = handoff.on_edge_hit
+
+    dispatched = False
+
+    def dispatch_once(generation=None):
+        nonlocal dispatched
+        if not dispatched:
+            dispatched = True
+            detector._dispatch_edge_hit(
+                generation,
+                "right",
+                995,
+                500,
+                {"x": 0, "y": 0, "width": 1000, "height": 1000},
+            )
+        return False
+
+    detector._check_edge = dispatch_once
+    for name in (
+        "_flow_server",
+        "_logi_flow_server",
+        "_logi_discovery",
+        "_presence_server",
+        "_juhflow_bridge",
+        "_flow_indicator",
+    ):
+        monkeypatch.setattr(flow_module, name, None)
+    monkeypatch.setattr(flow_module, "_edge_detector", detector)
+    monkeypatch.setattr(flow_module, "_handoff_manager", handoff)
+
+    try:
+        detector.start()
+        assert callback_entered.wait(timeout=1.0)
+        poll_thread = detector._thread
+
+        started = time.monotonic()
+        flow_module.stop_flow_server()
+        elapsed = time.monotonic() - started
+
+        assert 0.15 <= elapsed < 0.75
+        assert poll_thread.is_alive()
+        assert flow_module.get_edge_detector() is detector
+        assert flow_module.get_handoff_manager() is handoff
+        assert handoff.stopped is False
+
+        callback_release.set()
+        assert callback_finished.wait(timeout=1.0)
+        poll_thread.join(timeout=1.0)
+        assert not poll_thread.is_alive()
+        assert callback_observations == [(False, (
+            "right",
+            995,
+            500,
+            {"x": 0, "y": 0, "width": 1000, "height": 1000},
+        ))]
+
+        flow_module.stop_flow_server()
+        assert flow_module.get_edge_detector() is None
+        assert flow_module.get_handoff_manager() is None
+        assert handoff.stopped is True
+    finally:
+        callback_release.set()
+        detector.stop()
+        thread = detector._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+
+def test_retained_callback_dependency_graph_survives_stop_and_restart(
+    monkeypatch, tmp_path
+):
+    """A bounded stop retains every dependency of a real handoff callback."""
+    config_dir = tmp_path / ".config" / "juhradial"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.json"
+    config_path.write_text('{"flow": {"edge_trigger": true}}')
+    monkeypatch.setenv("HOME", os.fspath(tmp_path))
+
+    detector = ScreenEdgeDetector()
+    monkeypatch.setattr(detector, "_reload_config", lambda: None)
+    monkeypatch.setattr(detector, "cache_monitor_geometry", lambda: None)
+
+    callback_armed = threading.Event()
+    callback_entered = threading.Event()
+    callback_release = threading.Event()
+    callback_finished = threading.Event()
+    observations = []
+    teardown = []
+    dispatched = False
+
+    def dispatch_once(generation=None):
+        nonlocal dispatched
+        assert callback_armed.wait(timeout=2.0)
+        if not dispatched:
+            dispatched = True
+            detector._dispatch_edge_hit(
+                generation,
+                "right",
+                995,
+                500,
+                {"x": 0, "y": 0, "width": 1000, "height": 1000},
+            )
+        return False
+
+    detector._check_edge = dispatch_once
+
+    class _Service:
+        def __init__(self, *args, **kwargs):
+            self.started = False
+            self.stopped = False
+            self.start_calls = 0
+            self.stop_calls = 0
+            self.on_message = None
+
+        def start(self):
+            self.started = True
+            self.start_calls += 1
+
+        def stop(self):
+            self.stopped = True
+            self.stop_calls += 1
+
+        def add_peer_key(self, *args):
+            pass
+
+    class _Presence(_Service):
+        instances = []
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.instances.append(self)
+
+        def stop(self):
+            teardown.append("presence")
+            super().stop()
+
+        def send_to_peer(self, peer_name, message):
+            observations.append((
+                "presence",
+                self.stopped,
+                self.on_message.__self__,
+                peer_name,
+                message["type"],
+            ))
+            return True
+
+    class _Bridge(_Service):
+        instances = []
+
+        def __init__(self, on_edge_hit=None, on_clipboard=None, **kwargs):
+            super().__init__(**kwargs)
+            self.instances.append(self)
+            self.on_edge_hit = on_edge_hit
+            self.on_clipboard = on_clipboard
+
+        def stop(self):
+            teardown.append("bridge")
+            super().stop()
+
+        def get_peers(self):
+            return {"bridge-peer": object()}
+
+        def send_edge_hit(self, edge, position, screen, relative_position=None):
+            observations.append((
+                "bridge",
+                self.stopped,
+                edge,
+                position,
+                relative_position,
+            ))
+
+    class _Indicator:
+        def configure(self, direction):
+            pass
+
+        def hide(self):
+            pass
+
+        def deleteLater(self):
+            pass
+
+    keys_module = ModuleType("flow.keys")
+    keys_module.generate_identity = lambda: (object(), b"public", b"node")
+    keys_module.get_all_peers = lambda: {}
+    bridge_module = ModuleType("flow.juhflow_bridge")
+    bridge_module.JuhFlowBridge = _Bridge
+    indicator_module = ModuleType("flow.indicator")
+    indicator_module.FlowEdgeIndicator = _Indicator
+    monkeypatch.setitem(sys.modules, "flow.keys", keys_module)
+    monkeypatch.setitem(sys.modules, "flow.juhflow_bridge", bridge_module)
+    monkeypatch.setitem(sys.modules, "flow.indicator", indicator_module)
+    monkeypatch.setattr(edge_module, "ScreenEdgeDetector", lambda: detector)
+    monkeypatch.setattr(flow_module, "FlowServer", _Service)
+    monkeypatch.setattr(flow_module, "LogiFlowServer", _Service)
+    monkeypatch.setattr(flow_module, "FlowPresenceServer", _Presence)
+    monkeypatch.setattr(flow_module, "LogiFlowDiscoveryResponder", _Service)
+
+    from flow import handoff as handoff_module
+
+    monkeypatch.setattr(handoff_module, "_CFG_PATH", config_path)
+    for name in (
+        "_flow_server",
+        "_logi_flow_server",
+        "_logi_discovery",
+        "_presence_server",
+        "_handoff_manager",
+        "_edge_detector",
+        "_juhflow_bridge",
+        "_flow_indicator",
+    ):
+        monkeypatch.setattr(flow_module, name, None)
+
+    manager = None
+    presence = None
+    bridge = None
+    callback_thread = None
+    try:
+        flow_module.start_flow_server()
+        manager = flow_module.get_handoff_manager()
+        presence = flow_module.get_presence_server()
+        bridge = flow_module.get_juhflow_bridge()
+        manager.set_peer_edge("presence-peer", "right")
+        monkeypatch.setattr(manager, "_sync_clipboard", lambda _peer: None)
+
+        manager_stop = manager.stop
+
+        def counted_manager_stop():
+            teardown.append("manager")
+            manager_stop()
+
+        monkeypatch.setattr(manager, "stop", counted_manager_stop)
+
+        config_calls = 0
+
+        def blocked_flow_config():
+            nonlocal config_calls
+            config_calls += 1
+            if config_calls == 1:
+                callback_entered.set()
+                assert callback_release.wait(timeout=2.0)
+                callback_finished.set()
+            return {"direction": "right"}
+
+        monkeypatch.setattr(manager, "get_flow_config", blocked_flow_config)
+        callback_armed.set()
+        assert callback_entered.wait(timeout=1.0)
+        callback_thread = detector._thread
+
+        started = time.monotonic()
+        flow_module.stop_flow_server()
+        elapsed = time.monotonic() - started
+
+        assert 0.15 <= elapsed < 0.75
+        assert callback_thread.is_alive()
+        assert flow_module.get_edge_detector() is detector
+        assert flow_module.get_handoff_manager() is manager
+        assert flow_module.get_presence_server() is presence
+        assert flow_module.get_juhflow_bridge() is bridge
+        assert manager.presence_server is presence
+        assert manager.juhflow_bridge is bridge
+        assert presence.on_message.__self__ is manager
+        assert teardown == []
+        assert manager.presence_clients == {}
+        assert presence.stop_calls == 0
+        assert bridge.stop_calls == 0
+
+        callback_release.set()
+        assert callback_finished.wait(timeout=1.0)
+        callback_thread.join(timeout=1.0)
+        assert not callback_thread.is_alive()
+        assert observations == [
+            ("presence", False, manager, "presence-peer", "cursor_handoff"),
+            ("bridge", False, "right", (995, 500), 0.5),
+        ]
+
+        config_path.write_text('{"flow": {"edge_trigger": false}}')
+        flow_module.start_flow_server()
+
+        assert flow_module.get_edge_detector() is detector
+        assert flow_module.get_handoff_manager() is manager
+        assert flow_module.get_presence_server() is presence
+        assert flow_module.get_juhflow_bridge() is bridge
+        assert manager.presence_server is presence
+        assert manager.juhflow_bridge is bridge
+        assert presence.on_message.__self__ is manager
+        assert detector.on_edge_hit.__self__ is manager
+        assert len(_Presence.instances) == 1
+        assert len(_Bridge.instances) == 1
+        assert detector._enabled is False
+        assert detector._thread is not callback_thread
+
+        flow_module.stop_flow_server()
+
+        assert flow_module.get_edge_detector() is None
+        assert flow_module.get_handoff_manager() is None
+        assert flow_module.get_presence_server() is None
+        assert flow_module.get_juhflow_bridge() is None
+        assert teardown == ["manager", "bridge", "presence"]
+        assert presence.stop_calls == 1
+        assert bridge.stop_calls == 1
+    finally:
+        callback_armed.set()
+        callback_release.set()
+        flow_module.stop_flow_server()
+        detector.stop()
+        thread = detector._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+
+def test_callback_can_stop_reentrantly_without_claiming_quiescence(monkeypatch):
+    detector = ScreenEdgeDetector()
+    detector._enabled = True
+    monkeypatch.setattr(detector, "_reload_config", lambda: None)
+    monkeypatch.setattr(detector, "cache_monitor_geometry", lambda: None)
+
+    callback_finished = threading.Event()
+    stop_results = []
+
+    def on_edge_hit(*_args):
+        started = time.monotonic()
+        stop_results.append((detector.stop(), time.monotonic() - started))
+        callback_finished.set()
+
+    detector.on_edge_hit = on_edge_hit
+    dispatched = False
+
+    def dispatch_once(generation=None):
+        nonlocal dispatched
+        if not dispatched:
+            dispatched = True
+            detector._dispatch_edge_hit(
+                generation,
+                "right",
+                995,
+                500,
+                {"x": 0, "y": 0, "width": 1000, "height": 1000},
+            )
+        return False
+
+    detector._check_edge = dispatch_once
+
+    detector.start()
+    assert callback_finished.wait(timeout=1.0)
+    poll_thread = detector._thread
+    poll_thread.join(timeout=1.0)
+
+    assert not poll_thread.is_alive()
+    assert stop_results[0][0] is False
+    assert stop_results[0][1] < 0.5
+    assert detector.stop() is True
+
+
+def test_stop_restart_never_overlaps_or_orphans_a_blocked_poll_thread(monkeypatch):
+    detector = ScreenEdgeDetector()
+    detector._enabled = True
+    monkeypatch.setattr(detector, "_reload_config", lambda: None)
+    monkeypatch.setattr(detector, "cache_monitor_geometry", lambda: None)
+
+    first_entered = threading.Event()
+    first_release = threading.Event()
+    replacement_entered = threading.Event()
+    replacement_release = threading.Event()
+    counter_lock = threading.Lock()
+    active = 0
+    max_active = 0
+    calls = 0
+
+    def blocked_check(_generation=None):
+        nonlocal active, max_active, calls
+        with counter_lock:
+            calls += 1
+            call = calls
+            active += 1
+            max_active = max(max_active, active)
+        entered = first_entered if call == 1 else replacement_entered
+        release = first_release if call == 1 else replacement_release
+        entered.set()
+        release.wait(timeout=2.0)
+        with counter_lock:
+            active -= 1
+        return False
+
+    detector._check_edge = blocked_check
+    for name in (
+        "_flow_server",
+        "_logi_flow_server",
+        "_logi_discovery",
+        "_presence_server",
+        "_handoff_manager",
+        "_juhflow_bridge",
+        "_flow_indicator",
+    ):
+        monkeypatch.setattr(flow_module, name, None)
+    monkeypatch.setattr(flow_module, "_edge_detector", detector)
+
+    try:
+        detector.start()
+        assert first_entered.wait(timeout=1.0)
+        first_thread = detector._thread
+
+        # stop_flow_server must return promptly, but it must retain ownership
+        # while the real poll thread remains blocked beyond the 200 ms join.
+        started = time.monotonic()
+        flow_module.stop_flow_server()
+        assert time.monotonic() - started < 0.75
+        assert flow_module.get_edge_detector() is detector
+        assert first_thread.is_alive()
+
+        # This is the detector.start() performed by the next Flow startup. It
+        # records a pending restart rather than creating an overlapping thread.
+        detector.start()
+        time.sleep(0.05)
+        assert calls == 1
+
+        first_release.set()
+        assert replacement_entered.wait(timeout=1.0)
+        replacement_thread = detector._thread
+        assert replacement_thread is not first_thread
+        assert not first_thread.is_alive()
+        first_thread.join(timeout=1.0)
+        assert max_active == 1
+
+        replacement_release.set()
+        assert detector.stop() is True
+        assert detector._thread is None
+        assert not replacement_thread.is_alive()
+    finally:
+        first_release.set()
+        replacement_release.set()
+        detector.stop()
+        thread = detector._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+
+def test_restart_resets_state_written_by_a_terminal_old_edge_check(monkeypatch):
+    detector = ScreenEdgeDetector()
+    detector._enabled = True
+    detector._extend_edge_zone = True
+    detector._flow_direction = "right"
+    monkeypatch.setattr(detector, "_reload_config", lambda: None)
+    monkeypatch.setattr(detector, "cache_monitor_geometry", lambda: None)
+    monkeypatch.setattr(edge_module, "EDGE_DWELL_MS", 0)
+    monkeypatch.setattr(edge_module, "EDGE_VELOCITY_INSTANT_PX_PER_S", 0.000001)
+
+    cursor_entered = threading.Event()
+    cursor_release = threading.Event()
+    old_state_written = threading.Event()
+    old_return_release = threading.Event()
+    replacement_sampled = threading.Event()
+    replacement_return_release = threading.Event()
+    call_lock = threading.Lock()
+    cursor_calls = 0
+    check_calls = 0
+    hits = []
+    old_state = {}
+    replacement_state = {}
+
+    cursor_module = ModuleType("overlay_cursor")
+
+    def get_cursor_pos():
+        nonlocal cursor_calls
+        with call_lock:
+            cursor_calls += 1
+            call = cursor_calls
+        if call == 1:
+            cursor_entered.set()
+            cursor_release.wait(timeout=2.0)
+            return (995, 500)
+        return (996, 500)
+
+    setattr(cursor_module, "get_cursor_pos", get_cursor_pos)
+    setattr(
+        cursor_module,
+        "get_screen_geometry",
+        lambda cursor_pos=None: {
+            "x": 0,
+            "y": 0,
+            "width": 1000,
+            "height": 1000,
+        },
+    )
+    monkeypatch.setitem(sys.modules, "overlay_cursor", cursor_module)
+    monkeypatch.setitem(sys.modules, "overlay.overlay_cursor", cursor_module)
+    detector.on_edge_hit = lambda *args: hits.append(args)
+
+    real_check_edge = detector._check_edge
+
+    def observed_check(generation=None):
+        nonlocal check_calls
+        with call_lock:
+            check_calls += 1
+            call = check_calls
+        result = real_check_edge(generation)
+        state = {
+            "dwell_start": detector._dwell_start,
+            "dwell_edge": detector._dwell_edge,
+            "prev_pos": detector._prev_pos,
+            "prev_time": detector._prev_time,
+            "last_fire_time": detector._last_fire_time,
+            "result": result,
+        }
+        if call == 1:
+            old_state.update(state)
+            old_state_written.set()
+            old_return_release.wait(timeout=2.0)
+        else:
+            replacement_state.update(state)
+            replacement_sampled.set()
+            replacement_return_release.wait(timeout=2.0)
+        return result
+
+    detector._check_edge = observed_check
+
+    try:
+        detector.start()
+        assert cursor_entered.wait(timeout=1.0)
+        first_thread = detector._thread
+
+        # The old sample passed cooldown before blocking. Seed an otherwise
+        # expired generation-local cooldown while it is blocked so restart must
+        # clear that state as well as dwell and velocity history.
+        assert detector.stop() is False
+        stale_fire_time = time.monotonic() - 10.0
+        detector._last_fire_time = stale_fire_time
+        detector.start()
+
+        cursor_release.set()
+        assert old_state_written.wait(timeout=1.0)
+        assert old_state["dwell_edge"] == "right"
+        assert old_state["dwell_start"] is not None
+        assert old_state["prev_pos"] == (995, 500)
+        assert old_state["prev_time"] > 0
+        assert old_state["last_fire_time"] == stale_fire_time
+        assert old_state["result"] is True
+
+        old_return_release.set()
+        assert replacement_sampled.wait(timeout=1.0)
+        replacement_thread = detector._thread
+        assert replacement_thread is not first_thread
+        assert not first_thread.is_alive()
+
+        # A replacement's first real sample establishes new dwell/velocity
+        # state. It must neither inherit enough dwell nor derive slam velocity
+        # from the terminal generation, and stale cooldown must be gone.
+        assert hits == []
+        assert replacement_state["result"] is True
+        assert replacement_state["dwell_edge"] == "right"
+        assert replacement_state["dwell_start"] is not None
+        assert replacement_state["prev_pos"] == (996, 500)
+        assert replacement_state["prev_time"] > old_state["prev_time"]
+        assert replacement_state["last_fire_time"] == 0.0
+    finally:
+        cursor_release.set()
+        old_return_release.set()
+        replacement_return_release.set()
+        detector.stop()
+        thread = detector._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+
+def test_retained_production_owner_applies_disabled_edge_config_on_restart(
+    monkeypatch, tmp_path
+):
+    config_dir = tmp_path / ".config" / "juhradial"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.json"
+    config_path.write_text('{"flow": {"edge_trigger": true}}')
+    monkeypatch.setenv("HOME", os.fspath(tmp_path))
+
+    detector = ScreenEdgeDetector()
+    monkeypatch.setattr(detector, "_reload_config", lambda: None)
+    monkeypatch.setattr(detector, "cache_monitor_geometry", lambda: None)
+
+    class _RecordingEvent:
+        def __init__(self):
+            self.event = threading.Event()
+            self.indefinite_wait = threading.Event()
+
+        def wait(self, timeout=None):
+            if timeout is None:
+                self.indefinite_wait.set()
+            return self.event.wait(timeout)
+
+        def set(self):
+            self.event.set()
+
+        def clear(self):
+            self.event.clear()
+
+    wake = _RecordingEvent()
+    detector._wake_event = wake
+    first_check_entered = threading.Event()
+    first_check_release = threading.Event()
+    unexpected_check = threading.Event()
+    check_lock = threading.Lock()
+    check_calls = 0
+    hits = []
+
+    def blocked_check(generation=None):
+        nonlocal check_calls
+        with check_lock:
+            check_calls += 1
+            call = check_calls
+        if call == 1:
+            first_check_entered.set()
+            first_check_release.wait(timeout=2.0)
+        else:
+            unexpected_check.set()
+            detector._dispatch_edge_hit(
+                generation,
+                "right",
+                995,
+                500,
+                {"x": 0, "y": 0, "width": 1000, "height": 1000},
+            )
+        return False
+
+    detector._check_edge = blocked_check
+
+    class _Service:
+        def __init__(self, *args, **kwargs):
+            self.stopped = False
+            self.on_message = None
+
+        def start(self):
+            pass
+
+        def stop(self):
+            self.stopped = True
+
+        def add_peer_key(self, *args):
+            pass
+
+    class _HandoffManager:
+        def __init__(self, edge_detector=None, presence_server=None):
+            self.edge_detector = edge_detector
+            self.presence_server = presence_server
+            self.juhflow_bridge = None
+            self.stopped = False
+            if edge_detector is not None:
+                edge_detector.on_edge_hit = self.on_edge_hit
+
+        def on_edge_hit(self, *args):
+            hits.append(args)
+
+        def cache_flow_monitor_geometry(self):
+            pass
+
+        def connect_to_peer(self, *args):
+            pass
+
+        def stop(self):
+            self.stopped = True
+
+    class _Bridge(_Service):
+        pass
+
+    class _Indicator:
+        def configure(self, direction):
+            pass
+
+        def hide(self):
+            pass
+
+        def deleteLater(self):
+            pass
+
+    keys_module = ModuleType("flow.keys")
+    keys_module.generate_identity = lambda: (object(), b"public", b"node")
+    keys_module.get_all_peers = lambda: {}
+    handoff_module = ModuleType("flow.handoff")
+    handoff_module.FlowHandoffManager = _HandoffManager
+    bridge_module = ModuleType("flow.juhflow_bridge")
+    bridge_module.JuhFlowBridge = _Bridge
+    indicator_module = ModuleType("flow.indicator")
+    indicator_module.FlowEdgeIndicator = _Indicator
+    monkeypatch.setitem(sys.modules, "flow.keys", keys_module)
+    monkeypatch.setitem(sys.modules, "flow.handoff", handoff_module)
+    monkeypatch.setitem(sys.modules, "flow.juhflow_bridge", bridge_module)
+    monkeypatch.setitem(sys.modules, "flow.indicator", indicator_module)
+    monkeypatch.setattr(edge_module, "ScreenEdgeDetector", lambda: detector)
+    monkeypatch.setattr(flow_module, "FlowServer", _Service)
+    monkeypatch.setattr(flow_module, "LogiFlowServer", _Service)
+    monkeypatch.setattr(flow_module, "FlowPresenceServer", _Service)
+    monkeypatch.setattr(flow_module, "LogiFlowDiscoveryResponder", _Service)
+
+    for name in (
+        "_flow_server",
+        "_logi_flow_server",
+        "_logi_discovery",
+        "_presence_server",
+        "_handoff_manager",
+        "_edge_detector",
+        "_juhflow_bridge",
+        "_flow_indicator",
+    ):
+        monkeypatch.setattr(flow_module, name, None)
+
+    manager = None
+    try:
+        flow_module.start_flow_server()
+        assert first_check_entered.wait(timeout=1.0)
+        first_thread = detector._thread
+        manager = flow_module.get_handoff_manager()
+        assert detector._enabled is True
+
+        started = time.monotonic()
+        flow_module.stop_flow_server()
+        assert time.monotonic() - started < 0.75
+        assert flow_module.get_edge_detector() is detector
+        assert flow_module.get_handoff_manager() is manager
+        assert manager.stopped is False
+
+        config_path.write_text('{"flow": {"edge_trigger": false}}')
+        flow_module.start_flow_server()
+        first_check_release.set()
+
+        assert _wait_until(
+            lambda: wake.indefinite_wait.is_set() or unexpected_check.is_set()
+        )
+        assert detector._thread is not first_thread
+        assert not first_thread.is_alive()
+        assert detector._enabled is False
+        assert wake.indefinite_wait.is_set()
+        assert not unexpected_check.is_set()
+        assert check_calls == 1
+        assert hits == []
+
+        flow_module.stop_flow_server()
+        assert flow_module.get_edge_detector() is None
+        assert flow_module.get_handoff_manager() is None
+        assert manager.stopped is True
+    finally:
+        first_check_release.set()
+        flow_module.stop_flow_server()
+        detector.stop()
+        thread = detector._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+
+def _install_cursor(monkeypatch, positions, screen=None):
+    samples = iter(positions)
+    cursor_module = ModuleType("overlay_cursor")
+    setattr(cursor_module, "get_cursor_pos", lambda: next(samples))
+    setattr(
+        cursor_module,
+        "get_screen_geometry",
+        lambda cursor_pos=None: screen
+        or {"x": 0, "y": 0, "width": 1000, "height": 1000},
+    )
+    monkeypatch.setitem(sys.modules, "overlay_cursor", cursor_module)
+    monkeypatch.setitem(sys.modules, "overlay.overlay_cursor", cursor_module)
+
+
+def test_edge_check_reports_far_and_near_polling_zones(monkeypatch):
+    detector = ScreenEdgeDetector()
+    detector._extend_edge_zone = True
+    detector._flow_direction = "right"
+    monkeypatch.setattr(edge_module.time, "monotonic", lambda: 100.0)
+    _install_cursor(monkeypatch, [(500, 500), (950, 500), (995, 500)])
+
+    assert detector._check_edge() is False
+    assert detector._check_edge() is True
+    assert detector._check_edge() is True
+
+
+def test_existing_dwell_threshold_still_fires(monkeypatch):
+    detector = ScreenEdgeDetector()
+    detector._extend_edge_zone = True
+    detector._flow_direction = "right"
+    hits = []
+    detector.on_edge_hit = lambda *args: hits.append(args)
+    clock = iter([100.0, 100.4])
+    monkeypatch.setattr(edge_module.time, "monotonic", lambda: next(clock))
+    _install_cursor(monkeypatch, [(995, 500), (995, 500)])
+
+    assert detector._check_edge() is True
+    assert detector._check_edge() is False
+    assert len(hits) == 1
+    assert hits[0][0] == "right"
+
+
+def test_existing_fast_slam_still_fires_immediately(monkeypatch):
+    detector = ScreenEdgeDetector()
+    detector._extend_edge_zone = True
+    detector._flow_direction = "right"
+    hits = []
+    detector.on_edge_hit = lambda *args: hits.append(args)
+    clock = iter([100.0, 100.01])
+    monkeypatch.setattr(edge_module.time, "monotonic", lambda: next(clock))
+    _install_cursor(monkeypatch, [(500, 500), (995, 500)])
+
+    assert detector._check_edge() is False
+    assert detector._check_edge() is False
+    assert len(hits) == 1
+    assert hits[0][0] == "right"


### PR DESCRIPTION
## Summary

Adapt Flow edge polling to cursor proximity: keep the existing 8 ms cadence near an active edge, but use a 32 ms cadence while the cursor is farther than 64 px away.

## Why

The edge detector previously polled every 8 ms for its entire enabled lifetime, including long idle periods when the cursor was nowhere near a handoff edge. The near-edge hot path must stay responsive, while far-away checks can run less often.

## Measured impact

In a deterministic 250 ms cadence probe:

- far from every edge: 31 checks -> 8 checks (about 74% fewer)
- within the 64 px approach zone: 31 checks -> 31 checks
- disabled state: event-driven wait instead of periodic polling

## Behavior

- preserve the original 8 ms cadence inside the 64 px approach zone
- use a 32 ms cadence only while outside that zone
- enable, disable, stop, suppression, and configuration changes wake the worker immediately
- stop uses a shared 200 ms deadline for worker/start/callback quiescence
- non-quiescent stop retains the entire detector, handoff manager, presence server, and bridge ownership graph
- only a quiescent detector permits dependent-first teardown of the retained Flow graph
- start generations are reserved before configuration I/O, and restart requests behind a cancelled load coalesce into one replacement worker
- callbacks are generation-checked; replacement workers reset generation-local dwell, velocity, sample, and cooldown state after the old worker exits
- retained detectors always apply the current enabled or disabled configuration before restart
- retained restarts reuse the existing presence/bridge/manager wiring without duplicates
- elapsed-time configuration reload remains approximately every two seconds
- dwell, fast-slam, cooldown, monitor filtering, and indicator-zone behavior are preserved

## Testing

- focused adaptive polling and lifecycle regressions: 17 passed
- full overlay pytest suite: 67 passed
- JuhFlow bridge suite: 12 passed
- full Flow unittest discovery: 30 passed
- `py_compile`
- `git diff --check`

## Scope

Only Flow edge-poll scheduling and its lifecycle ownership are changed. Menu rendering, non-Flow input handling, and handoff transport behavior remain unchanged.

## Pull Request Checklist

- [x] Performance improvement
- [x] Code follows the project style and has been self-reviewed
- [x] Hard-to-understand lifecycle or concurrency behavior is documented in code where needed
- [x] The change introduces no new warnings
- [x] Regression tests cover the changed behavior
- [x] New and existing relevant unit tests pass locally
- [x] No dependent changes need to be merged first

Documentation was updated where the externally visible compositor contract changed; otherwise no user-facing documentation change is required. Tests used deterministic fakes/mocks or the offscreen platform and do not require a physical MX Master 4 or a live KDE session.
