### PR TITLE
perf: batch ThumbWheel helper invocations

### DIFF
--- a/daemon/src/actions.rs
+++ b/daemon/src/actions.rs
@@ -87,7 +87,7 @@ impl ActionExecutor {
     pub async fn execute(action: &Action) -> Result<(), ActionError> {
         match &action.action_type {
             ActionType::Shortcut(keys) => {
-                Self::execute_shortcut(keys).await
+                Self::execute_shortcut(keys, 1).await
             }
             ActionType::Command(cmd) => {
                 Self::execute_command(cmd).await
@@ -108,10 +108,14 @@ impl ActionExecutor {
     /// Format: "ctrl+c", "ctrl+shift+z", "super+e"
     ///
     /// AC1: Execution within 10ms
-    async fn execute_shortcut(keys: &str) -> Result<(), ActionError> {
+    async fn execute_shortcut(keys: &str, repeats: u8) -> Result<(), ActionError> {
+        if repeats == 0 {
+            return Ok(());
+        }
+
         let start = Instant::now();
 
-        tracing::info!(keys, "Executing keyboard shortcut");
+        tracing::info!(keys, repeats, "Executing keyboard shortcut");
 
         // session_var, not std::env: started from the systemd user unit the
         // daemon has neither variable, so this read said "X11" on a Wayland
@@ -129,7 +133,7 @@ impl ActionExecutor {
         let mut injected = false;
         if is_wayland {
             if let Some(codes) = Self::shortcut_to_evdev_codes(keys) {
-                injected = Self::inject_via_ydotool(keys, &codes);
+                injected = Self::inject_via_ydotool(keys, &codes, repeats);
                 if !injected {
                     tracing::warn!(keys, "ydotool injection failed; trying xdotool");
                 }
@@ -142,14 +146,14 @@ impl ActionExecutor {
         // XF86AudioRaiseVolume), so pass the ORIGINAL case to xdotool.
         if !injected {
             let mut cmd = Command::new("xdotool");
-            cmd.args(["key", keys]);
+            cmd.args(Self::xdotool_shortcut_args(keys, repeats));
             apply_session_env(&mut cmd);
             match cmd.spawn() {
                 Ok(child) => reap_in_background(child, keys, "xdotool"),
                 Err(e) => {
                     tracing::debug!("xdotool unavailable: {}, trying ydotool codes", e);
                     let ok = Self::shortcut_to_evdev_codes(keys)
-                        .map(|c| Self::inject_via_ydotool(keys, &c))
+                        .map(|c| Self::inject_via_ydotool(keys, &c, repeats))
                         .unwrap_or(false);
                     if !ok {
                         return Err(ActionError::ExecutionFailed(format!(
@@ -222,13 +226,33 @@ impl ActionExecutor {
         }
     }
 
+    /// Build one xdotool invocation for the complete shortcut burst.
+    fn xdotool_shortcut_args(keys: &str, repeats: u8) -> Vec<String> {
+        let mut args = vec!["key".to_string()];
+        if repeats > 1 {
+            args.extend(["--repeat".to_string(), repeats.to_string()]);
+        }
+        args.push(keys.to_string());
+        args
+    }
+
+    /// Build one ydotool invocation for the complete shortcut burst. ydotool's
+    /// `key` subcommand has no repeat flag, but accepts an arbitrary sequence of
+    /// press/release events, so repeat the chord inside one argument vector.
+    fn ydotool_shortcut_args(codes: &[u16], repeats: u8) -> Vec<String> {
+        let mut args = vec!["key".to_string()];
+        for _ in 0..repeats {
+            args.extend(codes.iter().map(|c| format!("{}:1", c)));
+            args.extend(codes.iter().rev().map(|c| format!("{}:0", c)));
+        }
+        args
+    }
+
     /// Inject a key chord through the kernel uinput device via ydotool: press
     /// every code in order, then release in reverse. ydotool uses uinput, so it
     /// drives both X11 and Wayland (incl. KDE Plasma). Returns true if started.
-    fn inject_via_ydotool(keys: &str, codes: &[u16]) -> bool {
-        let mut args: Vec<String> = vec!["key".to_string()];
-        args.extend(codes.iter().map(|c| format!("{}:1", c)));
-        args.extend(codes.iter().rev().map(|c| format!("{}:0", c)));
+    fn inject_via_ydotool(keys: &str, codes: &[u16], repeats: u8) -> bool {
+        let args = Self::ydotool_shortcut_args(codes, repeats);
         match Command::new("ydotool").args(&args).spawn() {
             Ok(child) => {
                 reap_in_background(child, keys, "ydotool");
@@ -705,41 +729,100 @@ pub async fn execute_button_action(action: ButtonAction) -> Result<bool, ActionE
     }
 }
 
+/// Execute a button action repeatedly. Shortcut-backed actions (including every
+/// diverted ThumbWheel button output) are synthesized by a single helper
+/// process; other action kinds preserve their existing per-execution behavior.
+pub async fn execute_button_action_repeated(
+    action: ButtonAction,
+    repeats: u8,
+) -> Result<bool, ActionError> {
+    if repeats == 0 {
+        return Ok(true);
+    }
+    if repeats == 1 {
+        return execute_button_action(action).await;
+    }
+
+    if let Some(keys) = button_action_to_shortcut(action) {
+        ActionExecutor::execute_shortcut(keys, repeats).await?;
+        return Ok(true);
+    }
+
+    let mut handled = true;
+    for _ in 0..repeats {
+        handled &= execute_button_action(action).await?;
+    }
+    Ok(handled)
+}
+
+/// Build one xdotool command for a complete horizontal-scroll burst.
+fn xdotool_horizontal_scroll_args(clicks: i32) -> Option<Vec<String>> {
+    let count = clicks.unsigned_abs().min(16);
+    if count == 0 {
+        return None;
+    }
+    let button = if clicks > 0 { "7" } else { "6" };
+    Some(vec![
+        "click".to_string(),
+        "--repeat".to_string(),
+        count.to_string(),
+        button.to_string(),
+    ])
+}
+
+/// Build one ydotool command for a complete horizontal-scroll burst.
+///
+/// ydotool's `click` IDs 0x06/0x07 are BACK/TASK buttons, not wheel directions.
+/// Its `mousemove --wheel -- X Y` form emits X as one signed REL_HWHEEL value
+/// and Y as REL_WHEEL, so the signed magnitude carries the complete burst in a
+/// single process without a shell.
+fn ydotool_horizontal_scroll_args(clicks: i32) -> Option<Vec<String>> {
+    let horizontal = clicks.clamp(-16, 16);
+    if horizontal == 0 {
+        return None;
+    }
+    Some(vec![
+        "mousemove".to_string(),
+        "--wheel".to_string(),
+        "--".to_string(),
+        horizontal.to_string(),
+        "0".to_string(),
+    ])
+}
+
 /// Inject horizontal scroll clicks for the diverted thumb wheel.
 ///
 /// Positive `clicks` scroll right, negative scroll left. Horizontal scroll on
 /// X11 is mouse buttons 6 (left) and 7 (right); xdotool synthesizes these
 /// directly, with ydotool as a Wayland fallback (consistent with the keyboard
-/// shortcut path). Non-blocking: each click is spawned, not awaited.
+/// shortcut path). Non-blocking: the complete burst is spawned once and reaped
+/// in the background.
 pub async fn execute_horizontal_scroll(clicks: i32) -> Result<(), ActionError> {
-    if clicks == 0 {
+    let Some(args) = xdotool_horizontal_scroll_args(clicks) else {
         return Ok(());
-    }
-    // Button 6 = scroll left, 7 = scroll right.
-    let button = if clicks > 0 { "7" } else { "6" };
+    };
     let count = clicks.unsigned_abs().min(16);
+    let input = format!("horizontal scroll x{count}");
 
-    for _ in 0..count {
-        let mut cmd = Command::new("xdotool");
-        cmd.args(["click", button]);
-        // Same hole as the shortcut path: without the session environment
-        // xdotool dies on an empty DISPLAY and the click is lost (issue #60).
-        apply_session_env(&mut cmd);
-        match cmd.spawn() {
-            Ok(child) => reap_in_background(child, button, "xdotool"),
-            Err(e) => {
-                tracing::debug!("xdotool horizontal scroll failed: {}, trying ydotool", e);
-                // ydotool click button codes: 0x06 = left scroll, 0x07 = right scroll.
-                let yd_button = if clicks > 0 { "0x07" } else { "0x06" };
-                match Command::new("ydotool").args(["click", yd_button]).spawn() {
-                    Ok(child) => reap_in_background(child, yd_button, "ydotool"),
-                    Err(e2) => {
-                        tracing::error!("Both xdotool and ydotool horizontal scroll failed: {}", e2);
-                        return Err(ActionError::ExecutionFailed(format!(
-                            "Horizontal scroll failed: {}",
-                            e2
-                        )));
-                    }
+    let mut cmd = Command::new("xdotool");
+    cmd.args(&args);
+    // Same hole as the shortcut path: without the session environment xdotool
+    // dies on an empty DISPLAY and the click is lost (issue #60).
+    apply_session_env(&mut cmd);
+    match cmd.spawn() {
+        Ok(child) => reap_in_background(child, &input, "xdotool"),
+        Err(e) => {
+            tracing::debug!("xdotool horizontal scroll failed: {}, trying ydotool", e);
+            let yd_args = ydotool_horizontal_scroll_args(clicks)
+                .expect("non-zero clicks always produce ydotool arguments");
+            match Command::new("ydotool").args(&yd_args).spawn() {
+                Ok(child) => reap_in_background(child, &input, "ydotool"),
+                Err(e2) => {
+                    tracing::error!("Both xdotool and ydotool horizontal scroll failed: {}", e2);
+                    return Err(ActionError::ExecutionFailed(format!(
+                        "Horizontal scroll failed: {}",
+                        e2
+                    )));
                 }
             }
         }
@@ -971,6 +1054,68 @@ mod tests {
 
         let err = ActionError::ShellExecution("command not found".to_string());
         assert!(format!("{}", err).contains("Shell execution"));
+    }
+
+    #[test]
+    fn repeated_shortcuts_use_one_batched_helper_argument_vector() {
+        assert_eq!(
+            ActionExecutor::xdotool_shortcut_args("XF86AudioRaiseVolume", 4),
+            ["key", "--repeat", "4", "XF86AudioRaiseVolume"]
+        );
+        assert_eq!(
+            ActionExecutor::xdotool_shortcut_args("ctrl+c", 1),
+            ["key", "ctrl+c"]
+        );
+
+        assert_eq!(
+            ActionExecutor::ydotool_shortcut_args(&[29, 78], 3),
+            [
+                "key", "29:1", "78:1", "78:0", "29:0", "29:1", "78:1", "78:0", "29:0",
+                "29:1", "78:1", "78:0", "29:0",
+            ]
+        );
+    }
+
+    /// Interpret the documented ydotool `mousemove --wheel -- X Y` grammar:
+    /// X is REL_HWHEEL and Y is REL_WHEEL. Keeping this decoder in the test
+    /// makes the assertion about emitted wheel motion rather than duplicating
+    /// the production argument constants.
+    fn ydotool_wheel_delta(args: &[String]) -> Option<(i32, i32)> {
+        let [subcommand, wheel, separator, horizontal, vertical] = args else {
+            return None;
+        };
+        if subcommand != "mousemove" || (wheel != "--wheel" && wheel != "-w") || separator != "--" {
+            return None;
+        }
+        Some((horizontal.parse().ok()?, vertical.parse().ok()?))
+    }
+
+    #[test]
+    fn horizontal_scroll_uses_one_batched_helper_with_real_wheel_semantics() {
+        assert_eq!(
+            xdotool_horizontal_scroll_args(5).unwrap(),
+            ["click", "--repeat", "5", "7"]
+        );
+        assert_eq!(
+            xdotool_horizontal_scroll_args(i32::MAX).unwrap(),
+            ["click", "--repeat", "16", "7"]
+        );
+
+        let right = ydotool_horizontal_scroll_args(5).unwrap();
+        let left = ydotool_horizontal_scroll_args(-5).unwrap();
+        let clamped = ydotool_horizontal_scroll_args(i32::MIN).unwrap();
+        assert_eq!(ydotool_wheel_delta(&right), Some((5, 0)), "{right:?}");
+        assert_eq!(ydotool_wheel_delta(&left), Some((-5, 0)), "{left:?}");
+        assert_eq!(ydotool_wheel_delta(&clamped), Some((-16, 0)), "{clamped:?}");
+
+        // ydotool click IDs 0x06/0x07 are BACK/TASK buttons. Without the
+        // 0x40/0x80 press/release bits they do nothing, and even complete
+        // clicks would still be buttons rather than REL_HWHEEL movement.
+        let invalid_button_click = ["click", "--repeat=5", "0x06"].map(String::from);
+        assert_eq!(ydotool_wheel_delta(&invalid_button_click), None);
+
+        assert!(xdotool_horizontal_scroll_args(0).is_none());
+        assert!(ydotool_horizontal_scroll_args(0).is_none());
     }
 
     #[test]

--- a/daemon/src/evdev.rs
+++ b/daemon/src/evdev.rs
@@ -57,6 +57,9 @@ pub enum GestureEvent {
     ButtonActionEvent {
         action: crate::config::ButtonAction,
         pressed: bool,
+        /// Number of times to execute the action. Physical buttons always use
+        /// one; diverted ThumbWheel notifications batch their configured speed.
+        repeats: u8,
     },
     /// Horizontal scroll from the diverted thumb wheel (sign = direction).
     ThumbwheelScroll { clicks: i32 },
@@ -783,6 +786,7 @@ impl EvdevHandler {
                         .send(GestureEvent::ButtonActionEvent {
                             action,
                             pressed: true,
+                            repeats: 1,
                         })
                         .await;
                 }
@@ -812,6 +816,7 @@ impl EvdevHandler {
                             .send(GestureEvent::ButtonActionEvent {
                                 action,
                                 pressed: false,
+                                repeats: 1,
                             })
                             .await;
                     }

--- a/daemon/src/hidraw.rs
+++ b/daemon/src/hidraw.rs
@@ -445,13 +445,16 @@ impl HidrawHandler {
 
         match output {
             crate::config::ThumbwheelOutput::Button(action) => {
-                // Emit one press per repeat; non-radial actions dispatch directly.
-                for _ in 0..repeats {
-                    let _ = self
-                        .event_tx
-                        .send(GestureEvent::ButtonActionEvent { action, pressed: true })
-                        .await;
-                }
+                // Keep the whole rotation in one channel message so configured
+                // speed does not multiply queue traffic and helper processes.
+                let _ = self
+                    .event_tx
+                    .send(GestureEvent::ButtonActionEvent {
+                        action,
+                        pressed: true,
+                        repeats,
+                    })
+                    .await;
             }
             crate::config::ThumbwheelOutput::HorizontalScroll(dir) => {
                 let _ = self
@@ -519,6 +522,7 @@ impl HidrawHandler {
                     .send(GestureEvent::ButtonActionEvent {
                         action,
                         pressed: true,
+                        repeats: 1,
                     })
                     .await;
             }
@@ -561,6 +565,7 @@ impl HidrawHandler {
                             .send(GestureEvent::ButtonActionEvent {
                                 action,
                                 pressed: false,
+                                repeats: 1,
                             })
                             .await;
                     }
@@ -804,6 +809,37 @@ mod tests {
         let result = handler.open_path(&missing_path);
 
         assert!(matches!(result, Err(HidrawError::DeviceNotFound)));
+    }
+
+    #[tokio::test]
+    async fn thumbwheel_repetitions_are_batched_into_one_event() {
+        let config = crate::config::new_shared_config();
+        {
+            let mut config = config.write().unwrap();
+            config.thumbwheel.mode = crate::config::ThumbwheelMode::Volume;
+            config.thumbwheel.speed = 8;
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut handler = HidrawHandler::new(tx);
+        handler.set_shared_config(config);
+
+        handler
+            .handle_thumbwheel_event(&[HIDPP_LONG, 0, 0, 0, 0, 1])
+            .await;
+
+        assert_eq!(
+            rx.recv().await,
+            Some(GestureEvent::ButtonActionEvent {
+                action: crate::config::ButtonAction::VolumeUp,
+                pressed: true,
+                repeats: 8,
+            })
+        );
+        assert!(matches!(
+            rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
     }
 
     #[test]

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1228,6 +1228,48 @@ async fn run_generic_evdev_loop(
     }
 }
 
+enum ButtonActionDispatchOutcome {
+    Executed {
+        action: juhradiald::config::ButtonAction,
+        repeats: u8,
+        result: Result<bool, juhradiald::actions::ActionError>,
+    },
+    Released {
+        action: juhradiald::config::ButtonAction,
+    },
+}
+
+/// Dispatch one button-action event through an injectable execution boundary.
+///
+/// `process_gesture_events` uses this seam with the real action executor; tests
+/// use an in-memory fake, avoiding helper processes and global PATH changes.
+async fn dispatch_button_action_event_with<Executor, Execution>(
+    event: GestureEvent,
+    execute: Executor,
+) -> ButtonActionDispatchOutcome
+where
+    Executor: FnOnce(juhradiald::config::ButtonAction, u8) -> Execution,
+    Execution: std::future::Future<Output = Result<bool, juhradiald::actions::ActionError>>,
+{
+    match event {
+        GestureEvent::ButtonActionEvent {
+            action,
+            pressed: true,
+            repeats,
+        } => ButtonActionDispatchOutcome::Executed {
+            action,
+            repeats,
+            result: execute(action, repeats).await,
+        },
+        GestureEvent::ButtonActionEvent {
+            action,
+            pressed: false,
+            ..
+        } => ButtonActionDispatchOutcome::Released { action },
+        _ => unreachable!("button-action dispatcher received a different event kind"),
+    }
+}
+
 /// Process gesture events from the evdev handler
 ///
 /// Press triggers ydotool injection -> cursor_grabber catches -> emits ShowMenu
@@ -1315,24 +1357,36 @@ async fn process_gesture_events(
                     }
                 }
             }
-            GestureEvent::ButtonActionEvent { action, pressed } => {
-                if pressed {
-                    info!(%action, "Button action triggered");
-                    match juhradiald::actions::execute_button_action(action).await {
-                        Ok(true) => {
-                            // Action was handled directly
-                        }
-                        Ok(false) => {
-                            // Should not happen (RadialMenu goes through Pressed path)
-                            warn!("ButtonActionEvent with radial_menu - unexpected");
-                        }
-                        Err(e) => {
-                            error!(%action, error = %e, "Failed to execute button action");
+            event @ GestureEvent::ButtonActionEvent { .. } => {
+                match dispatch_button_action_event_with(
+                    event,
+                    juhradiald::actions::execute_button_action_repeated,
+                )
+                .await
+                {
+                    ButtonActionDispatchOutcome::Executed {
+                        action,
+                        repeats,
+                        result,
+                    } => {
+                        info!(%action, repeats, "Button action triggered");
+                        match result {
+                            Ok(true) => {
+                                // Action was handled directly
+                            }
+                            Ok(false) => {
+                                // Should not happen (RadialMenu goes through Pressed path)
+                                warn!("ButtonActionEvent with radial_menu - unexpected");
+                            }
+                            Err(e) => {
+                                error!(%action, error = %e, "Failed to execute button action");
+                            }
                         }
                     }
-                } else {
-                    // Button released for non-radial action - no HideMenu needed
-                    tracing::debug!(%action, "Button action released (no-op)");
+                    ButtonActionDispatchOutcome::Released { action } => {
+                        // Button released for non-radial action - no HideMenu needed
+                        tracing::debug!(%action, "Button action released (no-op)");
+                    }
                 }
             }
             GestureEvent::ThumbwheelScroll { clicks } => {
@@ -1525,6 +1579,63 @@ mod tests {
 
         let event = rx.recv().await.unwrap();
         assert!(matches!(event, GestureEvent::Released { duration_ms: 500 }));
+    }
+
+    #[tokio::test]
+    async fn button_action_dispatch_forwards_repeats_once_and_ignores_release() {
+        use juhradiald::config::ButtonAction;
+
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let pressed_calls = calls.clone();
+        let pressed = dispatch_button_action_event_with(
+            GestureEvent::ButtonActionEvent {
+                action: ButtonAction::VolumeUp,
+                pressed: true,
+                repeats: 8,
+            },
+            move |action, repeats| {
+                pressed_calls.lock().unwrap().push((action, repeats));
+                std::future::ready(Ok(true))
+            },
+        )
+        .await;
+
+        match pressed {
+            ButtonActionDispatchOutcome::Executed {
+                action,
+                repeats,
+                result,
+            } => {
+                assert_eq!(action, ButtonAction::VolumeUp);
+                assert_eq!(repeats, 8);
+                assert!(result.unwrap());
+            }
+            ButtonActionDispatchOutcome::Released { .. } => {
+                panic!("pressed event was treated as a release")
+            }
+        }
+
+        let released_calls = calls.clone();
+        let released = dispatch_button_action_event_with(
+            GestureEvent::ButtonActionEvent {
+                action: ButtonAction::VolumeUp,
+                pressed: false,
+                repeats: 8,
+            },
+            move |action, repeats| {
+                released_calls.lock().unwrap().push((action, repeats));
+                std::future::ready(Ok(true))
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            released,
+            ButtonActionDispatchOutcome::Released {
+                action: ButtonAction::VolumeUp
+            }
+        ));
+        assert_eq!(*calls.lock().unwrap(), [(ButtonAction::VolumeUp, 8)]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Batch ThumbWheel repetitions so one physical sample produces one dispatcher event and one input-helper process, including horizontal scrolling.

## Why

At `speed=8`, one physical sample previously expanded into eight channel messages, eight dispatcher passes, eight helper processes, and eight blocking-pool reapers. Horizontal scroll also spawned one helper per synthetic click.

## Measured impact

Audit process-lifecycle probe (`/usr/bin/true`, 120 samples):

- 1 process: median 0.592 ms, p95 1.576 ms
- 8 processes: median 4.376 ms, p95 7.903 ms
- process count at speed 8: 8 -> 1

For the maximum horizontal-scroll batch, helper count falls from 16 to 1.

## Behavior

- preserve configured repeat clamp, direction, inversion, and zero handling
- preserve one press/release pair per logical repetition
- keep ordinary non-ThumbWheel button actions unchanged
- batch xdotool/ydotool key and click arguments without shell interpolation

## Testing

- focused ThumbWheel batching regressions: 3 passed
- dispatcher seam regression: 1 passed; one call carries all repeats and release performs no action
- `cargo test --locked --lib`: 283 passed, 2 ignored
- `cargo test --locked --bin juhradiald`: 9 passed
- `cargo clippy --locked --lib --bin juhradiald --tests -- -D warnings`
- `git diff --check`

## Scope

This is the single broad ThumbWheel batching PR. It intentionally supersedes a narrower horizontal-scroll-only optimization.

## Pull Request Checklist

- [x] Performance improvement
- [x] Code follows the project style and has been self-reviewed
- [x] Hard-to-understand lifecycle or concurrency behavior is documented in code where needed
- [x] The change introduces no new warnings
- [x] Regression tests cover the changed behavior
- [x] New and existing relevant unit tests pass locally
- [x] No dependent changes need to be merged first

Documentation was updated where the externally visible compositor contract changed; otherwise no user-facing documentation change is required. Tests used deterministic fakes/mocks or the offscreen platform and do not require a physical MX Master 4 or a live KDE session.
