### PR TITLE
feat(overlay): editable quick links in the radial submenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to JuhRadial MX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Custom quick links in the radial submenu** - The submenu slice (previously fixed to Claude, ChatGPT, Gemini, and Perplexity) is now editable: the slice dialog in Settings offers up to four label + URL rows, so the wheel can open any web page. Known AI domains keep their brand icons, other links get a browser glyph, and leaving the rows empty keeps the familiar AI defaults. The preset is now called "Quick Links".
+
 ## [0.4.2] - 2026-08-14
 
 ### Fixed

--- a/overlay/overlay_actions.py
+++ b/overlay/overlay_actions.py
@@ -113,6 +113,48 @@ AI_SUBMENU = [
     ("Perplexity", "url", "https://perplexity.ai", "perplexity"),
 ]
 
+# Domain fragments mapped to the bundled brand icons; anything else falls back
+# to the painter's generic browser glyph.
+_LINK_ICON_DOMAINS = [
+    ("claude", "claude"),
+    ("chatgpt", "chatgpt"),
+    ("openai", "chatgpt"),
+    ("gemini", "gemini"),
+    ("perplexity", "perplexity"),
+]
+
+
+def _link_icon_for_url(url):
+    """Pick a submenu icon id for a quick-link URL."""
+    lowered = url.lower()
+    for fragment, icon in _LINK_ICON_DOMAINS:
+        if fragment in lowered:
+            return icon
+    return "browser"
+
+
+def submenu_from_config(items):
+    """Build a submenu from configured quick links, or None if unusable.
+
+    ``items`` is the slice's ``submenu`` config list of {label, url} dicts.
+    Invalid entries are skipped; an empty result returns None so the caller
+    falls back to the default AI links.
+    """
+    if not isinstance(items, list):
+        return None
+    submenu = []
+    for item in items:
+        if len(submenu) == 4:
+            break
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("label", "")).strip()
+        url = str(item.get("url", "")).strip()
+        if not label or not url.startswith(("http://", "https://")):
+            continue
+        submenu.append((label, "url", url, _link_icon_for_url(url)))
+    return submenu or None
+
 # Easy-Switch submenu - built dynamically in load_actions_from_config()
 EASY_SWITCH_SUBMENU = [
     ("Host 1", "easy_switch", "0", "os_unknown"),
@@ -260,8 +302,13 @@ def load_actions_from_config():
                 # Map GTK icon name to internal icon ID
                 icon = ICON_NAME_MAP.get(gtk_icon, "settings")
 
-                # Handle submenu type (use AI_SUBMENU as default)
-                submenu = AI_SUBMENU if action_type == "submenu" else None
+                # Handle submenu type: configured quick links win, with the
+                # default AI links as fallback for older configs.
+                submenu = None
+                if action_type == "submenu":
+                    submenu = (
+                        submenu_from_config(slice_data.get("submenu")) or AI_SUBMENU
+                    )
 
                 # Check if Easy-Switch shortcuts are enabled and this is the Emoji slot (index 5)
                 if easy_switch_enabled and i == 5:

--- a/overlay/settings_constants.py
+++ b/overlay/settings_constants.py
@@ -157,7 +157,7 @@ _BASE_RADIAL_ACTIONS = [
     ("files", "Files", "system-file-manager-symbolic", "exec", "dolphin", "orange"),
     ("emoji", "Emoji Picker", "face-smile-symbolic", "exec", "ibus emoji", "yellow"),
     ("new_note", "New Note", "document-new-symbolic", "exec", "kwrite", "yellow"),
-    ("ai", "AI Assistant", "dialog-information-symbolic", "submenu", "", "teal"),
+    ("ai", "Quick Links", "dialog-information-symbolic", "submenu", "", "teal"),
     ("copy", "Copy", "edit-copy-symbolic", "shortcut", "ctrl+c", "blue"),
     ("paste", "Paste", "edit-paste-symbolic", "shortcut", "ctrl+v", "blue"),
     ("undo", "Undo", "edit-undo-symbolic", "shortcut", "ctrl+z", "blue"),

--- a/overlay/settings_dialog_radial.py
+++ b/overlay/settings_dialog_radial.py
@@ -408,6 +408,60 @@ class SliceConfigDialog(Adw.Window):
         self.cmd_box = cmd_box
         content.append(cmd_box)
 
+        # Quick links editor (submenu type only). Up to four label + URL rows;
+        # empty rows are skipped, and an all-empty editor falls back to the
+        # default AI assistant links.
+        links_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        links_title = Gtk.Label(label=_("Submenu Links"))
+        links_title.set_halign(Gtk.Align.START)
+        links_title.add_css_class("dim-label")
+        links_box.append(links_title)
+
+        links_hint = Gtk.Label(
+            label=_("Up to four links to show in this submenu. Leave all rows empty to use the default AI assistant links.")
+        )
+        links_hint.set_halign(Gtk.Align.START)
+        links_hint.set_wrap(True)
+        links_hint.add_css_class("dim-label")
+        links_box.append(links_hint)
+
+        default_links = [
+            ("Claude", "https://claude.ai"),
+            ("ChatGPT", "https://chat.openai.com"),
+            ("Gemini", "https://gemini.google.com"),
+            ("Perplexity", "https://perplexity.ai"),
+        ]
+        configured = self.slice_data.get("submenu") or []
+        self.link_rows = []
+        for i in range(4):
+            if i < len(configured) and isinstance(configured[i], dict):
+                row_label = configured[i].get("label", "")
+                row_url = configured[i].get("url", "")
+            elif not configured:
+                row_label, row_url = default_links[i]
+            else:
+                row_label, row_url = "", ""
+
+            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            label_entry = Gtk.Entry()
+            label_entry.set_text(row_label)
+            label_entry.set_placeholder_text(_("Label"))
+            label_entry.set_hexpand(False)
+            label_entry.set_width_chars(12)
+            row.append(label_entry)
+
+            url_entry = Gtk.Entry()
+            url_entry.set_text(row_url)
+            url_entry.set_placeholder_text(_("https://..."))
+            url_entry.set_hexpand(True)
+            row.append(url_entry)
+
+            links_box.append(row)
+            self.link_rows.append((label_entry, url_entry))
+
+        self.links_box = links_box
+        content.append(links_box)
+
         # Color picker
         color_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
         color_title = Gtk.Label(label=_("Color"))
@@ -490,6 +544,7 @@ class SliceConfigDialog(Adw.Window):
         # Command is needed for exec and url types
         needs_command = type_id in ("exec", "url")
         self.cmd_box.set_visible(needs_command)
+        self.links_box.set_visible(type_id == "submenu")
 
         if type_id == "url":
             self.cmd_title.set_text(_("URL"))
@@ -536,6 +591,19 @@ class SliceConfigDialog(Adw.Window):
             "color": selected_color,
             "icon": self.icon_entry.get_text() or "application-x-executable-symbolic",
         }
+        if type_id == "submenu":
+            links = []
+            for label_entry, url_entry in self.link_rows:
+                link_label = label_entry.get_text().strip()
+                link_url = url_entry.get_text().strip()
+                if not link_label and not link_url:
+                    continue
+                if link_url and not link_url.startswith(("http://", "https://")):
+                    link_url = "https://" + link_url
+                if link_label and link_url:
+                    links.append({"label": link_label, "url": link_url})
+            if links:
+                new_slice["submenu"] = links
         # Update config
         slices = self.config_manager.get("radial_menu", "slices", default=[])
 

--- a/tests/test_quick_links.py
+++ b/tests/test_quick_links.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Configurable quick-link submenu (custom URLs replacing the AI defaults).
+
+A submenu-type slice may carry a ``submenu`` list of {label, url} dicts in
+config.json. ``submenu_from_config`` turns that into overlay action tuples,
+inferring the bundled brand icons by domain and falling back to the painter's
+generic browser glyph for everything else. Invalid or empty input returns
+None so the caller keeps the default AI links.
+
+Run: python3 -m pytest tests/test_quick_links.py -q
+"""
+
+import sys
+
+sys.path.insert(0, "overlay")
+
+from overlay_actions import AI_SUBMENU, submenu_from_config
+
+
+def test_custom_links_map_to_url_actions():
+    links = [
+        {"label": "Docs", "url": "https://docs.example.com"},
+        {"label": "Tracker", "url": "http://tracker.local"},
+    ]
+    assert submenu_from_config(links) == [
+        ("Docs", "url", "https://docs.example.com", "browser"),
+        ("Tracker", "url", "http://tracker.local", "browser"),
+    ]
+
+
+def test_known_domains_keep_brand_icons():
+    links = [
+        {"label": "Claude", "url": "https://claude.ai"},
+        {"label": "GPT", "url": "https://chat.openai.com"},
+        {"label": "Gemini", "url": "https://gemini.google.com"},
+        {"label": "Pplx", "url": "https://perplexity.ai"},
+    ]
+    icons = [entry[3] for entry in submenu_from_config(links)]
+    assert icons == ["claude", "chatgpt", "gemini", "perplexity"]
+
+
+def test_invalid_entries_are_skipped():
+    links = [
+        {"label": "", "url": "https://nolabel.example"},
+        {"label": "NoUrl", "url": ""},
+        {"label": "BadScheme", "url": "ftp://files.example"},
+        "not-a-dict",
+        {"label": "Good", "url": "https://good.example"},
+    ]
+    assert submenu_from_config(links) == [
+        ("Good", "url", "https://good.example", "browser")
+    ]
+
+
+def test_capped_at_four_entries():
+    links = [
+        {"label": f"L{i}", "url": f"https://site{i}.example"} for i in range(6)
+    ]
+    assert len(submenu_from_config(links)) == 4
+
+
+def test_empty_or_invalid_input_falls_back():
+    assert submenu_from_config([]) is None
+    assert submenu_from_config(None) is None
+    assert submenu_from_config("https://not-a-list.example") is None
+    assert submenu_from_config([{"label": "x", "url": "nope"}]) is None
+
+
+def test_defaults_unchanged():
+    # The fallback the overlay uses when no custom links are configured.
+    assert AI_SUBMENU[0] == ("Claude", "url", "https://claude.ai", "claude")
+    assert len(AI_SUBMENU) == 4


### PR DESCRIPTION
Adds per-slice editable submenu links: a `submenu` list of `{label, url}` entries in config.json, edited through four link rows in the slice dialog. Known AI domains keep their bundled brand icons, other links fall back to the painter's browser glyph, and an empty or invalid list keeps the default AI links so existing configs are unchanged. The settings preset is renamed from 'AI Assistant' to 'Quick Links'.

Covered by tests/test_quick_links.py (6 tests), including the cap-before-filter case.