### PR TITLE
fix(install): add python3-gi-cairo to Debian/Ubuntu dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to JuhRadial MX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Settings UI and overlay render on Debian/Ubuntu** - The PyGObject cairo bindings (`python3-gi-cairo`) were missing from the Debian/Ubuntu install path. On those distros `python3-gi` does not pull in cairo, so GTK4/libadwaita widgets failed to render. The installer, the installation guide, and the contributor setup now install `python3-gi-cairo`. The Fedora and Arch packaging already list cairo explicitly; those paths and openSUSE are unchanged.
+
 ## [0.4.1] - 2026-07-21
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ sudo pacman -S --needed \
 sudo apt install \
   rustc cargo \
   python3-pyqt6 python3-pyqt6.qtsvg \
-  python3-gi gir1.2-gtk-4.0 gir1.2-adw-1 \
+  python3-gi python3-gi-cairo gir1.2-gtk-4.0 gir1.2-adw-1 \
   libdbus-1-dev libsystemd-dev \
   libevdev-dev libhidapi-dev \
   git make build-essential

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -136,7 +136,7 @@ sudo apt-get install -y \
     rustc cargo \
     python3 python3-pip python3-venv \
     python3-pyqt6 python3-pyqt6.qtsvg \
-    python3-gi gir1.2-gtk-4.0 gir1.2-adw-1 \
+    python3-gi python3-gi-cairo gir1.2-gtk-4.0 gir1.2-adw-1 \
     python3-cryptography \
     libdbus-1-dev libsystemd-dev \
     libevdev-dev libhidapi-dev \

--- a/install.sh
+++ b/install.sh
@@ -372,7 +372,7 @@ install_deps_debian() {
         rustc cargo \
         python3 python3-pip python3-venv \
         python3-pyqt6 python3-pyqt6.qtsvg \
-        python3-gi gir1.2-gtk-4.0 gir1.2-adw-1 \
+        python3-gi python3-gi-cairo gir1.2-gtk-4.0 gir1.2-adw-1 \
         python3-cryptography \
         libdbus-1-dev libsystemd-dev \
         libevdev-dev libhidapi-dev \


### PR DESCRIPTION
## Problem

On Debian/Ubuntu, the \`python3-gi\` (PyGObject) package **does not** pull in the cairo bindings. Without \`python3-gi-cairo\`, the GTK4/libadwaita widgets in the Settings UI and overlay fail to render, and users have to install \`python3-gi-cairo\` manually to get a working UI.

## Root cause

The Debian/Ubuntu dependency lists named \`python3-gi\` but omitted the cairo integration package. By contrast, the packaging for other distros already covers cairo:

- **Fedora** RPM spec: \`Requires: python3-cairo\` (alongside \`python3-gobject\`)
- **Arch** PKGBUILD: \`python-cairo\` (alongside \`python-gobject\`)

So only the Debian/Ubuntu path was missing cairo.

## Fix

Add \`python3-gi-cairo\` next to \`python3-gi\` in the three Debian/Ubuntu dependency declarations:

- \`install.sh\` → \`install_deps_debian()\`
- \`docs/installation.md\` → Ubuntu / Debian block
- \`CONTRIBUTING.md\` → Debian/Ubuntu setup

No other OS is affected: the Fedora and Arch packaging already list cairo explicitly, and the openSUSE path is unchanged.

## Testing

- [x] Diff scoped to Debian/Ubuntu paths only (verified Fedora/Arch already list cairo, openSUSE untouched)
- [ ] Validated on a clean Ubuntu/Debian install that the Settings UI renders without manually installing \`python3-gi-cairo\`

## Checklist

- [x] Conventional commit message used
- [x] CHANGELOG entry added under \`[Unreleased]\`
- [x] No changes to Fedora / Arch / openSUSE install paths