### PR TITLE
perf: use native D-Bus calls for KWin cursor scripts

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -1501,6 +1501,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -52,6 +52,8 @@ default = []
 [dev-dependencies]
 # Performance benchmarks
 criterion = "0.8"
+# Isolated peer-to-peer D-Bus coverage for the native KWin scripting client.
+zbus = { version = "5", features = ["p2p"] }
 
 [[bench]]
 name = "latency"

--- a/daemon/src/compositor.rs
+++ b/daemon/src/compositor.rs
@@ -10,13 +10,231 @@
 //! whenever KWin is running, and the watcher updates the flag live so a KWin
 //! restart is reflected without restarting the daemon.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::fmt;
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use tokio_stream::StreamExt;
 
 /// The well-known bus name KWin owns while it is running.
 const KWIN_BUS_NAME: &str = "org.kde.KWin";
+const KWIN_SCRIPTING_PATH: &str = "/Scripting";
+const KWIN_SCRIPTING_INTERFACE: &str = "org.kde.kwin.Scripting";
+const KWIN_SCRIPT_INTERFACE: &str = "org.kde.kwin.Script";
+
+/// Error returned when KWin cannot load or run a cursor-position script.
+#[derive(Debug)]
+pub enum KWinScriptError {
+    Io {
+        operation: &'static str,
+        source: io::Error,
+    },
+    Dbus(zbus::Error),
+    LoadRejected(i32),
+}
+
+/// Result after the `Script.run` call has been attempted.
+///
+/// A D-Bus call error cannot prove that KWin did not receive and execute the
+/// method. Callers must therefore suppress their cursor fallback for both
+/// variants: only an outer [`KWinScriptError`] is definitely pre-dispatch.
+#[derive(Debug)]
+pub enum KWinScriptRunOutcome {
+    Confirmed { script_id: i32 },
+    Unconfirmed { script_id: i32, error: zbus::Error },
+}
+
+impl KWinScriptRunOutcome {
+    pub fn script_id(&self) -> i32 {
+        match self {
+            Self::Confirmed { script_id } | Self::Unconfirmed { script_id, .. } => *script_id,
+        }
+    }
+}
+
+impl fmt::Display for KWinScriptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { operation, source } => {
+                write!(f, "failed to {operation} KWin script: {source}")
+            }
+            Self::Dbus(error) => write!(f, "KWin D-Bus call failed: {error}"),
+            Self::LoadRejected(script_id) => {
+                write!(f, "KWin rejected script load with id {script_id}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KWinScriptError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::Dbus(error) => Some(error),
+            Self::LoadRejected(_) => None,
+        }
+    }
+}
+
+impl From<zbus::Error> for KWinScriptError {
+    fn from(error: zbus::Error) -> Self {
+        Self::Dbus(error)
+    }
+}
+
+/// Native client for KWin's scripting API.
+///
+/// Clones share the daemon's existing session-bus connection and serialize
+/// one-shot scripts. This removes the two `dbus-send` process launches that
+/// previously ran on every radial-menu open in both input backends.
+#[derive(Clone)]
+pub struct KWinScripting {
+    connection: zbus::Connection,
+    sequence: Arc<AtomicU64>,
+    one_shot_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl KWinScripting {
+    pub fn new(connection: zbus::Connection) -> Self {
+        Self {
+            connection,
+            sequence: Arc::new(AtomicU64::new(0)),
+            one_shot_lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
+    }
+
+    /// Run the one-shot cursor script.
+    ///
+    /// `Err` means the call definitely failed before `Script.run` dispatch and
+    /// handlers may use their cursor fallback. An unconfirmed `Ok` means the run
+    /// call may have executed, so falling back could open the menu twice.
+    pub async fn run_cursor_script(&self) -> Result<KWinScriptRunOutcome, KWinScriptError> {
+        let _guard = self.one_shot_lock.lock().await;
+        let sequence = self.sequence.fetch_add(1, Ordering::Relaxed);
+        let plugin_name = format!("juhradial-cursor-{}-{sequence}", std::process::id());
+
+        self.run_one_shot_script(crate::cursor::KWIN_CURSOR_SCRIPT, &plugin_name)
+            .await
+    }
+
+    async fn run_one_shot_script(
+        &self,
+        script: &str,
+        plugin_name: &str,
+    ) -> Result<KWinScriptRunOutcome, KWinScriptError> {
+        let mut temp_file =
+            tempfile::Builder::new()
+                .suffix(".js")
+                .tempfile()
+                .map_err(|source| KWinScriptError::Io {
+                    operation: "create temporary file for",
+                    source,
+                })?;
+        temp_file
+            .write_all(script.as_bytes())
+            .map_err(|source| KWinScriptError::Io {
+                operation: "write",
+                source,
+            })?;
+        let script_path = temp_file.path().to_string_lossy().into_owned();
+
+        let scripting = zbus::Proxy::new(
+            &self.connection,
+            KWIN_BUS_NAME,
+            KWIN_SCRIPTING_PATH,
+            KWIN_SCRIPTING_INTERFACE,
+        )
+        .await?;
+        let script_id: i32 = scripting
+            .call("loadScript", &(script_path.as_str(), plugin_name))
+            .await?;
+        if script_id < 0 {
+            return Err(KWinScriptError::LoadRejected(script_id));
+        }
+
+        let object_path = format!("/Scripting/Script{script_id}");
+        let script_proxy = zbus::Proxy::new(
+            &self.connection,
+            KWIN_BUS_NAME,
+            object_path.as_str(),
+            KWIN_SCRIPT_INTERFACE,
+        )
+        .await?;
+        let run_result: zbus::Result<()> = script_proxy.call("run", &()).await;
+
+        // Attempt cleanup even when the void run reply is an error: KWin may
+        // already have evaluated the script and dispatched ShowMenuAtCursor.
+        // Cleanup failure must likewise not trigger the handler fallback.
+        match scripting
+            .call::<_, _, bool>("unloadScript", &(plugin_name))
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => tracing::warn!(
+                script_id,
+                plugin_name,
+                "KWin did not unload completed cursor script"
+            ),
+            Err(error) => tracing::warn!(
+                script_id,
+                plugin_name,
+                error = %error,
+                "Failed to unload completed KWin cursor script"
+            ),
+        }
+
+        Ok(match run_result {
+            Ok(()) => KWinScriptRunOutcome::Confirmed { script_id },
+            Err(error) => KWinScriptRunOutcome::Unconfirmed { script_id, error },
+        })
+    }
+}
+
+/// Run the shared KWin cursor trigger and invoke `fallback` only when dispatch
+/// definitely did not happen.
+///
+/// Both input handlers use this consumer so the outcome policy cannot drift:
+/// a confirmed or unconfirmed `Script.run` suppresses fallback, while a
+/// pre-dispatch error (or an unavailable scripting client) invokes it exactly
+/// once.
+pub async fn trigger_kwin_cursor_script<F, Fut>(scripting: Option<&KWinScripting>, fallback: F)
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let should_fallback = match scripting {
+        Some(scripting) => match scripting.run_cursor_script().await {
+            Ok(KWinScriptRunOutcome::Confirmed { script_id }) => {
+                tracing::debug!(script_id, "KWin cursor script run confirmed");
+                false
+            }
+            Ok(KWinScriptRunOutcome::Unconfirmed { script_id, error }) => {
+                tracing::warn!(
+                    script_id,
+                    error = %error,
+                    "KWin cursor script run is unconfirmed; suppressing fallback"
+                );
+                false
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "KWin cursor script failed before run dispatch"
+                );
+                true
+            }
+        },
+        None => {
+            tracing::warn!("KWin scripting client is not configured");
+            true
+        }
+    };
+
+    if should_fallback {
+        fallback().await;
+    }
+}
 
 /// Shared, live "is KWin available?" flag. Cheap to clone (an `Arc`) and
 /// lock-free to read on the input hot path.

--- a/daemon/src/cursor.rs
+++ b/daemon/src/cursor.rs
@@ -103,9 +103,9 @@ pub fn get_cursor_position() -> CursorPosition {
         return pos;
     }
 
-    // KWin scripting is handled by hidraw.rs trigger_kwin_cursor_script()
-    // which calls ShowMenuAtCursor via D-Bus asynchronously. This fallback
-    // path is only reached when that async path isn't used.
+    // KWin scripting is handled by the input handlers through the shared
+    // native zbus client, which calls ShowMenuAtCursor asynchronously. This
+    // fallback path is only reached when that KWin path isn't used or fails.
 
     // Try KWin D-Bus property (older Plasma versions)
     if let Some(pos) = get_cursor_via_kwin_dbus() {

--- a/daemon/src/evdev.rs
+++ b/daemon/src/evdev.rs
@@ -114,6 +114,8 @@ pub struct EvdevHandler {
     /// Live KWin availability (D-Bus name ownership), used to pick the cursor
     /// backend on KDE instead of the XDG_CURRENT_DESKTOP env var (issue #32).
     kwin_available: Option<crate::compositor::KWinAvailability>,
+    /// Native KWin scripting client backed by the daemon's session connection.
+    kwin_scripting: Option<crate::compositor::KWinScripting>,
 }
 
 impl EvdevHandler {
@@ -134,6 +136,7 @@ impl EvdevHandler {
             shared_config: None,
             active_button_action: None,
             kwin_available: None,
+            kwin_scripting: None,
         }
     }
 
@@ -154,6 +157,7 @@ impl EvdevHandler {
             shared_config: None,
             active_button_action: None,
             kwin_available: None,
+            kwin_scripting: None,
         }
     }
 
@@ -166,6 +170,11 @@ impl EvdevHandler {
     /// cursor backend by D-Bus capability rather than an environment string.
     pub fn set_kwin_availability(&mut self, kwin: crate::compositor::KWinAvailability) {
         self.kwin_available = Some(kwin);
+    }
+
+    /// Reuse the daemon's native D-Bus connection for KWin cursor scripts.
+    pub fn set_kwin_scripting(&mut self, scripting: crate::compositor::KWinScripting) {
+        self.kwin_scripting = Some(scripting);
     }
 
     /// Set which key codes should be suppressed (eaten) from the OS.
@@ -750,18 +759,23 @@ impl EvdevHandler {
                             kwin_owned,
                             "Gesture button pressed (radial_menu) - triggering KWin cursor query"
                         );
-                        if !Self::trigger_kwin_cursor_script() {
-                            let pos = crate::cursor::get_cursor_position();
-                            tracing::warn!(
-                                x = pos.x,
-                                y = pos.y,
-                                "KWin script failed, using fallback"
-                            );
-                            let _ = self
-                                .event_tx
-                                .send(GestureEvent::Pressed { x: pos.x, y: pos.y })
-                                .await;
-                        }
+                        let scripting = self.kwin_scripting.clone();
+                        let event_tx = self.event_tx.clone();
+                        crate::compositor::trigger_kwin_cursor_script(
+                            scripting.as_ref(),
+                            move || async move {
+                                let pos = crate::cursor::get_cursor_position();
+                                tracing::warn!(
+                                    x = pos.x,
+                                    y = pos.y,
+                                    "KWin script failed, using fallback"
+                                );
+                                let _ = event_tx
+                                    .send(GestureEvent::Pressed { x: pos.x, y: pos.y })
+                                    .await;
+                            },
+                        )
+                        .await;
                     } else {
                         let pos = crate::cursor::get_cursor_position();
                         tracing::info!(
@@ -819,93 +833,6 @@ impl EvdevHandler {
             }
             _ => {
                 // Repeat events (value=2) are ignored
-            }
-        }
-    }
-
-    /// Trigger KWin script to get cursor position and call ShowMenuAtCursor
-    ///
-    /// This works correctly on Plasma 6 Wayland with multiple monitors.
-    fn trigger_kwin_cursor_script() -> bool {
-        use std::io::Write;
-        use std::process::Command;
-        use tempfile::Builder;
-
-        let script = crate::cursor::KWIN_CURSOR_SCRIPT;
-
-        // Create a temporary file with .js suffix securely
-        let mut temp_file = match Builder::new().suffix(".js").tempfile() {
-            Ok(file) => file,
-            Err(e) => {
-                tracing::warn!("Failed to create temp file for KWin script: {}", e);
-                return false;
-            }
-        };
-
-        // Write script to temp file
-        if let Err(e) = write!(temp_file, "{}", script) {
-            tracing::warn!("Failed to write KWin script: {}", e);
-            return false;
-        }
-
-        // Get the path as a string
-        let script_path = temp_file.path().to_string_lossy();
-
-        // Load script via D-Bus
-        let load_result = Command::new("dbus-send")
-            .args([
-                "--session",
-                "--print-reply",
-                "--dest=org.kde.KWin",
-                "/Scripting",
-                "org.kde.kwin.Scripting.loadScript",
-                &format!("string:{}", script_path),
-            ])
-            .output();
-
-        let load_output = match load_result {
-            Ok(output) if output.status.success() => output,
-            _ => {
-                tracing::warn!("Failed to load KWin script");
-                return false;
-            }
-        };
-
-        // Parse script ID from output (looks like "int32 5")
-        let stdout = String::from_utf8_lossy(&load_output.stdout);
-        let script_id: Option<i32> = stdout
-            .lines()
-            .find(|line| line.contains("int32"))
-            .and_then(|line| line.split_whitespace().last())
-            .and_then(|s| s.parse().ok());
-
-        let script_id = match script_id {
-            Some(id) => id,
-            None => {
-                tracing::warn!("Failed to parse KWin script ID");
-                return false;
-            }
-        };
-
-        // Run the script
-        let run_result = Command::new("dbus-send")
-            .args([
-                "--session",
-                "--print-reply",
-                "--dest=org.kde.KWin",
-                &format!("/Scripting/Script{}", script_id),
-                "org.kde.kwin.Script.run",
-            ])
-            .output();
-
-        match run_result {
-            Ok(output) if output.status.success() => {
-                tracing::debug!(script_id, "KWin cursor script triggered successfully");
-                true
-            }
-            _ => {
-                tracing::warn!("Failed to run KWin script");
-                false
             }
         }
     }

--- a/daemon/src/hidraw.rs
+++ b/daemon/src/hidraw.rs
@@ -80,6 +80,8 @@ pub struct HidrawHandler {
     /// Live KWin availability (D-Bus name ownership), used to pick the cursor
     /// backend on KDE instead of the XDG_CURRENT_DESKTOP env var (issue #32).
     kwin_available: Option<crate::compositor::KWinAvailability>,
+    /// Native KWin scripting client backed by the daemon's session connection.
+    kwin_scripting: Option<crate::compositor::KWinScripting>,
 }
 
 /// Map HID++ CID to evdev key code for macro trigger forwarding
@@ -119,6 +121,7 @@ impl HidrawHandler {
             thumbwheel_feature_index: None,
             notification_indices: Default::default(),
             kwin_available: None,
+            kwin_scripting: None,
         }
     }
 
@@ -126,6 +129,11 @@ impl HidrawHandler {
     /// cursor backend by D-Bus capability rather than an environment string.
     pub fn set_kwin_availability(&mut self, kwin: crate::compositor::KWinAvailability) {
         self.kwin_available = Some(kwin);
+    }
+
+    /// Reuse the daemon's native D-Bus connection for KWin cursor scripts.
+    pub fn set_kwin_scripting(&mut self, scripting: crate::compositor::KWinScripting) {
+        self.kwin_scripting = Some(scripting);
     }
 
     /// Register CIDs that are diverted for macro triggers (not gesture buttons)
@@ -605,12 +613,25 @@ impl HidrawHandler {
                 .unwrap_or(false);
             match crate::compositor::cursor_backend(kwin_owned) {
                 crate::compositor::CursorBackend::KWin => {
-                    tracing::info!(kwin_owned, "Gesture button PRESSED - triggering KWin cursor query");
-                    if !Self::trigger_kwin_cursor_script() {
-                        let (x, y) = Self::get_cursor_position();
-                        tracing::warn!(x, y, "KWin script failed, using fallback cursor position");
-                        let _ = self.event_tx.send(GestureEvent::Pressed { x, y }).await;
-                    }
+                    tracing::info!(
+                        kwin_owned,
+                        "Gesture button PRESSED - triggering KWin cursor query"
+                    );
+                    let scripting = self.kwin_scripting.clone();
+                    let event_tx = self.event_tx.clone();
+                    crate::compositor::trigger_kwin_cursor_script(
+                        scripting.as_ref(),
+                        move || async move {
+                            let (x, y) = Self::get_cursor_position();
+                            tracing::warn!(
+                                x,
+                                y,
+                                "KWin script failed, using fallback cursor position"
+                            );
+                            let _ = event_tx.send(GestureEvent::Pressed { x, y }).await;
+                        },
+                    )
+                    .await;
                     // If KWin script succeeded, it calls ShowMenuAtCursor via D-Bus
                 }
                 crate::compositor::CursorBackend::Fallback => {
@@ -641,94 +662,6 @@ impl HidrawHandler {
     fn get_cursor_position() -> (i32, i32) {
         let pos = crate::cursor::get_cursor_position();
         (pos.x, pos.y)
-    }
-
-    /// Trigger KWin script to get cursor position and call ShowMenuAtCursor
-    ///
-    /// This method works correctly on Plasma 6 Wayland with multiple monitors,
-    /// unlike xdotool/XWayland which clamps cursor to a single screen.
-    fn trigger_kwin_cursor_script() -> bool {
-        use std::io::Write;
-        use std::process::Command;
-        use tempfile::Builder;
-
-        let script = crate::cursor::KWIN_CURSOR_SCRIPT;
-
-        // Create a temporary file with .js suffix securely
-        let mut temp_file = match Builder::new().suffix(".js").tempfile() {
-            Ok(file) => file,
-            Err(e) => {
-                tracing::warn!("Failed to create temp file for KWin script: {}", e);
-                return false;
-            }
-        };
-
-        // Write script to temp file
-        if let Err(e) = write!(temp_file, "{}", script) {
-            tracing::warn!("Failed to write KWin script: {}", e);
-            return false;
-        }
-
-        // Get the path as a string
-        let script_path = temp_file.path().to_string_lossy();
-
-        // Load script via D-Bus
-        let load_result = Command::new("dbus-send")
-            .args([
-                "--session",
-                "--print-reply",
-                "--dest=org.kde.KWin",
-                "/Scripting",
-                "org.kde.kwin.Scripting.loadScript",
-                &format!("string:{}", script_path),
-            ])
-            .output();
-
-        let load_output = match load_result {
-            Ok(output) if output.status.success() => output,
-            _ => {
-                tracing::warn!("Failed to load KWin script");
-                return false;
-            }
-        };
-
-        // Parse script ID from output (looks like "int32 5")
-        let stdout = String::from_utf8_lossy(&load_output.stdout);
-        let script_id: Option<i32> = stdout
-            .lines()
-            .find(|line| line.contains("int32"))
-            .and_then(|line| line.split_whitespace().last())
-            .and_then(|s| s.parse().ok());
-
-        let script_id = match script_id {
-            Some(id) => id,
-            None => {
-                tracing::warn!("Failed to parse KWin script ID");
-                return false;
-            }
-        };
-
-        // Run the script
-        let run_result = Command::new("dbus-send")
-            .args([
-                "--session",
-                "--print-reply",
-                "--dest=org.kde.KWin",
-                &format!("/Scripting/Script{}", script_id),
-                "org.kde.kwin.Script.run",
-            ])
-            .output();
-
-        match run_result {
-            Ok(output) if output.status.success() => {
-                tracing::debug!(script_id, "KWin cursor script triggered successfully");
-                true
-            }
-            _ => {
-                tracing::warn!("Failed to run KWin script");
-                false
-            }
-        }
     }
 
     /// Check if handler is connected

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -488,11 +488,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // empty when systemd starts the daemon at cold boot, issue #32). The watcher
     // seeds the flag and follows KWin restarts on the same session connection.
     let kwin_availability = juhradiald::compositor::KWinAvailability::new();
+    let kwin_scripting = juhradiald::compositor::KWinScripting::new(dbus_connection.clone());
     {
         let conn = dbus_connection.clone();
         let kwin = kwin_availability.clone();
         tokio::spawn(async move { juhradiald::compositor::run_kwin_watcher(conn, kwin).await });
     }
+    let kwin_context = KWinContext {
+        availability: kwin_availability,
+        scripting: kwin_scripting,
+    };
 
     let haptic_manager_for_hidraw = haptic_manager_for_battery.clone();
 
@@ -608,7 +613,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let hidraw_tx = event_tx.clone();
     let hidraw_config = shared_config.clone();
     let hidraw_hotplug = hotplug_notify.clone();
-    let hidraw_kwin = kwin_availability.clone();
+    let hidraw_kwin = kwin_context.clone();
     let hidraw_handle = tokio::spawn(async move {
         run_hidraw_loop(
             hidraw_tx,
@@ -638,16 +643,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let hotplug_for_mx = hotplug_notify.clone();
     let evdev_config = shared_config.clone();
-    let evdev_kwin = kwin_availability.clone();
+    let evdev_kwin = kwin_context.clone();
     let evdev_handle = tokio::spawn(async move {
-        run_evdev_loop(evdev_tx, suppressed_for_mx, hotplug_for_mx, evdev_config, evdev_kwin).await
+        run_evdev_loop(
+            evdev_tx,
+            suppressed_for_mx,
+            hotplug_for_mx,
+            evdev_config,
+            evdev_kwin,
+        )
+        .await
     });
 
     let generic_evdev_tx = event_tx.clone();
     let suppressed_for_generic = macro_evdev_codes.clone();
     let hotplug_for_generic = hotplug_notify.clone();
     let generic_evdev_config = shared_config.clone();
-    let generic_evdev_kwin = kwin_availability.clone();
+    let generic_evdev_kwin = kwin_context;
     let generic_evdev_handle = tokio::spawn(async move {
         run_generic_evdev_loop(
             generic_evdev_tx,
@@ -764,6 +776,12 @@ fn list_logitech_devices() {
 
 struct HidrawStartup {
     preferred_path: Option<PathBuf>,
+}
+
+#[derive(Clone)]
+struct KWinContext {
+    availability: juhradiald::compositor::KWinAvailability,
+    scripting: juhradiald::compositor::KWinScripting,
 }
 
 /// Reconnect HID++ and re-apply volatile button diverts.
@@ -908,7 +926,7 @@ async fn run_hidraw_loop(
     shared_config: juhradiald::config::SharedConfig,
     hotplug: Arc<tokio::sync::Notify>,
     haptic_manager: SharedHapticManager,
-    kwin_availability: juhradiald::compositor::KWinAvailability,
+    kwin: KWinContext,
 ) {
     let HidrawStartup { mut preferred_path } = startup;
     let mut handler = HidrawHandler::new(event_tx);
@@ -917,7 +935,8 @@ async fn run_hidraw_loop(
     let config_for_divert = shared_config.clone();
     handler.set_macro_cids(macro_cids);
     handler.set_shared_config(shared_config);
-    handler.set_kwin_availability(kwin_availability);
+    handler.set_kwin_availability(kwin.availability);
+    handler.set_kwin_scripting(kwin.scripting);
 
     loop {
         // Re-read the reassigned buttons each cycle so a config change is
@@ -1046,12 +1065,13 @@ async fn run_evdev_loop(
     suppressed_keys: HashSet<u16>,
     hotplug: Arc<tokio::sync::Notify>,
     shared_config: juhradiald::config::SharedConfig,
-    kwin_availability: juhradiald::compositor::KWinAvailability,
+    kwin: KWinContext,
 ) {
     let mut handler = EvdevHandler::new(event_tx.clone());
     handler.set_suppressed_keys(suppressed_keys);
     handler.set_shared_config(shared_config);
-    handler.set_kwin_availability(kwin_availability);
+    handler.set_kwin_availability(kwin.availability);
+    handler.set_kwin_scripting(kwin.scripting);
 
     let mut logged_waiting = false;
 
@@ -1154,7 +1174,7 @@ async fn run_generic_evdev_loop(
     suppressed_keys: HashSet<u16>,
     hotplug: Arc<tokio::sync::Notify>,
     shared_config: juhradiald::config::SharedConfig,
-    kwin_availability: juhradiald::compositor::KWinAvailability,
+    kwin: KWinContext,
 ) {
     let trigger = read_trigger_button_from_config();
     if let Some(code) = trigger {
@@ -1163,7 +1183,8 @@ async fn run_generic_evdev_loop(
     let mut handler = EvdevHandler::new_generic(event_tx.clone(), trigger);
     handler.set_suppressed_keys(suppressed_keys);
     handler.set_shared_config(shared_config);
-    handler.set_kwin_availability(kwin_availability);
+    handler.set_kwin_availability(kwin.availability);
+    handler.set_kwin_scripting(kwin.scripting);
 
     let mut logged_waiting = false;
 

--- a/daemon/tests/kwin_scripting.rs
+++ b/daemon/tests/kwin_scripting.rs
@@ -1,0 +1,178 @@
+use std::fs;
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use juhradiald::compositor::{trigger_kwin_cursor_script, KWinScripting};
+use juhradiald::cursor::KWIN_CURSOR_SCRIPT;
+use zbus::{connection::Builder, interface};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Call {
+    Load { script: String, plugin_name: String },
+    Run,
+    Unload { plugin_name: String },
+}
+
+#[derive(Clone)]
+struct ScriptingMock {
+    calls: Arc<Mutex<Vec<Call>>>,
+    load_result: i32,
+}
+
+#[interface(name = "org.kde.kwin.Scripting")]
+impl ScriptingMock {
+    #[zbus(name = "loadScript")]
+    fn load_script(&self, script_path: String, plugin_name: String) -> i32 {
+        let script =
+            fs::read_to_string(script_path).expect("KWin script temp file must stay alive");
+        self.calls.lock().unwrap().push(Call::Load {
+            script,
+            plugin_name,
+        });
+        self.load_result
+    }
+
+    #[zbus(name = "unloadScript")]
+    fn unload_script(&self, plugin_name: String) -> bool {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(Call::Unload { plugin_name });
+        true
+    }
+}
+
+#[derive(Clone)]
+struct ScriptMock {
+    calls: Arc<Mutex<Vec<Call>>>,
+    fail_run: bool,
+}
+
+#[interface(name = "org.kde.kwin.Script")]
+impl ScriptMock {
+    #[zbus(name = "run")]
+    fn run(&self) -> zbus::fdo::Result<()> {
+        self.calls.lock().unwrap().push(Call::Run);
+        if self.fail_run {
+            Err(zbus::fdo::Error::Failed(
+                "simulated lost run reply".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+async fn kwin_peer(
+    load_result: i32,
+    fail_run: bool,
+) -> (zbus::Connection, zbus::Connection, Arc<Mutex<Vec<Call>>>) {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let guid = zbus::Guid::generate();
+    let (server_socket, client_socket) = UnixStream::pair().unwrap();
+
+    let server = Builder::unix_stream(server_socket)
+        .server(guid)
+        .unwrap()
+        .p2p()
+        .name("org.kde.KWin")
+        .unwrap()
+        .serve_at(
+            "/Scripting",
+            ScriptingMock {
+                calls: calls.clone(),
+                load_result,
+            },
+        )
+        .unwrap()
+        .serve_at(
+            "/Scripting/Script7",
+            ScriptMock {
+                calls: calls.clone(),
+                fail_run,
+            },
+        )
+        .unwrap()
+        .build();
+    let client = Builder::unix_stream(client_socket).p2p().build();
+    let (server, client) = tokio::try_join!(server, client).unwrap();
+
+    (server, client, calls)
+}
+
+#[tokio::test]
+async fn cursor_script_uses_native_load_run_and_unload_calls() {
+    let (_server, client, calls) = kwin_peer(7, false).await;
+    let scripting = KWinScripting::new(client);
+    let fallback_called = Arc::new(AtomicBool::new(false));
+    let fallback_flag = fallback_called.clone();
+
+    trigger_kwin_cursor_script(Some(&scripting), move || async move {
+        fallback_flag.store(true, Ordering::SeqCst);
+    })
+    .await;
+
+    assert!(
+        !fallback_called.load(Ordering::SeqCst),
+        "a confirmed run must not invoke the handler fallback"
+    );
+    let calls = calls.lock().unwrap();
+    assert_eq!(calls.len(), 3);
+    let plugin_name = match &calls[0] {
+        Call::Load {
+            script,
+            plugin_name,
+        } => {
+            assert_eq!(script, KWIN_CURSOR_SCRIPT);
+            assert!(plugin_name.starts_with("juhradial-cursor-"));
+            plugin_name.clone()
+        }
+        call => panic!("expected loadScript first, got {call:?}"),
+    };
+    assert_eq!(calls[1], Call::Run);
+    assert_eq!(calls[2], Call::Unload { plugin_name });
+}
+
+#[tokio::test]
+async fn dispatched_run_error_suppresses_handler_fallback_and_still_cleans_up() {
+    let (_server, client, calls) = kwin_peer(7, true).await;
+    let scripting = KWinScripting::new(client);
+    let fallback_called = Arc::new(AtomicBool::new(false));
+    let fallback_flag = fallback_called.clone();
+
+    trigger_kwin_cursor_script(Some(&scripting), move || async move {
+        fallback_flag.store(true, Ordering::SeqCst);
+    })
+    .await;
+
+    let calls = calls.lock().unwrap();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[1], Call::Run);
+    assert!(matches!(calls[2], Call::Unload { .. }));
+    assert!(
+        !fallback_called.load(Ordering::SeqCst),
+        "a run error is outcome-unknown after dispatch and must not double-open via fallback"
+    );
+}
+
+#[tokio::test]
+async fn rejected_load_preserves_pre_dispatch_handler_fallback() {
+    let (_server, client, calls) = kwin_peer(-1, false).await;
+    let scripting = KWinScripting::new(client);
+    let fallback_called = Arc::new(AtomicBool::new(false));
+    let fallback_flag = fallback_called.clone();
+
+    trigger_kwin_cursor_script(Some(&scripting), move || async move {
+        fallback_flag.store(true, Ordering::SeqCst);
+    })
+    .await;
+
+    assert!(
+        fallback_called.load(Ordering::SeqCst),
+        "load rejection is definitely pre-dispatch and must invoke fallback"
+    );
+    let calls = calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert!(matches!(calls[0], Call::Load { .. }));
+}


### PR DESCRIPTION
## Summary

Replace the two per-open `dbus-send` helper processes used by the KWin cursor script with native calls over the daemon's existing zbus session connection.

## Why

Every KDE menu open wrote a temporary script, spawned `dbus-send` for `loadScript`, parsed textual `int32` output, and spawned a second `dbus-send` for `Script.run`. This work sits directly on the gesture-to-menu latency path.

## Measured impact

Live session-bus probe for the two existing round trips:

- median: 3.711 ms
- p95: 5.983 ms
- 100 menu opens: 200 helper `execve` calls -> 0

The figures exclude tempfile I/O and KWin script compilation, so they are a lower bound on removed overhead.

## Behavior

- reuse the existing zbus session connection
- preserve `loadScript(ss) -> i`, `run() -> ()`, and `unloadScript(s) -> b` KWin contracts
- preserve current fallback menu behavior for failures before run dispatch
- treat a lost/error `Script.run` reply as outcome-unknown and suppress fallback to avoid a double-open
- unload the one-shot script after confirmed or unconfirmed dispatch
- keep both hidraw and evdev trigger paths consistent

## Testing

- isolated peer-to-peer D-Bus regressions: 3 passed
- `cargo test --locked --lib`: 280 passed, 2 ignored
- `cargo test --locked --bin juhradiald`: 8 passed
- `cargo clippy --locked --lib --bin juhradiald --tests -- -D warnings`
- live `busctl` introspection confirmed `loadScript(ss) -> i` and `unloadScript(s) -> b`
- `git diff --check`

## Scope

Only the latency-critical per-open KWin invocation changes; unrelated compositor behavior is left untouched.

## Pull Request Checklist

- [x] Performance improvement
- [x] Code follows the project style and has been self-reviewed
- [x] Hard-to-understand lifecycle or concurrency behavior is documented in code where needed
- [x] The change introduces no new warnings
- [x] Regression tests cover the changed behavior
- [x] New and existing relevant unit tests pass locally
- [x] No dependent changes need to be merged first

Documentation was updated where the externally visible compositor contract changed; otherwise no user-facing documentation change is required. Tests used deterministic fakes/mocks or the offscreen platform and do not require a physical MX Master 4 or a live KDE session.
