### PR TITLE
fix(packaging): install 99-juhradialmx.rules in Arch and RPM specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Settings UI and overlay render on Debian/Ubuntu** - The PyGObject cairo bindings (`python3-gi-cairo`) were missing from the Debian/Ubuntu install path. On those distros `python3-gi` does not pull in cairo, so GTK4/libadwaita widgets failed to render. The installer, the installation guide, and the contributor setup now install `python3-gi-cairo`. The Fedora and Arch packaging already list cairo explicitly; those paths and openSUSE are unchanged.
+- **Arch PKGBUILD and Fedora RPM spec build again** - Both still installed the removed `packaging/udev/99-logitech-hidpp.rules`, so `makepkg` and `rpmbuild` failed in the packaging step. They now install the current `99-juhradialmx.rules` (and `60-ydotool-uinput.rules` for uinput access, matching `install.sh`). Fixes [#89](https://github.com/JuhLabs/juhradial-mx/issues/89).
 
 ## [0.4.1] - 2026-07-21
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -84,7 +84,8 @@ package() {
     install -Dm644 packaging/systemd/juhradialmx-daemon.service "$pkgdir/usr/lib/systemd/user/juhradialmx-daemon.service"
 
     # Install udev rules
-    install -Dm644 packaging/udev/99-logitech-hidpp.rules "$pkgdir/usr/lib/udev/rules.d/99-logitech-hidpp.rules"
+    install -Dm644 packaging/udev/99-juhradialmx.rules "$pkgdir/usr/lib/udev/rules.d/99-juhradialmx.rules"
+    install -Dm644 packaging/udev/60-ydotool-uinput.rules "$pkgdir/usr/lib/udev/rules.d/60-ydotool-uinput.rules"
 
     # Install license
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/packaging/rpm/juhradial-mx.spec
+++ b/packaging/rpm/juhradial-mx.spec
@@ -93,7 +93,8 @@ install -Dm644 assets/juhradial-mx.svg %{buildroot}%{_datadir}/icons/hicolor/sca
 install -Dm644 packaging/systemd/juhradialmx-daemon.service %{buildroot}%{_userunitdir}/juhradialmx-daemon.service
 
 # Install udev rules
-install -Dm644 packaging/udev/99-logitech-hidpp.rules %{buildroot}%{_udevrulesdir}/99-logitech-hidpp.rules
+install -Dm644 packaging/udev/99-juhradialmx.rules %{buildroot}%{_udevrulesdir}/99-juhradialmx.rules
+install -Dm644 packaging/udev/60-ydotool-uinput.rules %{buildroot}%{_udevrulesdir}/60-ydotool-uinput.rules
 
 
 %post
@@ -117,7 +118,8 @@ install -Dm644 packaging/udev/99-logitech-hidpp.rules %{buildroot}%{_udevrulesdi
 %{_datadir}/applications/juhradial-mx.desktop
 %{_datadir}/icons/hicolor/scalable/apps/juhradial-mx.svg
 %{_userunitdir}/juhradialmx-daemon.service
-%{_udevrulesdir}/99-logitech-hidpp.rules
+%{_udevrulesdir}/99-juhradialmx.rules
+%{_udevrulesdir}/60-ydotool-uinput.rules
 %changelog
 * Tue Jul 21 2026 Julian Hermstad <dev@juhlabs.com> - 0.4.1-1
 - Radial menu opens at the cursor on GNOME Wayland

--- a/tests/distro_build_test.sh
+++ b/tests/distro_build_test.sh
@@ -33,6 +33,8 @@ grep -q "python3-PyQt6" "$SRC/install.sh" && echo "  ok: python3-PyQt6 present (
 grep -q "python3-qt6-svg" "$SRC/install.sh" && echo "  WARN: stale python3-qt6-svg still present (#24)" || echo "  ok: stale python3-qt6-svg gone (#24)"
 grep -q 'id -u' "$SRC/install.sh" && grep -q 'id -g' "$SRC/install.sh" && echo "  ok: installer uses numeric uid/gid (#52)" || echo "  WARN: installer not using numeric uid/gid (#52)"
 grep -q '\$USER:\$USER' "$SRC/install.sh" && echo "  WARN: installer still assumes username equals group name (#52)" || echo "  ok: no \$USER:\$USER group assumption (#52)"
+grep -rq '99-logitech-hidpp.rules' "$SRC/packaging/arch/PKGBUILD" "$SRC/packaging/rpm/juhradial-mx.spec" && echo "  WARN: packaging still references removed 99-logitech-hidpp.rules (#89)" || echo "  ok: packaging installs 99-juhradialmx.rules (#89)"
+grep -q 'KERNELS=="0005:046D' "$SRC/packaging/udev/99-juhradialmx.rules" && echo "  ok: Bluetooth KERNELS match present in udev rules (#19)" || echo "  WARN: Bluetooth KERNELS match missing from udev rules (#19)"
 echo
 
 # Bootstrap a new-enough Rust (mirrors install.sh ensure_rust_toolchain) then


### PR DESCRIPTION
## Summary

The Arch PKGBUILD and the Fedora RPM spec still install `packaging/udev/99-logitech-hidpp.rules`, which no longer exists in the tree, so `makepkg` and `rpmbuild` both fail in the packaging step.

- Install the current `packaging/udev/99-juhradialmx.rules` instead, keeping the destination name that `install.sh` manages (the installer deletes the old `99-logitech-hidpp.rules` on upgrade, so the old destination name must not come back).
- Also ship `60-ydotool-uinput.rules` for feature parity with `install.sh` (uinput access for ydotool and the virtual mouse).
- Add static checks to `tests/distro_build_test.sh`: packaging must not reference the removed rules file, and the Bluetooth `KERNELS=="0005:046D:*"` match from #19 must stay in the shipped rules.

The rules file itself is unchanged: `MODE="0660" GROUP="input"` and the Bluetooth KERNELS matches are exactly as before.

## Testing

- `bash -n packaging/arch/PKGBUILD` passes.
- `git grep 99-logitech-hidpp.rules packaging/` returns nothing.
- Static checks in `tests/distro_build_test.sh` report ok.

Fixes #89