### PR TITLE
fix(daemon): re-apply volatile HID++ divert after Bolt sleep or power-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Gesture button survives the power switch and radio sleep** - The mouse clears its volatile HID++ button divert when switched off or sleeping, but the Bolt receiver keeps its device nodes, so the daemon never saw a reconnect and the gesture and haptic buttons stayed dead until a restart. The daemon now re-applies all volatile state (gesture/haptic divert, reassigned buttons, thumb-wheel reporting) when the mouse announces it is back online, when a failing battery poll recovers, and on `ReloadConfig`, which now also re-diverts the gesture and haptic buttons. Fixes [#102](https://github.com/JuhLabs/juhradial-mx/issues/102).
 - **Settings UI and overlay render on Debian/Ubuntu** - The PyGObject cairo bindings (`python3-gi-cairo`) were missing from the Debian/Ubuntu install path. On those distros `python3-gi` does not pull in cairo, so GTK4/libadwaita widgets failed to render. The installer, the installation guide, and the contributor setup now install `python3-gi-cairo`. The Fedora and Arch packaging already list cairo explicitly; those paths and openSUSE are unchanged.
 - **Arch PKGBUILD and Fedora RPM spec build again** - Both still installed the removed `packaging/udev/99-logitech-hidpp.rules`, so `makepkg` and `rpmbuild` failed in the packaging step. They now install the current `99-juhradialmx.rules` (and `60-ydotool-uinput.rules` for uinput access, matching `install.sh`). Fixes [#89](https://github.com/JuhLabs/juhradial-mx/issues/89).
 

--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "juhradiald"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "criterion",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juhradiald"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "JuhRadial MX daemon - Radial menu for Logitech MX Master 4 on Linux"
 license = "GPL-3.0"

--- a/daemon/src/battery.rs
+++ b/daemon/src/battery.rs
@@ -491,6 +491,7 @@ pub async fn start_battery_updater(state: SharedBatteryState) {
 pub async fn start_battery_updater_shared(
     state: SharedBatteryState,
     haptic_manager: crate::hidpp::SharedHapticManager,
+    radio_recovered: std::sync::Arc<tokio::sync::Notify>,
 ) {
     let mut consecutive_errors = 0u32;
 
@@ -534,6 +535,9 @@ pub async fn start_battery_updater_shared(
             tracing::info!(percentage, charging, "Initial battery state");
         }
         Err(e) => {
+            // Count the failure so a later success is treated as a radio
+            // recovery (e.g. daemon started while the mouse was asleep).
+            consecutive_errors = 1;
             let mut s = state.write().await;
             s.available = false;
             s.error = Some(format!("{}", e));
@@ -553,6 +557,19 @@ pub async fn start_battery_updater_shared(
 
         match result {
             Ok((percentage, charging)) => {
+                if consecutive_errors > 0 {
+                    // Fail-then-success means the radio was down (mouse off or
+                    // asleep) and is back. The Bolt receiver keeps its device
+                    // nodes through that, so no hotplug fires; wake the device
+                    // loops so volatile diverts are re-applied (issue #102).
+                    // This piggybacks on the existing poll: no extra HID++
+                    // traffic, and it fires once per outage, not periodically.
+                    tracing::info!(
+                        after_failures = consecutive_errors,
+                        "Battery query recovered - waking device loops to re-apply volatile state"
+                    );
+                    radio_recovered.notify_waiters();
+                }
                 consecutive_errors = 0;
                 let mut s = state.write().await;
                 s.percentage = percentage;

--- a/daemon/src/dbus/interface.rs
+++ b/daemon/src/dbus/interface.rs
@@ -257,6 +257,23 @@ impl JuhRadialService {
                         for cid in Config::managed_button_cids() {
                             let _ = manager.set_button_divert(cid, remapped.contains(&cid));
                         }
+
+                        // Also re-divert the gesture and haptic buttons. Their
+                        // divert is volatile and the mouse clears it on
+                        // power-off / radio sleep (issue #102), so a Settings
+                        // save doubles as a manual recovery without waiting
+                        // for the next reconnect.
+                        match manager.divert_buttons() {
+                            Ok(n) if n > 0 => tracing::info!(
+                                count = n,
+                                "Gesture buttons re-diverted on reload"
+                            ),
+                            Ok(_) => {}
+                            Err(e) => tracing::warn!(
+                                error = %e,
+                                "Failed to re-divert gesture buttons on reload"
+                            ),
+                        }
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "Failed to lock haptic manager for update");

--- a/daemon/src/hidpp/constants.rs
+++ b/daemon/src/hidpp/constants.rs
@@ -88,6 +88,14 @@ pub mod features {
     /// Used for reading current Easy-Switch status - we only use function 0
     pub const CHANGE_HOST: u16 = 0x1814;
 
+    /// Wireless Device Status (0x1D4B)
+    ///
+    /// READ-ONLY here: we never call this feature. Its index is looked up so
+    /// the hidraw reader can decode the device-originated status broadcast the
+    /// mouse sends when it comes back online after power-off or radio sleep.
+    /// That broadcast is the signal to re-apply volatile diverts (issue #102).
+    pub const WIRELESS_DEVICE_STATUS: u16 = 0x1D4B;
+
     /// Host Info - READ-ONLY access to paired host names (0x1815)
     /// Functions: [0] getHostInfo, [1] getHostDescriptor, [3] getHostFriendlyName
     /// NOTE: This is blocklisted for WRITE but READ is safe for getting host names
@@ -175,6 +183,7 @@ pub mod allowed_features {
         features::HIRES_WHEEL,
         features::REPROG_CONTROLS_V4,
         features::THUMB_WHEEL,
+        features::WIRELESS_DEVICE_STATUS,
     ];
 
     /// Check if a feature ID is explicitly allowed

--- a/daemon/src/hidpp/manager.rs
+++ b/daemon/src/hidpp/manager.rs
@@ -772,6 +772,7 @@ impl HapticManager {
             change_host: device.feature_index(features::CHANGE_HOST),
             dpi: device.feature_index(features::ADJUSTABLE_DPI),
             hires_wheel: device.feature_index(features::HIRES_WHEEL),
+            wireless_status: device.feature_index(features::WIRELESS_DEVICE_STATUS),
         }
     }
 

--- a/daemon/src/hidpp/notifications.rs
+++ b/daemon/src/hidpp/notifications.rs
@@ -27,6 +27,12 @@ pub enum HardwareNotification {
     HostChanged { host: u8 },
     /// Pointer DPI changed (ADJUSTABLE_DPI 0x2201).
     DpiChanged { dpi: u16 },
+    /// Device came (back) online (WIRELESS_DEVICE_STATUS 0x1D4B broadcast).
+    ///
+    /// The mouse sends this after power-on and after waking from radio sleep,
+    /// exactly the moments it has cleared its volatile HID++ state. Consumers
+    /// treat it as "re-apply diverts now" (issue #102). Not surfaced on D-Bus.
+    DeviceConnected,
 }
 
 /// Feature indices for the notification-bearing features on the connected
@@ -38,6 +44,7 @@ pub struct NotificationIndices {
     pub change_host: Option<u8>,
     pub dpi: Option<u8>,
     pub hires_wheel: Option<u8>,
+    pub wireless_status: Option<u8>,
 }
 
 impl NotificationIndices {
@@ -56,6 +63,9 @@ impl NotificationIndices {
         }
         if self.hires_wheel == Some(feature_index) {
             return decode_ratchet(data);
+        }
+        if self.wireless_status == Some(feature_index) {
+            return decode_wireless_status(data);
         }
         None
     }
@@ -105,6 +115,19 @@ fn decode_dpi(data: &[u8]) -> Option<HardwareNotification> {
         return None;
     }
     Some(HardwareNotification::DpiChanged { dpi })
+}
+
+/// WIRELESS_DEVICE_STATUS 0x1D4B `statusBroadcast` event.
+///
+/// Payload (from byte 4): `[status, request, reason]` with status 1 =
+/// reconnection and request 1 = "software should reconfigure the device".
+/// The device only ever broadcasts on this feature when it (re)connects, so
+/// any event here means the radio is back and volatile state is gone.
+fn decode_wireless_status(data: &[u8]) -> Option<HardwareNotification> {
+    if data.len() < 5 {
+        return None;
+    }
+    Some(HardwareNotification::DeviceConnected)
 }
 
 /// HiResWheel 0x2121 `ratchetSwitchChanged` event: byte 4 bit 0 = ratchet
@@ -164,6 +187,22 @@ mod tests {
             idx.route(0x05, &report(0x05, &[0x00])),
             Some(HardwareNotification::RatchetChanged { ratchet: false })
         );
+    }
+
+    #[test]
+    fn routes_wireless_status_broadcast() {
+        let idx = NotificationIndices { wireless_status: Some(0x0c), ..Default::default() };
+        // statusBroadcast: status=1 (reconnection), request=1 (reconfigure), reason=0
+        assert_eq!(
+            idx.route(0x0c, &report(0x0c, &[0x01, 0x01, 0x00])),
+            Some(HardwareNotification::DeviceConnected)
+        );
+    }
+
+    #[test]
+    fn wireless_status_without_index_never_matches() {
+        let idx = NotificationIndices { battery: Some(0x06), ..Default::default() };
+        assert_eq!(idx.route(0x0c, &report(0x0c, &[0x01, 0x01, 0x00])), None);
     }
 
     #[test]

--- a/daemon/src/hidraw.rs
+++ b/daemon/src/hidraw.rs
@@ -31,6 +31,20 @@ pub const FEATURE_REPROG_CONTROLS_V4: u16 = 0x1B04;
 /// Diverted button notification function ID
 pub const DIVERTED_BUTTONS_EVENT: u8 = 0x00;
 
+/// HID++ 1.0 receiver notification sub-id: "device connection". Bolt and
+/// Unifying receivers emit this SHORT report when a paired device's radio
+/// link comes up or goes down, with byte 4 bit 6 set when the link is NOT
+/// established. It arrives on the same hidraw node as the 2.0 feature
+/// events, with the sub-id in the byte that 2.0 uses for the feature index.
+pub const RECEIVER_CONNECTION_SUB_ID: u8 = 0x41;
+
+/// Minimum spacing between divert-refresh triggers. A flapping radio link
+/// (mouse at the edge of range) can emit connection notifications in bursts;
+/// re-applying diverts is idempotent but costs HID++ round-trips, so bursts
+/// are coalesced instead of refreshing per report (same spirit as the 500ms
+/// hotplug debounce that guards issue #15).
+const DIVERT_REFRESH_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Known button CIDs (Control IDs) for MX Master 4
 pub mod button_cid {
     /// Middle button
@@ -80,6 +94,14 @@ pub struct HidrawHandler {
     /// Live KWin availability (D-Bus name ownership), used to pick the cursor
     /// backend on KDE instead of the XDG_CURRENT_DESKTOP env var (issue #32).
     kwin_available: Option<crate::compositor::KWinAvailability>,
+    /// Set when the device announced it came (back) online, meaning its
+    /// volatile HID++ state (button/thumb-wheel divert) is gone and must be
+    /// re-applied (issue #102). `start()` returns so the hidraw loop can run
+    /// its existing refresh path; the loop reads the flag via
+    /// `take_divert_refresh_needed()`.
+    divert_refresh_needed: bool,
+    /// Timestamp of the last accepted refresh trigger, for debouncing.
+    last_refresh_trigger: Option<Instant>,
 }
 
 /// Map HID++ CID to evdev key code for macro trigger forwarding
@@ -119,6 +141,8 @@ impl HidrawHandler {
             thumbwheel_feature_index: None,
             notification_indices: Default::default(),
             kwin_available: None,
+            divert_refresh_needed: false,
+            last_refresh_trigger: None,
         }
     }
 
@@ -151,6 +175,28 @@ impl HidrawHandler {
     /// Set the shared configuration for button action lookup
     pub fn set_shared_config(&mut self, config: crate::config::SharedConfig) {
         self.shared_config = Some(config);
+    }
+
+    /// Record that the device came (back) online and needs its volatile
+    /// diverts re-applied. Debounced so a flapping radio link cannot turn
+    /// into a refresh storm.
+    fn flag_divert_refresh(&mut self, reason: &str) {
+        let now = Instant::now();
+        if let Some(last) = self.last_refresh_trigger {
+            if now.duration_since(last) < DIVERT_REFRESH_DEBOUNCE {
+                tracing::debug!(reason, "Divert refresh trigger debounced");
+                return;
+            }
+        }
+        self.last_refresh_trigger = Some(now);
+        self.divert_refresh_needed = true;
+        tracing::info!(reason, "Device back online - volatile diverts need re-apply");
+    }
+
+    /// Consume the divert-refresh flag. Returns true when `start()` exited
+    /// because the device came back online (issue #102).
+    pub fn take_divert_refresh_needed(&mut self) -> bool {
+        std::mem::take(&mut self.divert_refresh_needed)
     }
 
     /// Look up the configured action for a CID from shared config
@@ -323,6 +369,12 @@ impl HidrawHandler {
             match read_result {
                 Ok(len) if len >= 7 => {
                     self.process_hidpp_report(&buf[..len]).await;
+                    // The device announced it came back online (power switch,
+                    // radio sleep): its volatile diverts are gone. Return so
+                    // the hidraw loop re-applies them (issue #102).
+                    if self.divert_refresh_needed {
+                        return Ok(());
+                    }
                 }
                 Ok(_) => {
                     // Short read, ignore
@@ -368,6 +420,18 @@ impl HidrawHandler {
             return;
         }
 
+        // Receiver-protocol "device connection" notification: the Bolt keeps
+        // its hidraw node while the mouse is off or asleep, so this SHORT
+        // report (not any node hotplug) is what signals the radio coming back.
+        // Byte 4 bit 6 set means "link not established" - only a link-up
+        // report triggers a divert refresh (issue #102).
+        if report_type == HIDPP_SHORT && feature_index == RECEIVER_CONNECTION_SUB_ID {
+            if data.len() >= 5 && (data[4] & 0x40) == 0 {
+                self.flag_divert_refresh("receiver device-connection notification");
+            }
+            return;
+        }
+
         // Log all HID++ reports for debugging
         tracing::debug!(
             report_type = format!("0x{:02X}", report_type),
@@ -387,6 +451,22 @@ impl HidrawHandler {
         if (function_sw_id & 0x0F) == 0 {
             if let Some(note) = self.notification_indices.route(feature_index, data) {
                 tracing::debug!(?note, "Hardware notification decoded");
+                use crate::hidpp::notifications::HardwareNotification as HN;
+                match note {
+                    // Wireless Device Status broadcast: the mouse just came
+                    // back online and has cleared its volatile HID++ state.
+                    // Internal signal only - nothing to surface on D-Bus.
+                    HN::DeviceConnected => {
+                        self.flag_divert_refresh("wireless device status broadcast");
+                        return;
+                    }
+                    // An Easy-Switch return also clears volatile state; keep
+                    // emitting the D-Bus signal as before, but refresh too.
+                    HN::HostChanged { .. } => {
+                        self.flag_divert_refresh("Easy-Switch host change");
+                    }
+                    _ => {}
+                }
                 let _ = self.event_tx.send(GestureEvent::Hardware(note)).await;
                 return;
             }
@@ -820,5 +900,73 @@ mod tests {
 
         assert!(!handler.is_connected());
         assert_eq!(handler.device_path(), None);
+    }
+
+    fn test_handler() -> HidrawHandler {
+        // The receiver is dropped: none of these reports reach the event
+        // channel (connection paths return before sending), and the handler
+        // ignores send failures anyway.
+        let (tx, _rx) = mpsc::channel(4);
+        HidrawHandler::new(tx)
+    }
+
+    // Issue #102: a receiver "device connection" notification with the link
+    // established must request a divert refresh...
+    #[tokio::test]
+    async fn receiver_link_up_requests_divert_refresh() {
+        let mut h = test_handler();
+        // [report, device idx, sub-id 0x41, protocol, device info (bit6 clear)]
+        let report = [0x10, 0x01, 0x41, 0x04, 0x02, 0x00, 0x00];
+        h.process_hidpp_report(&report).await;
+        assert!(h.take_divert_refresh_needed());
+        // take() consumes the flag
+        assert!(!h.take_divert_refresh_needed());
+    }
+
+    // ...while a link-DOWN notification (bit 6 set: mouse switched off) must not.
+    #[tokio::test]
+    async fn receiver_link_down_does_not_request_refresh() {
+        let mut h = test_handler();
+        let report = [0x10, 0x01, 0x41, 0x04, 0x42, 0x00, 0x00];
+        h.process_hidpp_report(&report).await;
+        assert!(!h.take_divert_refresh_needed());
+    }
+
+    // A LONG report whose feature index happens to be 0x41 is device feature
+    // traffic, not a receiver notification, and must not trigger a refresh.
+    #[tokio::test]
+    async fn long_report_with_0x41_index_is_not_a_connection_notification() {
+        let mut h = test_handler();
+        let report = [0x11, 0x01, 0x41, 0x00, 0x02, 0x00, 0x00];
+        h.process_hidpp_report(&report).await;
+        assert!(!h.take_divert_refresh_needed());
+    }
+
+    // Issue #102: the Wireless Device Status (0x1D4B) broadcast the mouse
+    // sends after power-on / radio sleep must request a divert refresh.
+    #[tokio::test]
+    async fn wireless_status_broadcast_requests_divert_refresh() {
+        let mut h = test_handler();
+        h.set_notification_indices(crate::hidpp::notifications::NotificationIndices {
+            wireless_status: Some(0x0c),
+            ..Default::default()
+        });
+        // statusBroadcast: sw_id nibble 0, status=1, request=1
+        let report = [0x11, 0x01, 0x0c, 0x00, 0x01, 0x01, 0x00];
+        h.process_hidpp_report(&report).await;
+        assert!(h.take_divert_refresh_needed());
+    }
+
+    // Issue #15 spirit: a burst of connection notifications (flapping link)
+    // must coalesce into one refresh, not a refresh storm.
+    #[tokio::test]
+    async fn refresh_triggers_are_debounced() {
+        let mut h = test_handler();
+        let report = [0x10, 0x01, 0x41, 0x04, 0x02, 0x00, 0x00];
+        h.process_hidpp_report(&report).await;
+        assert!(h.take_divert_refresh_needed());
+        // Immediately after, within the debounce window: no second trigger.
+        h.process_hidpp_report(&report).await;
+        assert!(!h.take_divert_refresh_needed());
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -500,9 +500,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // writes, so GetBatteryStatus reflects them even when the active query fails.
     let battery_state_for_events = battery_state.clone();
 
+    // Start inotify watcher on /dev/input/ for instant device hotplug detection.
+    // Shared across the evdev loops and the hidraw loop; the battery updater
+    // also fires it when a failing poll starts succeeding again, which is how
+    // a Bolt radio wake is detected without any node hotplug (issue #102).
+    let hotplug_notify = spawn_device_hotplug_watcher();
+
     // Spawn battery status updater (shares HidppDevice with haptic via SharedHapticManager)
+    let battery_radio_recovered = hotplug_notify.clone();
     let battery_handle = tokio::spawn(async move {
-        start_battery_updater_shared(battery_state, haptic_manager_for_battery).await
+        start_battery_updater_shared(
+            battery_state,
+            haptic_manager_for_battery,
+            battery_radio_recovered,
+        )
+        .await
     });
 
     // Load profiles (Story 3.1: Task 5)
@@ -594,10 +606,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         });
     }
-
-    // Start inotify watcher on /dev/input/ for instant device hotplug detection.
-    // Shared across both evdev loops so they re-scan immediately on device changes.
-    let hotplug_notify = spawn_device_hotplug_watcher();
 
     // Create channel for gesture events
     let (event_tx, mut event_rx) = mpsc::channel::<GestureEvent>(32);
@@ -985,7 +993,16 @@ async fn run_hidraw_loop(
 
                 match start_result {
                     Some(Ok(())) => {
-                        info!("HID++ event loop ended normally");
+                        if handler.take_divert_refresh_needed() {
+                            // The mouse announced it came back online (power
+                            // switch / radio sleep); its volatile diverts are
+                            // gone. Loop immediately so the refresh path above
+                            // re-applies them (issue #102).
+                            info!("Device back online, re-applying HID++ diverts");
+                            retry_immediately = true;
+                        } else {
+                            info!("HID++ event loop ended normally");
+                        }
                     }
                     Some(Err(HidrawError::DeviceNotFound)) => {
                         warn!("HID++ device disconnected, will poll for reconnection...");
@@ -1065,22 +1082,35 @@ async fn run_evdev_loop(
                     device_info.path, device_info.name
                 );
 
-                // Run the event loop until device disconnects
-                match handler.start().await {
-                    Ok(()) => {
+                // Run the event loop until device disconnect OR hotplug. The
+                // grabbed fd lives inside start(); without the hotplug arm a
+                // re-enumeration that leaves the old node present kept the
+                // loop glued to a dead grab. Cancelling start() drops its
+                // device handle, which closes the fd and releases the grab.
+                let start_result = tokio::select! {
+                    result = handler.start() => Some(result),
+                    _ = hotplug.notified() => None,
+                };
+                match start_result {
+                    Some(Ok(())) => {
                         info!("Event loop ended normally");
                     }
-                    Err(EvdevError::DeviceNotFound) => {
+                    Some(Err(EvdevError::DeviceNotFound)) => {
                         warn!("Device disconnected, will poll for reconnection...");
                         logged_waiting = false;
                     }
-                    Err(EvdevError::PermissionDenied) => {
+                    Some(Err(EvdevError::PermissionDenied)) => {
                         error!("Permission denied. Ensure udev rules are installed.");
                         error!("Run: sudo usermod -aG input $USER && logout");
                         // Continue polling in case permissions are fixed
                     }
-                    Err(EvdevError::IoError(e)) => {
+                    Some(Err(EvdevError::IoError(e))) => {
                         error!("I/O error: {}. Will retry...", e);
+                    }
+                    None => {
+                        info!("Device hotplug detected, re-scanning MX devices");
+                        logged_waiting = false;
+                        continue;
                     }
                 }
             }
@@ -1394,6 +1424,11 @@ async fn emit_hardware_notification(
             connection
                 .emit_signal(None::<&str>, DBUS_PATH, iface, "DpiChanged", &(dpi,))
                 .await?;
+        }
+        HN::DeviceConnected => {
+            // Handled inside the hidraw reader (divert refresh, issue #102);
+            // nothing to surface on D-Bus.
+            debug!("Device connected (notification)");
         }
     }
     Ok(())

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ flowchart TD
 
 `main.rs` spawns these concurrent tasks:
 
-- **hidraw loop** (`run_hidraw_loop`): connects to the device's hidraw node, re-applies volatile button diverts, thumb-wheel divert, and notification feature indices on every (re)connect, then reads diverted events. It owns re-applying diverts because they are reset by hotplug and Easy-Switch host changes.
+- **hidraw loop** (`run_hidraw_loop`): connects to the device's hidraw node, re-applies volatile button diverts, thumb-wheel divert, and notification feature indices on every (re)connect, then reads diverted events. It owns re-applying diverts because they are reset by hotplug and Easy-Switch host changes. Bolt/Unifying receivers keep their hidraw and `event*` nodes while the mouse is off or asleep, so liveness is not node presence alone: the reader also treats the device's Wireless Device Status (0x1D4B) wake broadcast and the receiver's device-connection notification as reconnects, and the battery poller wakes the loops when a failing query starts succeeding again (issue #102). The `/dev/input` watcher still ignores `Access` events (issue #15).
 - **MX evdev loop** (`run_evdev_loop`) and **generic evdev loop** (`run_generic_evdev_loop`): run simultaneously so either a Logitech MX or a generic mouse can trigger the wheel. The generic loop uses a configurable trigger button read from config.
 - **event processing** (`process_gesture_events`): consumes `GestureEvent`s and turns them into D-Bus signals or action injection.
 - **battery updater**: polls battery and writes the shared state behind `GetBatteryStatus`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ systemctl --user restart juhradialmx-daemon.service
 - Missing fields fall back to defaults, so a minimal `{}` file is valid. On first run the Settings app auto-detects your desktop environment and fills in environment-appropriate commands for the radial slices (controlled by the internal `de_defaults_applied` flag).
 
 !!! warning
-    The daemon writes only VOLATILE HID++ state to the device (no onboard-memory writes). Diverts and hardware overrides are re-applied on reconnect and on `ReloadConfig`, so a hotplugged mouse comes back to your configured state automatically.
+    The daemon writes only VOLATILE HID++ state to the device (no onboard-memory writes). Diverts and hardware overrides are re-applied on reconnect, on radio wake (power switch / sleep, where the receiver's device nodes never disappear), and on `ReloadConfig` (which re-diverts the gesture and haptic buttons too), so the mouse comes back to your configured state automatically.
 
 
 ## Top-level structure of config.json

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,7 +67,7 @@ GNOME and niri have specific setup notes (a Shell extension for GNOME, an XWayla
 
 Yes, it is safe. JuhRadial MX never writes or flashes firmware. It only sends standard HID++ feature commands that the mouse already exposes (DPI, scroll, haptics, easy-switch, battery queries) and reads input events.
 
-Button "diverts" (which let the daemon intercept the gesture and haptic buttons) are applied with the HID++ **volatile** flag. Volatile diverts are not persisted to the device and are cleared automatically on unplug, reboot, or hotplug. The daemon simply re-applies them when the device reconnects. Nothing about your mouse's saved state is permanently changed.
+Button "diverts" (which let the daemon intercept the gesture and haptic buttons) are applied with the HID++ **volatile** flag. Volatile diverts are not persisted to the device and are cleared automatically on unplug, reboot, power-off, radio sleep, or hotplug. The daemon re-applies them whenever the radio is seen again: after a hidraw/`event*` hotplug, after an Easy-Switch return, and after the mouse wakes from sleep or the power switch (wake broadcast or the next successful battery poll). Nothing about your mouse's saved state is permanently changed.
 
 ### Does it need root?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -275,6 +275,18 @@ id -nG | grep input
 
 **Fix.** Update to a build where the button you want is included in the divert set, and re-apply config after a reconnect (`ReloadConfig`, or just trigger the daemon's reconnect path by re-plugging). If your assignment still does nothing after a reload, the CID for that button is not yet diverted: note which physical button in a GitHub issue. See [Features](features.md) for which buttons are remappable.
 
+### Problem: the gesture button works, then dies after the mouse sleeps or is switched off
+
+**Cause.** Button divert is a volatile HID++ flag, and the mouse clears it on power-off and on radio sleep. The Logi Bolt receiver (`046d:c548`) stays enumerated the whole time, so `/dev/hidraw*` and `/dev/input/event*` never disappear and builds up to 0.4.1 saw no reconnect to react to ([#102](https://github.com/JuhLabs/juhradial-mx/issues/102)).
+
+**Fix.** Update to 0.4.2 or later: the daemon now re-applies volatile diverts when the mouse announces it is back online (Wireless Device Status broadcast or the receiver's device-connection notification), when a failing battery poll starts succeeding again, and on every `ReloadConfig` (a Settings save). On older builds, restart only the daemon after a wake:
+
+```bash
+systemctl --user restart juhradialmx-daemon
+```
+
+Re-plugging the dongle also forces a reconnect on older builds. If `ps -ef | grep -E 'juhradiald|juhradial-overlay'` shows two daemons or two overlays, that is issue [#60](https://github.com/JuhLabs/juhradial-mx/issues/60) (single instance), not this bug.
+
 ---
 
 ## Haptics and battery

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
           # Rust daemon - handles evdev input and D-Bus signaling
           juhradiald = pkgs.rustPlatform.buildRustPackage {
             pname = "juhradiald";
-            version = "0.4.1";
+            version = "0.4.2";
 
             src = ./.;
             cargoRoot = "daemon";
@@ -60,7 +60,7 @@
 
           default = pkgs.stdenv.mkDerivation {
             pname = "juhradial-mx";
-            version = "0.4.1";
+            version = "0.4.2";
             src = ./.;
 
             nativeBuildInputs = with pkgs; [

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -2,7 +2,7 @@
 # Arch Linux PKGBUILD for JuhRadial MX
 
 pkgname=juhradial-mx
-pkgver=0.4.1
+pkgver=0.4.2
 pkgrel=1
 pkgdesc="Beautiful radial menu for Logitech MX Master mice on Linux"
 arch=('x86_64')

--- a/packaging/rpm/juhradial-mx.spec
+++ b/packaging/rpm/juhradial-mx.spec
@@ -2,7 +2,7 @@
 # Build: rpmbuild -ba juhradial-mx.spec
 
 Name:           juhradial-mx
-Version:        0.4.1
+Version:        0.4.2
 Release:        1%{?dist}
 Summary:        Beautiful radial menu for Logitech MX Master mice on Linux
 


### PR DESCRIPTION
## Summary

The MX Master 4 clears its volatile HID++ state (gesture/haptic button divert, reassigned-button divert, thumb-wheel reporting) when switched off or entering radio sleep, but the Logi Bolt receiver stays on the USB bus, so `/dev/hidraw*` and `/dev/input/event*` never disappear. The hidraw reader sat in its `WouldBlock` loop forever, the divert refresh path never ran again, and the gesture button stayed dead until a daemon restart.

## Changes

- The hidraw reader now decodes the Wireless Device Status (0x1D4B) broadcast the mouse sends when it comes back online, plus the receiver's device-connection notification (sub-id 0x41, link established), and exits its read loop so the existing refresh path re-applies all volatile state. Triggers are debounced (2s) so a flapping radio link cannot cause a refresh storm.
- The battery updater fires the shared hotplug `Notify` when a failing poll starts succeeding again. Zero extra HID++ traffic: it rides the existing 60s cadence and fires once per outage, not periodically.
- `ReloadConfig` now also re-diverts the gesture and haptic buttons, so a Settings save doubles as a manual recovery.
- `run_evdev_loop` races its event loop against the hotplug `Notify` (like the hidraw loop already did), so it cannot stay glued to a dead grabbed fd across re-enumeration.
- Version bumped to 0.4.2 so installer users can tell the fixed build from 0.4.1.
- Docs: new troubleshooting section for this failure mode, corrected reconnect wording in FAQ/architecture/configuration.

## Regression guards (closed issues)

- `/dev/input` watcher untouched: still Create/Remove of `event*` only, 500ms debounce (#15).
- Refresh flows through `refresh_hidpp_button_diverts` and `config::action_for_cid`; reassigned buttons and thumb-wheel included (#14, #26).
- No persistent divert bits, no onboard memory writes (project safety rule).
- No udev-triggered restarts, no `Wants=graphical-session.target`, single-instance claim untouched (#60, #67).
- `DEVICE_POLL_INTERVAL_SECS` stays 60.

## Testing

- 295 unit tests pass (`cargo test`), including 7 new ones covering link-up/link-down decode, the 0x1D4B broadcast, long-report disambiguation, and trigger debounce. `cargo clippy` clean.
- Hardware-verified on an MX Master 4 with a Bolt USB-C receiver (046d:c548) under KDE Wayland, the reporter's scenario: power switch off, 10s wait, on. The daemon logged the device-connection notification and re-diverted within ~2.3s, and the gesture pad, haptic button, and radial menu all worked after wake, across repeated cycles.

Fixes #102