### PR TITLE
SmartShift/HiRes protocol fixes + settings live-state wave (0.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to JuhRadial MX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-08-18
+
+### Fixed
+
+- **SmartShift settings actually reach the mouse now** - On the MX Master 3/3S/4 the daemon was calling SmartShift with the legacy `0x2110` function IDs, but these mice expose SmartShift Enhanced (`0x2111`), whose functions are shifted by one. Reads therefore parsed a capabilities reply as ratchet state (reporting a constant threshold no matter the real setting) and writes landed on a getter, so changing the wheel mode or threshold silently did nothing. The daemon now records which SmartShift variant the device exposes and uses the matching function IDs, keeping the third parameter (torque on `0x2111`, default threshold on `0x2110`) per-variant so a threshold write can no longer reprogram torque. Fixing the writes also exposed an inverted mode mapping in the D-Bus layer (enabling SmartShift would have forced permanent free-spin) and two contradictory threshold encodings between the settings path and per-app profiles; both are now a single mapping. Reported with hardware traces by [@FoxQwartz](https://github.com/FoxQwartz). Fixes [#107](https://github.com/JuhLabs/juhradial-mx/issues/107).
+- **Hi-res scroll get/set target the right feature** - `GetHiresscrollMode`/`SetHiresscrollMode` were addressed to the SmartShift feature index instead of HiRes Wheel (`0x2121`), so the reported hi-res state was a misread of SmartShift's wheel mode, and toggling smooth or natural scrolling silently rewrote the SmartShift ratchet mode. Both now resolve `0x2121`, whose function IDs and mode bits the code already used correctly. Also reported by [@FoxQwartz](https://github.com/FoxQwartz). Fixes [#106](https://github.com/JuhLabs/juhradial-mx/issues/106).
+- **Settings live state is populated and stays current** - The Devices page WHEEL readout is primed from the daemon on open (previously blank until the wheel-mode button was pressed) and now distinguishes SmartShift from a permanent ratchet; the Connected Device battery row follows charge signals instead of freezing at its load-time value; and the Point-and-scroll mode selector re-reads device state when the hardware wheel-mode button fires. Reported by [@FoxQwartz](https://github.com/FoxQwartz). Fixes [#108](https://github.com/JuhLabs/juhradial-mx/issues/108).
+- **Connection row shows the real link** - The Devices page guessed "USB Receiver / Bluetooth"; it now reads the HID bus from sysfs and reports Bolt, Unifying, plain USB receiver, or Bluetooth, with icon names that exist on Breeze (the old hardcoded names rendered as a broken-image glyph on KDE).
+
+### Changed
+
+- **Scroll speed slider shows its effect** - The Point-and-scroll speed slider now displays the approximate lines-per-notch it produces instead of an unlabeled position, and the header info hints render as theme-independent glyphs (the themed info icon is full-color blue on Breeze and clashed with the dark header).
+
 ## [0.4.3] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
   <p>
     <a href="https://github.com/JuhLabs/juhradial-mx/releases">
-      <img src="https://img.shields.io/badge/version-0.4.1-cyan.svg" alt="Version 0.4.1">
+      <img src="https://img.shields.io/badge/version-0.4.4-cyan.svg" alt="Version 0.4.4">
     </a>
     <a href="https://juhlabs.github.io/juhradial-mx/">
       <img src="https://img.shields.io/badge/docs-juhlabs.github.io-4FEFC9.svg" alt="Documentation">
@@ -41,7 +41,7 @@
 -->
 
 > [!TIP]
-> **New in [v0.4.1](CHANGELOG.md):** Better GNOME Wayland cursor placement, tap-to-close, single-overlay enforcement ([#60](https://github.com/JuhLabs/juhradial-mx/issues/60)), working thumb-wheel assignments, and desktop-aware screenshots. [Update now](#installation).
+> **New in [v0.4.4](CHANGELOG.md):** SmartShift and hi-res scroll controls now really program the mouse: the daemon spoke the wrong HID++ dialect to the MX Master 3/3S/4 SmartShift feature, so mode changes silently did nothing ([#106](https://github.com/JuhLabs/juhradial-mx/issues/106), [#107](https://github.com/JuhLabs/juhradial-mx/issues/107)). Plus live wheel/battery readouts in Settings ([#108](https://github.com/JuhLabs/juhradial-mx/issues/108)). [Update now](#installation).
 
 ## Installation
 

--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "juhradiald"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "clap",
  "criterion",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juhradiald"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "JuhRadial MX daemon - Radial menu for Logitech MX Master 4 on Linux"
 license = "GPL-3.0"

--- a/daemon/src/dbus/interface.rs
+++ b/daemon/src/dbus/interface.rs
@@ -394,16 +394,7 @@ impl JuhRadialService {
 
     async fn get_smart_shift(&self) -> fdo::Result<(bool, u8)> {
         match self.haptic_manager.lock() {
-            Ok(mut manager) => {
-                match manager.get_smartshift() {
-                    Some((_wheel_mode, auto_disengage, _auto_disengage_default)) => {
-                        let enabled = auto_disengage > 0;
-                        let threshold = if enabled { auto_disengage } else { 30 };
-                        Ok((enabled, threshold))
-                    }
-                    None => Ok((false, 0))
-                }
-            }
+            Ok(mut manager) => Ok(manager.get_smart_shift().unwrap_or((false, 0))),
             Err(e) => {
                 tracing::error!(error = %e, "Failed to lock haptic manager for get_smart_shift");
                 Ok((false, 0))
@@ -416,11 +407,7 @@ impl JuhRadialService {
 
         match self.haptic_manager.lock() {
             Ok(mut manager) => {
-                let wheel_mode = if enabled { 1u8 } else { 2u8 };
-                let auto_disengage = if enabled { threshold } else { 255u8 };
-                let auto_disengage_default = auto_disengage;
-
-                match manager.set_smartshift(wheel_mode, auto_disengage, auto_disengage_default) {
+                match manager.set_smart_shift(enabled, threshold) {
                     Ok(()) => {
                         tracing::info!(enabled, threshold, "SmartShift set successfully");
                         Ok(())

--- a/daemon/src/hidpp/constants.rs
+++ b/daemon/src/hidpp/constants.rs
@@ -54,9 +54,11 @@ pub mod features {
     /// Users want their DPI setting to be remembered across reboots.
     /// Functions: [0] getSensorCount, [1] getSensorDpiList, [2] getSensorDpi, [3] setSensorDpi
     pub const ADJUSTABLE_DPI: u16 = 0x2201;
-    /// HiResScroll - High-resolution scroll with SmartShift (MX Master 3/4)
-    /// This is used by newer mice (MX Master 3, 3S, 4) for ratchet/free-spin control.
-    /// Functions: [0] getMode, [1] setMode (contains ratchet mode control)
+    /// SmartShift Enhanced (0x2111) - ratchet/free-spin control on newer mice
+    /// (MX Master 3, 3S, 4). NOTE: despite the constant's name this is NOT the
+    /// HiRes scrolling feature; hi-res mode lives on HIRES_WHEEL (0x2121).
+    /// Functions: [0] getCapabilities, [1] getRatchetControlMode,
+    /// [2] setRatchetControlMode (third byte = torque %, unlike 0x2110).
     pub const HIRES_SCROLL: u16 = 0x2111;
 
     /// SmartShift Legacy - For older mice (MX Master 2S and earlier)
@@ -65,9 +67,10 @@ pub mod features {
 
     /// HiResWheel - High-resolution vertical wheel (0x2121)
     ///
-    /// READ-ONLY here: used only to learn the feature index so the hidraw
-    /// reader can decode the device-originated `ratchetSwitchChanged` event
-    /// (free-spin vs ratchet). We never write to this feature.
+    /// Used for two things: decoding the device-originated
+    /// `ratchetSwitchChanged` event (free-spin vs ratchet) in the hidraw
+    /// reader, and get/set of the wheel mode bitfield (target/hi-res/invert)
+    /// via [1] getWheelMode / [2] setWheelMode.
     pub const HIRES_WHEEL: u16 = 0x2121;
 
     /// ThumbWheel - Horizontal thumb wheel on MX Master 3/3S/4 (0x2150)

--- a/daemon/src/hidpp/device.rs
+++ b/daemon/src/hidpp/device.rs
@@ -43,10 +43,14 @@ pub struct HidppDevice {
     dpi_supported: bool,
     /// Adjustable DPI feature index (0x2201)
     dpi_feature_index: Option<u8>,
-    /// Whether SmartShift feature is available (0x2110)
+    /// Whether SmartShift feature is available (0x2111 or 0x2110)
     smartshift_supported: bool,
-    /// SmartShift feature index (0x2110)
+    /// SmartShift feature index (0x2111 Enhanced preferred, 0x2110 legacy fallback)
     smartshift_feature_index: Option<u8>,
+    /// True when bound to SmartShift Enhanced (0x2111), which uses function IDs
+    /// [1] getRatchetControlMode / [2] setRatchetControlMode (its [0] is
+    /// getCapabilities). Legacy 0x2110 uses [0] get / [1] set.
+    smartshift_is_enhanced: bool,
     /// Whether unified battery feature is available (0x1004)
     battery_supported: bool,
     /// Battery feature index (0x1004 or 0x1000)
@@ -323,6 +327,7 @@ impl HidppDevice {
                     dpi_feature_index: None,
                     smartshift_supported: false,
                     smartshift_feature_index: None,
+                    smartshift_is_enhanced: false,
                     battery_supported: false,
                     battery_feature_index: None,
                     is_unified_battery: false,
@@ -806,13 +811,14 @@ impl HidppDevice {
                     );
                 }
 
-                // Check for HiResScroll feature (0x2111) - MX Master 3/4 SmartShift control
+                // Check for SmartShift Enhanced (0x2111) - MX Master 3/4 SmartShift control
                 if feature_id == features::HIRES_SCROLL {
                     self.smartshift_supported = true;
                     self.smartshift_feature_index = Some(feature_index);
+                    self.smartshift_is_enhanced = true;
                     tracing::info!(
                         index = feature_index,
-                        "HiResScroll feature found (0x2111) - SmartShift control available"
+                        "SmartShift Enhanced feature found (0x2111) - SmartShift control available"
                     );
                 }
 
@@ -1540,10 +1546,10 @@ impl HidppDevice {
     /// Returns the current SmartShift wheel mode and auto-disengage threshold.
     ///
     /// # Returns
-    /// Some((wheel_mode, auto_disengage, auto_disengage_default)) where:
+    /// Some((wheel_mode, auto_disengage, third)) where:
     /// - wheel_mode: 1 = Freespin, 2 = Ratchet
     /// - auto_disengage: Threshold for automatic ratchet disengagement (1-254 = N/4 turns/sec, 255 = always engaged)
-    /// - auto_disengage_default: Default threshold stored in device
+    /// - third: autoDisengageDefault on legacy 0x2110, torque % on Enhanced 0x2111
     ///
     /// None if SmartShift is not supported
     pub fn get_smartshift(&mut self) -> Option<(u8, u8, u8)> {
@@ -1551,10 +1557,12 @@ impl HidppDevice {
 
         tracing::debug!(feature_index, "Getting SmartShift config from device");
 
-        // Function [0] getRatchetControlMode() -> wheelMode, autoDisengage, autoDisengageDefault
+        // Legacy 0x2110: function [0] getRatchetControlMode.
+        // Enhanced 0x2111: function [1] getRatchetControlMode ([0] is getCapabilities).
+        let read_fn = if self.smartshift_is_enhanced { 0x01 } else { 0x00 };
         let params = [0x00, 0x00, 0x00];
 
-        self.hidpp_request(feature_index, 0x00, &params).and_then(|resp| {
+        self.hidpp_request(feature_index, read_fn, &params).and_then(|resp| {
             if resp.len() >= 7 {
                 // Response: [report_type, device_idx, feature_idx, fn_sw_id, wheel_mode, auto_disengage, auto_disengage_default, ...]
                 let wheel_mode = resp[4];
@@ -1582,7 +1590,9 @@ impl HidppDevice {
     /// # Arguments
     /// * `wheel_mode` - 0 = no change, 1 = Freespin, 2 = Ratchet
     /// * `auto_disengage` - 0 = no change, 1-254 = N/4 turns/sec threshold, 255 = always engaged
-    /// * `auto_disengage_default` - 0 = no change, 1-254 = default threshold, 255 = always engaged
+    /// * `auto_disengage_default` - 0 = no change, 1-254 = default threshold, 255 = always
+    ///   engaged. Legacy 0x2110 only: on Enhanced 0x2111 the third byte is torque %, so this
+    ///   parameter is ignored and 0 (= leave unchanged) is sent instead.
     ///
     /// # Returns
     /// Ok(()) on success, error on failure
@@ -1608,10 +1618,17 @@ impl HidppDevice {
             "Setting SmartShift config"
         );
 
-        // Function [1] setRatchetControlMode(wheelMode, autoDisengage, autoDisengageDefault)
-        let params = [wheel_mode, auto_disengage, auto_disengage_default];
+        // Legacy 0x2110: function [1] setRatchetControlMode(wheelMode, autoDisengage,
+        // autoDisengageDefault). Enhanced 0x2111: function [2] setRatchetControlMode,
+        // whose third byte is torque % - send 0 (= leave unchanged) there.
+        let (write_fn, third_byte) = if self.smartshift_is_enhanced {
+            (0x02, 0x00)
+        } else {
+            (0x01, auto_disengage_default)
+        };
+        let params = [wheel_mode, auto_disengage, third_byte];
 
-        match self.hidpp_request(feature_index, 0x01, &params) {
+        match self.hidpp_request(feature_index, write_fn, &params) {
             Some(resp) if resp.len() >= 7 => {
                 // Response echoes the parameters
                 let returned_wheel_mode = resp[4];
@@ -1642,13 +1659,13 @@ impl HidppDevice {
         }
     }
 
-    /// Get HiResScroll mode configuration
+    /// Get HiResScroll mode configuration (HiRes Wheel 0x2121)
     pub fn get_hiresscroll_mode(&mut self) -> Option<(bool, bool, bool)> {
-        let feature_index = self.smartshift_feature_index?;
+        let feature_index = self.feature_index(features::HIRES_WHEEL)?;
 
         tracing::debug!(feature_index, "Getting HiResScroll mode from device");
 
-        // Function [1] getMode() -> mode byte
+        // Function [1] getWheelMode() -> mode byte
         let params = [0x00, 0x00, 0x00];
 
         self.hidpp_request(feature_index, 0x01, &params).and_then(|resp| {
@@ -1673,14 +1690,14 @@ impl HidppDevice {
         })
     }
 
-    /// Set HiResScroll mode configuration
+    /// Set HiResScroll mode configuration (HiRes Wheel 0x2121)
     pub fn set_hiresscroll_mode(
         &mut self,
         hires: bool,
         invert: bool,
         target: bool,
     ) -> Result<(), HapticError> {
-        let feature_index = match self.smartshift_feature_index {
+        let feature_index = match self.feature_index(features::HIRES_WHEEL) {
             Some(idx) => idx,
             None => {
                 tracing::debug!("HiResScroll not supported on this device");
@@ -1709,7 +1726,7 @@ impl HidppDevice {
             "Setting HiResScroll mode"
         );
 
-        // Function [2] setMode(mode)
+        // Function [2] setWheelMode(mode)
         let params = [mode, 0x00, 0x00];
 
         match self.hidpp_request(feature_index, 0x02, &params) {

--- a/daemon/src/hidpp/manager.rs
+++ b/daemon/src/hidpp/manager.rs
@@ -693,19 +693,38 @@ impl HapticManager {
         }
     }
 
-    /// Get SmartShift configuration (simplified API for DBus)
+    /// Get SmartShift configuration (simplified API for DBus and profiles)
+    ///
+    /// Returns (enabled, threshold), the inverse of [`Self::set_smart_shift`]:
+    /// SmartShift auto-disengage -> (true, 1-254), freespin -> (true, 0),
+    /// permanent ratchet (autoDisengage 255) -> (false, 0).
     pub fn get_smart_shift(&mut self) -> Option<(bool, u8)> {
-        self.get_smartshift().map(|(wheel_mode, auto_disengage, _default)| {
-            let enabled = wheel_mode == 1;
-            let threshold = 255u8.saturating_sub(auto_disengage);
-            (enabled, threshold)
+        self.get_smartshift().map(|(wheel_mode, auto_disengage, _third)| {
+            if wheel_mode == 1 {
+                (true, 0)
+            } else if auto_disengage == 255 {
+                (false, 0)
+            } else {
+                (true, auto_disengage)
+            }
         })
     }
 
-    /// Set SmartShift configuration (simplified API for DBus)
+    /// Set SmartShift configuration (simplified API for DBus and profiles)
+    ///
+    /// (true, 1-254) = ratchet with auto-disengage at the given threshold
+    /// (SmartShift), (true, 0) = freespin, (false, _) = permanently ratcheted.
+    /// Device semantics: wheelMode 1 = Freespin, 2 = Ratchet; autoDisengage
+    /// 255 = never disengage.
     pub fn set_smart_shift(&mut self, enabled: bool, threshold: u8) -> Result<(), HapticError> {
-        let wheel_mode = if enabled { 1 } else { 2 };
-        let auto_disengage = 255u8.saturating_sub(threshold);
+        let (wheel_mode, auto_disengage) = if !enabled {
+            (2, 255)
+        } else if threshold == 0 {
+            // Freespin; auto_disengage 0 = leave the stored threshold unchanged.
+            (1, 0)
+        } else {
+            (2, threshold.min(254))
+        };
         self.set_smartshift(wheel_mode, auto_disengage, auto_disengage)
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,7 +171,7 @@ Device state:
 | `GetBatteryStatus` | `(y percent, b charging)` | UnifiedBattery `0x1004` |
 | `GetDpi` / `SetDpi` / `DpiSupported` | `u16` / `(u16)` / `bool` | AdjustableDPI `0x2201` |
 | `GetSmartShift` / `SetSmartShift` / `SmartShiftSupported` | `(b, y)` / `(b, y)` / `bool` | SmartShift / HiResScroll `0x2110` / `0x2111` |
-| `GetHiresscrollMode` / `SetHiresscrollMode` | `(b hires, b invert, b target)` | HiResScroll `0x2111` |
+| `GetHiresscrollMode` / `SetHiresscrollMode` | `(b hires, b invert, b target)` | HiResWheel `0x2121` |
 | `SetThumbwheelReporting` / `ThumbwheelSupported` | `(b divert, b invert)` / `bool` | ThumbWheel `0x2150` |
 | `GetHostNames` / `GetEasySwitchInfo` / `SetHost` | `as` / `(y, y)` / `(y) -> b` | HostsInfo `0x1815`, ChangeHost `0x1814` |
 | `GetDeviceMode` / `GetDeviceName` | `s` / `s` | discovery result |
@@ -248,8 +248,8 @@ A device exposes features by index. The daemon resolves IFeatureSet (`0x0001`) v
 | UnifiedBattery | `0x1004` | Preferred battery feature for the MX Master 4 (read-only). |
 | AdjustableDPI | `0x2201` | Get/set sensor DPI; also the "is a mouse" filter during discovery. |
 | SmartShift (legacy) | `0x2110` | Ratchet control on older mice. |
-| HiResScroll | `0x2111` | SmartShift / ratchet and hi-res scroll mode on MX Master 3/3S/4. |
-| HiResWheel | `0x2121` | Read-only: learn the index to decode the wheel ratchet-changed event. |
+| SmartShift Enhanced | `0x2111` | Ratchet / free-spin control on MX Master 3/3S/4 (functions 1/2; function 0 is getCapabilities). |
+| HiResWheel | `0x2121` | Wheel-mode bitfield get/set (hi-res, invert, target) and decoding of the wheel ratchet-changed event. |
 | ThumbWheel | `0x2150` | Volatile divert so thumb-wheel rotation arrives as notifications (horizontal scroll). |
 | ChangeHost | `0x1814` | Easy-Switch: read host count / current, switch host. |
 | HostsInfo | `0x1815` | Read-only: paired host friendly names. |

--- a/overlay/settings_dashboard.py
+++ b/overlay/settings_dashboard.py
@@ -159,7 +159,7 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
         minimal_label.add_css_class("dim-label")
         minimal_box.append(minimal_label)
         minimal_info_btn = Gtk.Button()
-        minimal_info_btn.set_child(Gtk.Image.new_from_icon_name("dialog-information-symbolic"))
+        minimal_info_btn.set_child(Gtk.Label(label="ⓘ"))  # themed info icons render full-color blue on Breeze
         minimal_info_btn.add_css_class("flat")
         minimal_info_btn.add_css_class("dim-label")
         minimal_info_btn.set_tooltip_text(_("Show a minimal radial wheel with icons only - no pizza slices or labels"))
@@ -178,7 +178,7 @@ class SettingsWindow(SidebarMixin, Adw.ApplicationWindow):
         generic_label.add_css_class("dim-label")
         generic_box.append(generic_label)
         generic_info_btn = Gtk.Button()
-        generic_info_btn.set_child(Gtk.Image.new_from_icon_name("dialog-information-symbolic"))
+        generic_info_btn.set_child(Gtk.Label(label="ⓘ"))
         generic_info_btn.add_css_class("flat")
         generic_info_btn.add_css_class("dim-label")
         generic_info_btn.set_tooltip_text(_("Enable for non-Logitech mice. Disables HID++ features like haptics and Easy-Switch."))

--- a/overlay/settings_page_devices.py
+++ b/overlay/settings_page_devices.py
@@ -232,12 +232,25 @@ class DevicesPage(Gtk.ScrolledWindow):
 
         conn_row = SettingRow(_("Connection"), _("How your device is connected"))
         conn_icon_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        if "Bluetooth" in connection_type:
-            conn_icon = Gtk.Image.new_from_icon_name("bluetooth-symbolic")
-        elif "USB" in connection_type:
-            conn_icon = Gtk.Image.new_from_icon_name("usb-symbolic")
+        if "USB" in connection_type:
+            candidates = [
+                "usb-symbolic",
+                "drive-removable-media-usb-symbolic",
+                "drive-removable-media-usb",
+                "media-removable-symbolic",
+                "drive-removable-media-symbolic",
+            ]
+        elif "Bluetooth" in connection_type:
+            candidates = [
+                "bluetooth-symbolic",
+                "bluetooth-active-symbolic",
+                "network-bluetooth-symbolic",
+                "preferences-system-bluetooth-symbolic",
+                "preferences-system-bluetooth",
+            ]
         else:
-            conn_icon = Gtk.Image.new_from_icon_name("network-wireless-symbolic")
+            candidates = ["network-wireless-symbolic", "network-wireless"]
+        conn_icon = Gtk.Image.new_from_icon_name(self._first_available_icon(candidates))
         conn_icon.add_css_class("accent-color")
         conn_icon_box.append(conn_icon)
         conn_label = Gtk.Label(label=connection_type)
@@ -245,6 +258,7 @@ class DevicesPage(Gtk.ScrolledWindow):
         conn_row.set_control(conn_icon_box)
         box.append(conn_row)
 
+        self._conn_battery_label = None
         if not self._is_generic and battery_info is not None:
             sep = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
             sep.set_margin_top(12)
@@ -259,6 +273,8 @@ class DevicesPage(Gtk.ScrolledWindow):
             battery_label = Gtk.Label(label=battery_info)
             battery_label.add_css_class("battery-indicator")
             battery_box.append(battery_label)
+            # Keep a reference so BatteryChanged signals can update this row.
+            self._conn_battery_label = battery_label
             battery_row.set_control(battery_box)
             box.append(battery_row)
 
@@ -282,13 +298,12 @@ class DevicesPage(Gtk.ScrolledWindow):
                     None,
                 )
                 # Connection
-                connection_type = _("USB Receiver")
+                connection_type = self._detect_logitech_connection()
                 try:
                     res = proxy.call_sync(
                         "GetBatteryStatus", None, Gio.DBusCallFlags.NONE, 500, None
                     )
                     if res:
-                        connection_type = _("USB Receiver / Bluetooth")
                         percentage, charging = res.unpack()
                         if percentage > 0:
                             status = _("Charging") if charging else _("Discharging")
@@ -390,11 +405,7 @@ class DevicesPage(Gtk.ScrolledWindow):
             self._live_dot.add_css_class("connected")
 
     def _prime_live(self):
-        """Pull initial values so the readouts are populated before any signal.
-
-        Ratchet/free-spin has no pull getter, so it stays '--' until a
-        RatchetChanged signal arrives.
-        """
+        """Pull initial values so the readouts are populated before any signal."""
         try:
             bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
             proxy = Gio.DBusProxy.new_sync(
@@ -439,16 +450,44 @@ class DevicesPage(Gtk.ScrolledWindow):
         except GLib.GError:
             # daemon unavailable or method missing; leave this live field empty
             pass
+        try:
+            res = proxy.call_sync(
+                "GetSmartShift", None, Gio.DBusCallFlags.NONE, 500, None
+            )
+            enabled, threshold = res.unpack()
+            self._live_labels["ratchet"].set_label(
+                self._wheel_mode_text(enabled, threshold)
+            )
+            any_value = True
+        except GLib.GError:
+            # daemon unavailable or method missing; leave this live field empty
+            pass
 
         if any_value:
             self._set_live_connected()
         return False
+
+    @staticmethod
+    def _wheel_mode_text(enabled, threshold):
+        """Three-state wheel label from the daemon's (enabled, threshold).
+
+        (True, 1-254) = SmartShift auto-disengage, (True, 0) = free-spin,
+        (False, _) = permanently ratcheted.
+        """
+        if not enabled:
+            return _("RATCHET")
+        if threshold == 0:
+            return _("FREE-SPIN")
+        return _("SMARTSHIFT")
 
     def _set_battery(self, percent, status):
         text = f"{percent}%"
         if status:
             text = f"{text} · {status}"
         self._live_labels["battery"].set_label(text)
+        # Keep the Connected Device card's battery row in sync as well.
+        if getattr(self, "_conn_battery_label", None) is not None:
+            self._conn_battery_label.set_label(text)
 
     def _on_battery_signal(self, _c, _s, _p, _i, _sig, params, _u):
         percent, status = params.unpack()
@@ -497,3 +536,56 @@ class DevicesPage(Gtk.ScrolledWindow):
         except OSError:
             pass  # HID sysfs scan can fail on some systems
         return _("USB")
+
+    @staticmethod
+    def _first_available_icon(candidates):
+        """Return the first icon name the current theme can render.
+
+        Avoids the red broken-image glyph when a theme (e.g. Breeze) lacks a
+        given symbolic name.
+        """
+        display = Gdk.Display.get_default()
+        if display is not None:
+            theme = Gtk.IconTheme.get_for_display(display)
+            for name in candidates:
+                if theme.has_icon(name):
+                    return name
+        return "input-mouse-symbolic"
+
+    def _detect_logitech_connection(self):
+        """Detect how the Logitech mouse is actually connected.
+
+        Scans /sys/bus/hid/devices/ for Logitech (046D) entries: bus type
+        0005 = Bluetooth, 0003 = a USB receiver (Bolt C548, Unifying C52B/C534).
+        Falls back to plain 'USB Receiver' when the scan is inconclusive.
+        """
+        bluetooth = False
+        receiver = None
+        try:
+            from pathlib import Path as _Path
+
+            hid_path = _Path("/sys/bus/hid/devices/")
+            if hid_path.exists():
+                for device in hid_path.iterdir():
+                    # HID device names: BBBB:VVVV:PPPP.NNNN
+                    name = device.name.upper()
+                    if ":046D:" not in name:
+                        continue
+                    if name.startswith("0005:"):
+                        bluetooth = True
+                    elif name.startswith("0003:"):
+                        pid = name.split(".")[0].rsplit(":", 1)[-1]
+                        if pid == "C548":
+                            receiver = _("USB Receiver (Bolt)")
+                        elif pid in ("C52B", "C534"):
+                            receiver = _("USB Receiver (Unifying)")
+                        elif receiver is None:
+                            receiver = _("USB Receiver")
+        except OSError:
+            pass  # HID sysfs scan can fail on some systems
+
+        if receiver and bluetooth:
+            return _("{receiver} + Bluetooth").format(receiver=receiver)
+        if bluetooth:
+            return _("Bluetooth")
+        return receiver or _("USB Receiver")

--- a/overlay/settings_page_scroll.py
+++ b/overlay/settings_page_scroll.py
@@ -425,7 +425,15 @@ class ScrollPage(Gtk.ScrolledWindow):
         scroll_speed_scale.set_draw_value(False)
         scroll_speed_scale.connect("value-changed", self._on_scroll_speed_changed)
         disable_scroll_on_scale(scroll_speed_scale)
-        scroll_speed_row.set_control(scroll_speed_scale)
+        speed_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        speed_box.append(scroll_speed_scale)
+        self._scroll_speed_label = Gtk.Label()
+        self._scroll_speed_label.add_css_class("dim-label")
+        self._scroll_speed_label.set_size_request(70, -1)
+        self._scroll_speed_label.set_xalign(0.0)
+        self._update_scroll_speed_label(int(scroll_speed_scale.get_value()))
+        speed_box.append(self._scroll_speed_label)
+        scroll_speed_row.set_control(speed_box)
         scroll_card.append(scroll_speed_row)
 
         # Direction
@@ -659,7 +667,16 @@ class ScrollPage(Gtk.ScrolledWindow):
     def _on_scroll_speed_changed(self, scale):
         value = int(scale.get_value())
         config.set("scroll", "speed", value)
+        self._update_scroll_speed_label(value)
         self._apply_scroll_speed(value)
+
+    def _update_scroll_speed_label(self, value):
+        # The slider drives a desktop scroll factor (see _apply_scroll_speed);
+        # most desktops scroll 3 lines per notch at factor 1.0, so surface the
+        # effective line count instead of the raw slider position.
+        lines = 3 * (0.5 + (value - 1) * 0.167)
+        text = f"{lines:.1f}".rstrip("0").rstrip(".")
+        self._scroll_speed_label.set_text(_("≈ {n} lines").format(n=text))
 
     def _apply_scroll_speed(self, lines):
         """Apply scroll speed multiplier - works on GNOME, KDE, Hyprland, etc."""
@@ -985,6 +1002,16 @@ None,      Down, Button5, {lines}
     def _on_startup_session_bus_ready(self, _source, async_result, _user_data):
         try:
             bus = Gio.bus_get_finish(async_result)
+            if not getattr(self, "_ratchet_sub_id", None):
+                # Follow the hardware wheel-mode button: re-read device state on
+                # RatchetChanged. Empty sender so a daemon restart does not
+                # silence us (see CLAUDE.md).
+                self._ratchet_sub_id = bus.signal_subscribe(
+                    None, "org.kde.juhradialmx.Daemon", "RatchetChanged",
+                    "/org/kde/juhradialmx/Daemon", None, Gio.DBusSignalFlags.NONE,
+                    self._on_ratchet_changed_signal, None,
+                )
+                self._ratchet_bus = bus
             Gio.DBusProxy.new(
                 bus,
                 Gio.DBusProxyFlags.NONE,
@@ -1054,6 +1081,12 @@ None,      Down, Button5, {lines}
         except GLib.Error as e:
             logger.error("D-Bus error starting SmartShift read: %s", e.message)
             self._apply_saved_scroll_mode()
+
+    def _on_ratchet_changed_signal(self, *_args):
+        # Hardware wheel-mode button pressed: re-read device state through the
+        # guarded startup path so local edits win and nothing echoes back to
+        # the device.
+        self._load_device_settings()
 
     def _on_smartshift_loaded(self, proxy, async_result, _user_data):
         try:


### PR DESCRIPTION
On the MX Master 3/3S/4 the daemon spoke the legacy SmartShift dialect (0x2110 function IDs) to the SmartShift Enhanced feature (0x2111), so reads returned a constant parsed out of a capabilities reply and writes landed on a getter and did nothing. Hi-res scroll get/set were additionally addressed to the SmartShift feature index instead of HiRes Wheel (0x2121), which made every smooth/natural-scroll toggle silently rewrite the ratchet mode.

Fixing the writes exposed two defects the no-op had been masking: the D-Bus layer mapped enabled=true to wheelMode 1 (free-spin), and the per-app profile path used a second, contradictory threshold encoding. Both paths now share one mapping in HapticManager.

The settings wave primes the Devices page wheel readout, adds a three-state label (SmartShift vs permanent ratchet vs free-spin), keeps the Connected Device battery row live, follows the hardware wheel-mode button on the Point-and-scroll page, replaces the guessed connection text with a sysfs-based readout (Bolt/Unifying/Bluetooth) using icon names Breeze can render, and labels the scroll speed slider with its effective lines-per-notch.

Verified on an MX Master 4 over a Bolt receiver: thresholds round-trip, all three wheel modes stick on the device, hi-res toggles no longer disturb ratchet state, torque is preserved (the 0x2111 third write byte is sent as 0 = no change). 313 daemon tests pass, clippy clean.

Reported with exemplary hardware traces by @FoxQwartz.

Fixes #106, fixes #107, fixes #108.