### PR TITLE
feat(overlay): pick installed app + auto-import icon for radial slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to JuhRadial MX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Pick an installed application for a radial slice** - The slice dialog in Settings has a "Pick Application…" button (for `exec` slices) that lists installed applications the same way your desktop menu would, instead of typing a raw command by hand. Picking one fills the command and imports the app's real icon (cached under `~/.config/juhradial/icons/`), replacing the generic glyph on the wheel. Submenu rows (Quick Links) got the same treatment: each of the four rows can now point at an app instead of a URL, via a per-row "App…" picker with a "Clear" button to switch back to a link.
+
 ## [0.4.4] - 2026-08-18
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,6 +209,9 @@ The 8-way ring is defined under `radial_menu.slices`. Each slice is an object:
 | `color` | A theme color name (`green`, `yellow`, `red`, `blue`, `mauve`, `pink`, `sapphire`, `teal`, and so on) |
 | `icon` | A freedesktop symbolic icon name, an emoji, or a path to `.png` / `.svg` / `.ico` |
 
+!!! tip
+    The Settings app's slice editor has a **Pick Application…** button (for `exec` slices) that lists installed applications the same way your desktop menu would. Picking one fills `command` with its launch command and `icon` with a path to a cached copy of its real icon, under `~/.config/juhradial/icons/`.
+
 Slice `type` values:
 
 | Type | Behaviour |
@@ -223,6 +226,26 @@ Slice `type` values:
 !!! tip
     On first run the slice commands are auto-filled for your desktop environment. For example, the Screenshot slice becomes `spectacle` on KDE, `gnome-screenshot --interactive` on GNOME, `cosmic-screenshot` on COSMIC, and `flameshot gui` on generic desktops. Set `desktop_environment` to pin a specific mapping.
 
+### Submenus
+
+A `submenu`-type slice carries up to four entries under `submenu`, each either a link or an app:
+
+```json
+"submenu": [
+  { "label": "Docs", "url": "https://docs.example.com" },
+  { "label": "Files", "type": "exec", "command": "dolphin", "icon": "/home/user/.config/juhradial/icons/org.kde.dolphin.desktop.png" }
+]
+```
+
+| Entry field | Meaning |
+| --- | --- |
+| `label` | Text shown for the submenu item |
+| `url` | For link entries: opened in the default browser |
+| `type` | Set to `exec` for an app entry (omit for a link entry) |
+| `command` | For `exec` entries: the launch command |
+| `icon` | For `exec` entries: a path to the app's cached icon |
+
+The Settings app's submenu editor has an **App…** button per row for picking an installed application, filling `command`/`icon` the same way the slice-level app picker does; a **Clear** button switches the row back to a plain link. Leaving all four rows empty falls back to the default AI-assistant links.
 
 ### Easy-switch
 

--- a/overlay/overlay_actions.py
+++ b/overlay/overlay_actions.py
@@ -136,7 +136,9 @@ def _link_icon_for_url(url):
 def submenu_from_config(items):
     """Build a submenu from configured quick links, or None if unusable.
 
-    ``items`` is the slice's ``submenu`` config list of {label, url} dicts.
+    ``items`` is the slice's ``submenu`` config list of dicts, each either
+    a link (``{label, url}``) or an app (``{label, type: "exec", command,
+    icon}``, "icon" holding an absolute path to a user-imported app icon).
     Invalid entries are skipped; an empty result returns None so the caller
     falls back to the default AI links.
     """
@@ -149,8 +151,18 @@ def submenu_from_config(items):
         if not isinstance(item, dict):
             continue
         label = str(item.get("label", "")).strip()
+        if not label:
+            continue
+        if item.get("type") == "exec":
+            command = str(item.get("command", "")).strip()
+            if not command:
+                continue
+            icon_path = str(item.get("icon", ""))
+            icon = icon_path if load_user_icon(icon_path) else "browser"
+            submenu.append((label, "exec", command, icon))
+            continue
         url = str(item.get("url", "")).strip()
-        if not label or not url.startswith(("http://", "https://")):
+        if not url.startswith(("http://", "https://")):
             continue
         submenu.append((label, "url", url, _link_icon_for_url(url)))
     return submenu or None
@@ -299,8 +311,12 @@ def load_actions_from_config():
                 color = slice_data.get("color", "teal")
                 gtk_icon = slice_data.get("icon", "application-x-executable-symbolic")
 
-                # Map GTK icon name to internal icon ID
-                icon = ICON_NAME_MAP.get(gtk_icon, "settings")
+                # A user-imported app icon is stored as an absolute file path;
+                # anything else is a symbolic icon name mapped to an internal ID.
+                if load_user_icon(gtk_icon):
+                    icon = gtk_icon
+                else:
+                    icon = ICON_NAME_MAP.get(gtk_icon, "settings")
 
                 # Handle submenu type: configured quick links win, with the
                 # default AI links as fallback for older configs.
@@ -338,6 +354,7 @@ def load_actions_from_config():
 
 AI_ICONS = {}
 OS_ICONS = {}
+USER_ICONS = {}
 
 
 def _get_assets_dir():
@@ -363,6 +380,30 @@ def _svg_to_pixmap(path, size=64):
     renderer.render(p)
     p.end()
     return QPixmap.fromImage(img)
+
+
+def load_user_icon(path):
+    """Load a user-imported app icon (absolute .svg/.png/... path) into
+    USER_ICONS, keyed by its own path. Returns True if the icon is cached
+    (already loaded or loaded now), False if it can't be read/rendered."""
+    if path in USER_ICONS:
+        return True
+    if not path or not os.path.isabs(path) or not os.path.exists(path):
+        return False
+    if path.lower().endswith(".svg"):
+        pixmap = _svg_to_pixmap(path)
+    else:
+        pixmap = QPixmap(path)
+        if pixmap.isNull():
+            pixmap = None
+        else:
+            pixmap = pixmap.scaled(
+                64, 64, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation
+            )
+    if not pixmap:
+        return False
+    USER_ICONS[path] = pixmap
+    return True
 
 
 def load_ai_icons():

--- a/overlay/overlay_actions.py
+++ b/overlay/overlay_actions.py
@@ -158,7 +158,7 @@ def submenu_from_config(items):
             if not command:
                 continue
             icon_path = str(item.get("icon", ""))
-            icon = icon_path if load_user_icon(icon_path) else "browser"
+            icon = icon_path if _is_user_icon_path(icon_path) else "browser"
             submenu.append((label, "exec", command, icon))
             continue
         url = str(item.get("url", "")).strip()
@@ -313,7 +313,11 @@ def load_actions_from_config():
 
                 # A user-imported app icon is stored as an absolute file path;
                 # anything else is a symbolic icon name mapped to an internal ID.
-                if load_user_icon(gtk_icon):
+                # The actual pixmap is rendered lazily at paint time (see
+                # overlay_painting._draw_action_icon) - this runs at import
+                # time, before QApplication exists, and QPixmap/QSvgRenderer
+                # abort the process if constructed that early.
+                if _is_user_icon_path(gtk_icon):
                     icon = gtk_icon
                 else:
                     icon = ICON_NAME_MAP.get(gtk_icon, "settings")
@@ -382,13 +386,23 @@ def _svg_to_pixmap(path, size=64):
     return QPixmap.fromImage(img)
 
 
+def _is_user_icon_path(path):
+    """Plain filesystem check - safe to call at import time, unlike
+    load_user_icon() which constructs Qt objects (see its docstring)."""
+    return bool(path) and os.path.isabs(path) and os.path.exists(path)
+
+
 def load_user_icon(path):
     """Load a user-imported app icon (absolute .svg/.png/... path) into
     USER_ICONS, keyed by its own path. Returns True if the icon is cached
-    (already loaded or loaded now), False if it can't be read/rendered."""
+    (already loaded or loaded now), False if it can't be read/rendered.
+
+    Constructs QPixmap/QSvgRenderer, which abort the process if called
+    before a QApplication exists - only call this after one is constructed
+    (e.g. lazily at paint time), never from load_actions_from_config()."""
     if path in USER_ICONS:
         return True
-    if not path or not os.path.isabs(path) or not os.path.exists(path):
+    if not _is_user_icon_path(path):
         return False
     if path.lower().endswith(".svg"):
         pixmap = _svg_to_pixmap(path)

--- a/overlay/overlay_painting.py
+++ b/overlay/overlay_painting.py
@@ -426,7 +426,7 @@ class RadialMenuPaintingMixin:
         p.save()
         p.translate(icon_x, icon_y)
         p.scale(hover_bold, hover_bold)
-        self._draw_icon(p, 0, 0, action[4], icon_size, icon_color)
+        self._draw_action_icon(p, 0, 0, action[4], icon_size, icon_color)
         p.restore()
 
     def _draw_slice(self, p, cx, cy, index):
@@ -523,7 +523,7 @@ class RadialMenuPaintingMixin:
             int(ct1.green() + (ct2.green() - ct1.green()) * h),
             int(ct1.blue() + (ct2.blue() - ct1.blue()) * h),
         )
-        self._draw_icon(p, icon_x, icon_y, action[4], icon_radius * 0.65, icon_color)
+        self._draw_action_icon(p, icon_x, icon_y, action[4], icon_radius * 0.65, icon_color)
 
     def _draw_minimal_icon(self, p, cx, cy, index):
         """Draw a floating icon without slice background (vector minimal mode)."""
@@ -566,7 +566,24 @@ class RadialMenuPaintingMixin:
             int(ct1.green() + (ct2.green() - ct1.green()) * h),
             int(ct1.blue() + (ct2.blue() - ct1.blue()) * h),
         )
-        self._draw_icon(p, icon_x, icon_y, action[4], icon_radius * 0.65, icon_color)
+        self._draw_action_icon(p, icon_x, icon_y, action[4], icon_radius * 0.65, icon_color)
+
+    def _draw_action_icon(self, p, cx, cy, icon_id, size, color):
+        """Draw a pre-rendered pixmap for icon_id if one is cached, else fall
+        back to the hand-drawn vector glyph. icon_id is either an internal
+        glyph name (e.g. "play_pause") or an absolute path to a user-imported
+        app icon (see overlay_actions.USER_ICONS)."""
+        all_icons = {
+            **overlay_actions.AI_ICONS,
+            **overlay_actions.OS_ICONS,
+            **overlay_actions.USER_ICONS,
+        }
+        if icon_id in all_icons:
+            icon_size = size * 1.4
+            icon_rect = QRectF(cx - icon_size / 2, cy - icon_size / 2, icon_size, icon_size)
+            p.drawPixmap(icon_rect.toRect(), all_icons[icon_id])
+            return
+        self._draw_icon(p, cx, cy, icon_id, size, color)
 
     def _draw_icon(self, p, cx, cy, icon_type, size, color):
         # Thicker strokes for better visibility
@@ -1144,8 +1161,12 @@ class RadialMenuPaintingMixin:
             p.drawEllipse(QPointF(item_x, item_y), scaled_radius, scaled_radius)
 
             # Icon - use pre-rendered pixmap if available, fallback to drawn icon
-            icon_name = item[3]  # e.g., "claude", "chatgpt", "os_linux", etc.
-            all_icons = {**overlay_actions.AI_ICONS, **overlay_actions.OS_ICONS}
+            icon_name = item[3]  # e.g., "claude", "chatgpt", "os_linux", or an absolute icon path
+            all_icons = {
+                **overlay_actions.AI_ICONS,
+                **overlay_actions.OS_ICONS,
+                **overlay_actions.USER_ICONS,
+            }
             if icon_name in all_icons:
                 icon_size = scaled_radius * 1.4
                 icon_rect = QRectF(

--- a/overlay/overlay_painting.py
+++ b/overlay/overlay_painting.py
@@ -572,7 +572,12 @@ class RadialMenuPaintingMixin:
         """Draw a pre-rendered pixmap for icon_id if one is cached, else fall
         back to the hand-drawn vector glyph. icon_id is either an internal
         glyph name (e.g. "play_pause") or an absolute path to a user-imported
-        app icon (see overlay_actions.USER_ICONS)."""
+        app icon (see overlay_actions.USER_ICONS).
+
+        User icons are rendered here, on first paint, rather than when the
+        config is loaded: that happens before QApplication exists, and
+        QPixmap/QSvgRenderer abort the process if constructed that early."""
+        overlay_actions.load_user_icon(icon_id)
         all_icons = {
             **overlay_actions.AI_ICONS,
             **overlay_actions.OS_ICONS,
@@ -1162,6 +1167,7 @@ class RadialMenuPaintingMixin:
 
             # Icon - use pre-rendered pixmap if available, fallback to drawn icon
             icon_name = item[3]  # e.g., "claude", "chatgpt", "os_linux", or an absolute icon path
+            overlay_actions.load_user_icon(icon_name)
             all_icons = {
                 **overlay_actions.AI_ICONS,
                 **overlay_actions.OS_ICONS,

--- a/overlay/settings_dialog_app_picker.py
+++ b/overlay/settings_dialog_app_picker.py
@@ -101,6 +101,13 @@ class AppPickerDialog(Adw.Window):
         cancel_btn = Gtk.Button(label=_("Cancel"))
         cancel_btn.connect("clicked", lambda _b: self.close())
         header.pack_start(cancel_btn)
+
+        self.select_btn = Gtk.Button(label=_("Select"))
+        self.select_btn.add_css_class("suggested-action")
+        self.select_btn.set_sensitive(False)
+        self.select_btn.connect("clicked", self._on_select_clicked)
+        header.pack_end(self.select_btn)
+
         main_box.append(header)
 
         content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
@@ -118,10 +125,13 @@ class AppPickerDialog(Adw.Window):
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_vexpand(True)
 
+        self._selected_app = None
+
         self.list_box = Gtk.ListBox()
-        self.list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+        self.list_box.set_selection_mode(Gtk.SelectionMode.SINGLE)
         self.list_box.add_css_class("boxed-list")
         self.list_box.set_filter_func(self._filter_row)
+        self.list_box.connect("row-selected", self._on_row_selected)
         self.list_box.connect("row-activated", self._on_row_activated)
 
         self._populate_apps()
@@ -164,9 +174,19 @@ class AppPickerDialog(Adw.Window):
             return True
         return query in row.get_title().lower()
 
+    def _on_row_selected(self, _list_box, row):
+        self._selected_app = getattr(row, "app_info", None) if row else None
+        self.select_btn.set_sensitive(self._selected_app is not None)
+
     def _on_row_activated(self, _list_box, row):
+        """Double-click / Enter on a row picks it immediately."""
         app_info = getattr(row, "app_info", None)
         if app_info is None:
             return
         self._on_pick(app_info)
+        self.close()
+
+    def _on_select_clicked(self, _button):
+        if self._selected_app is not None:
+            self._on_pick(self._selected_app)
         self.close()

--- a/overlay/settings_dialog_app_picker.py
+++ b/overlay/settings_dialog_app_picker.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+JuhRadial MX - Application Picker
+
+AppPickerDialog lists installed applications (the same set a desktop menu
+would show) so a radial slice or submenu link can launch one directly, and
+resolve_and_cache_icon()/command_for_app() turn the picked Gio.DesktopAppInfo
+into a slice's plain "command"/"icon" fields.
+
+SPDX-License-Identifier: GPL-3.0
+"""
+
+import logging
+import os
+import re
+import shutil
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+gi.require_version("Gdk", "4.0")
+
+from gi.repository import Gtk, Adw, Gio, Gdk
+
+from i18n import _
+from settings_config import ConfigManager
+
+logger = logging.getLogger(__name__)
+
+# Desktop Entry "Exec=" field codes (XDG Desktop Entry spec, section on
+# "Exec key") - stripped since slices launch with no associated file/URL.
+_FIELD_CODE_RE = re.compile(r"%[fFuUdDnNickvm%]")
+
+
+def command_for_app(app_info):
+    """Return a plain shell command for launching app_info."""
+    exec_line = app_info.get_string("Exec") or ""
+    return _FIELD_CODE_RE.sub("", exec_line).strip()
+
+
+def resolve_and_cache_icon(app_info):
+    """Resolve app_info's icon to a real image file and cache a copy under
+    the config dir, returning the cached absolute path. Returns None if the
+    icon can't be resolved to a file - callers should keep whatever icon
+    text was already in place."""
+    gicon = app_info.get_icon()
+    if gicon is None:
+        return None
+
+    src_path = None
+    try:
+        if isinstance(gicon, Gio.FileIcon):
+            src_path = gicon.get_file().get_path()
+        else:
+            theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+            paintable = theme.lookup_by_gicon(
+                gicon, 64, 1, Gtk.TextDirection.NONE, Gtk.IconLookupFlags(0)
+            )
+            icon_file = paintable.get_file() if paintable else None
+            src_path = icon_file.get_path() if icon_file else None
+    except Exception:
+        logger.debug("Icon lookup failed for %s", app_info.get_id(), exc_info=True)
+        src_path = None
+
+    if not src_path or not os.path.isfile(src_path):
+        return None
+
+    ext = os.path.splitext(src_path)[1] or ".png"
+    app_id = app_info.get_id() or app_info.get_display_name() or "app"
+    safe_id = "".join(c if c.isalnum() or c in "-_." else "_" for c in app_id)
+    dest_dir = ConfigManager.CONFIG_DIR / "icons"
+    dest_path = dest_dir / f"{safe_id}{ext}"
+
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src_path, dest_path)
+    except OSError:
+        logger.debug("Failed to cache icon for %s", app_id, exc_info=True)
+        return None
+
+    return str(dest_path)
+
+
+class AppPickerDialog(Adw.Window):
+    """Dialog listing installed applications, like a desktop menu's app list."""
+
+    def __init__(self, parent, on_pick):
+        super().__init__()
+        self.set_transient_for(parent)
+        self.set_modal(True)
+        self.set_title(_("Choose Application"))
+        self.set_default_size(420, 520)
+        self._on_pick = on_pick
+
+        main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+
+        header = Adw.HeaderBar()
+        header.set_show_end_title_buttons(True)
+        header.set_show_start_title_buttons(False)
+        cancel_btn = Gtk.Button(label=_("Cancel"))
+        cancel_btn.connect("clicked", lambda _b: self.close())
+        header.pack_start(cancel_btn)
+        main_box.append(header)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        content.set_margin_top(12)
+        content.set_margin_bottom(12)
+        content.set_margin_start(12)
+        content.set_margin_end(12)
+
+        self.search = Gtk.SearchEntry()
+        self.search.set_placeholder_text(_("Search applications…"))
+        self.search.connect("search-changed", lambda _e: self.list_box.invalidate_filter())
+        content.append(self.search)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_vexpand(True)
+
+        self.list_box = Gtk.ListBox()
+        self.list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+        self.list_box.add_css_class("boxed-list")
+        self.list_box.set_filter_func(self._filter_row)
+        self.list_box.connect("row-activated", self._on_row_activated)
+
+        self._populate_apps()
+
+        scrolled.set_child(self.list_box)
+        content.append(scrolled)
+
+        main_box.append(content)
+        self.set_content(main_box)
+
+    def _populate_apps(self):
+        apps = [a for a in Gio.AppInfo.get_all() if a.should_show()]
+        apps.sort(key=lambda a: (a.get_display_name() or a.get_name() or "").lower())
+
+        seen_ids = set()
+        for app in apps:
+            app_id = app.get_id()
+            if app_id in seen_ids:
+                continue
+            seen_ids.add(app_id)
+
+            row = Adw.ActionRow()
+            row.set_title(app.get_display_name() or app.get_name() or app_id)
+            row.app_info = app
+
+            gicon = app.get_icon()
+            img = (
+                Gtk.Image.new_from_gicon(gicon)
+                if gicon
+                else Gtk.Image.new_from_icon_name("application-x-executable")
+            )
+            img.set_pixel_size(28)
+            row.add_prefix(img)
+
+            self.list_box.append(row)
+
+    def _filter_row(self, row):
+        query = self.search.get_text().strip().lower()
+        if not query:
+            return True
+        return query in row.get_title().lower()
+
+    def _on_row_activated(self, _list_box, row):
+        app_info = getattr(row, "app_info", None)
+        if app_info is None:
+            return
+        self._on_pick(app_info)
+        self.close()

--- a/overlay/settings_dialog_radial.py
+++ b/overlay/settings_dialog_radial.py
@@ -8,6 +8,7 @@ SPDX-License-Identifier: GPL-3.0
 """
 
 import logging
+import types
 
 import gi
 
@@ -24,6 +25,7 @@ from settings_constants import (
     DE_COMMAND_MAP,
     get_de_key,
 )
+from settings_dialog_app_picker import AppPickerDialog, resolve_and_cache_icon, command_for_app
 
 logger = logging.getLogger(__name__)
 
@@ -401,10 +403,18 @@ class SliceConfigDialog(Adw.Window):
         self.cmd_title.add_css_class("dim-label")
         cmd_box.append(self.cmd_title)
 
+        cmd_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         self.command_entry = Gtk.Entry()
         self.command_entry.set_text(self.slice_data.get("command", ""))
         self.command_entry.set_placeholder_text(_("e.g., playerctl play-pause"))
-        cmd_box.append(self.command_entry)
+        self.command_entry.set_hexpand(True)
+        cmd_row.append(self.command_entry)
+
+        self.pick_app_btn = Gtk.Button(label=_("Pick Application…"))
+        self.pick_app_btn.connect("clicked", self._on_pick_app_clicked)
+        cmd_row.append(self.pick_app_btn)
+
+        cmd_box.append(cmd_row)
         self.cmd_box = cmd_box
         content.append(cmd_box)
 
@@ -418,7 +428,7 @@ class SliceConfigDialog(Adw.Window):
         links_box.append(links_title)
 
         links_hint = Gtk.Label(
-            label=_("Up to four links to show in this submenu. Leave all rows empty to use the default AI assistant links.")
+            label=_("Up to four links or apps to show in this submenu. Leave all rows empty to use the default AI assistant links.")
         )
         links_hint.set_halign(Gtk.Align.START)
         links_hint.set_wrap(True)
@@ -434,30 +444,59 @@ class SliceConfigDialog(Adw.Window):
         configured = self.slice_data.get("submenu") or []
         self.link_rows = []
         for i in range(4):
+            row_label, row_url = "", ""
+            row_kind, row_command, row_icon = "url", "", ""
             if i < len(configured) and isinstance(configured[i], dict):
-                row_label = configured[i].get("label", "")
-                row_url = configured[i].get("url", "")
+                entry = configured[i]
+                row_label = entry.get("label", "")
+                if entry.get("type") == "exec":
+                    row_kind = "app"
+                    row_command = entry.get("command", "")
+                    row_icon = entry.get("icon", "")
+                else:
+                    row_url = entry.get("url", "")
             elif not configured:
                 row_label, row_url = default_links[i]
-            else:
-                row_label, row_url = "", ""
 
-            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
             label_entry = Gtk.Entry()
             label_entry.set_text(row_label)
             label_entry.set_placeholder_text(_("Label"))
             label_entry.set_hexpand(False)
             label_entry.set_width_chars(12)
-            row.append(label_entry)
+            row_box.append(label_entry)
 
             url_entry = Gtk.Entry()
-            url_entry.set_text(row_url)
             url_entry.set_placeholder_text(_("https://..."))
             url_entry.set_hexpand(True)
-            row.append(url_entry)
+            row_box.append(url_entry)
 
-            links_box.append(row)
-            self.link_rows.append((label_entry, url_entry))
+            row = types.SimpleNamespace(
+                label_entry=label_entry,
+                url_entry=url_entry,
+                kind=row_kind,
+                app_command=row_command,
+                app_icon=row_icon,
+            )
+
+            pick_app_btn = Gtk.Button(label=_("App…"))
+            pick_app_btn.connect("clicked", lambda _b, r=row: self._on_pick_link_app(r))
+            row_box.append(pick_app_btn)
+
+            clear_btn = Gtk.Button(icon_name="edit-clear-symbolic")
+            clear_btn.set_tooltip_text(_("Clear app, use as link instead"))
+            clear_btn.connect("clicked", lambda _b, r=row: self._on_clear_link_app(r))
+            row_box.append(clear_btn)
+            row.clear_btn = clear_btn
+
+            if row_kind == "app":
+                self._show_link_app(row, row_label)
+            else:
+                url_entry.set_text(row_url)
+                clear_btn.set_visible(False)
+
+            links_box.append(row_box)
+            self.link_rows.append(row)
 
         self.links_box = links_box
         content.append(links_box)
@@ -545,6 +584,7 @@ class SliceConfigDialog(Adw.Window):
         needs_command = type_id in ("exec", "url")
         self.cmd_box.set_visible(needs_command)
         self.links_box.set_visible(type_id == "submenu")
+        self.pick_app_btn.set_visible(type_id == "exec")
 
         if type_id == "url":
             self.cmd_title.set_text(_("URL"))
@@ -552,6 +592,45 @@ class SliceConfigDialog(Adw.Window):
         else:
             self.cmd_title.set_text(_("Command"))
             self.command_entry.set_placeholder_text(_("e.g., playerctl play-pause"))
+
+    def _on_pick_app_clicked(self, _button):
+        AppPickerDialog(self, on_pick=self._on_app_picked).present()
+
+    def _on_app_picked(self, app_info):
+        """Fill command/label/icon from a picked application."""
+        self.command_entry.set_text(command_for_app(app_info))
+        if not self.label_entry.get_text().strip():
+            name = app_info.get_display_name() or app_info.get_name() or ""
+            self.label_entry.set_text(name)
+        icon_path = resolve_and_cache_icon(app_info)
+        if icon_path:
+            self.icon_entry.set_text(icon_path)
+
+    def _show_link_app(self, row, label):
+        """Render a submenu row as pointing at an app: read-only display text."""
+        row.url_entry.set_text(_("App: {}").format(label) if label else _("App"))
+        row.url_entry.set_editable(False)
+        row.clear_btn.set_visible(True)
+
+    def _on_pick_link_app(self, row):
+        def on_pick(app_info):
+            row.kind = "app"
+            row.app_command = command_for_app(app_info)
+            row.app_icon = resolve_and_cache_icon(app_info) or ""
+            name = app_info.get_display_name() or app_info.get_name() or ""
+            if not row.label_entry.get_text().strip():
+                row.label_entry.set_text(name)
+            self._show_link_app(row, row.label_entry.get_text().strip() or name)
+
+        AppPickerDialog(self, on_pick=on_pick).present()
+
+    def _on_clear_link_app(self, row):
+        row.kind = "url"
+        row.app_command = ""
+        row.app_icon = ""
+        row.url_entry.set_text("")
+        row.url_entry.set_editable(True)
+        row.clear_btn.set_visible(False)
 
     def _on_color_selected(self, color, button):
         """Handle color selection - ensure exactly one is selected"""
@@ -593,9 +672,18 @@ class SliceConfigDialog(Adw.Window):
         }
         if type_id == "submenu":
             links = []
-            for label_entry, url_entry in self.link_rows:
-                link_label = label_entry.get_text().strip()
-                link_url = url_entry.get_text().strip()
+            for row in self.link_rows:
+                link_label = row.label_entry.get_text().strip()
+                if row.kind == "app":
+                    if link_label and row.app_command:
+                        links.append({
+                            "label": link_label,
+                            "type": "exec",
+                            "command": row.app_command,
+                            "icon": row.app_icon,
+                        })
+                    continue
+                link_url = row.url_entry.get_text().strip()
                 if not link_label and not link_url:
                     continue
                 if link_url and not link_url.startswith(("http://", "https://")):

--- a/overlay/settings_dialog_radial.py
+++ b/overlay/settings_dialog_radial.py
@@ -188,7 +188,7 @@ class SliceConfigDialog(Adw.Window):
     def __init__(self, parent, slice_index, config_manager, on_save_callback=None):
         super().__init__()
         self.ACTION_TYPES = [
-            ("exec", _("Run Command"), _("Execute a shell command")),
+            ("exec", _("Run Command / App"), _("Execute a shell command, or pick an installed application")),
             ("url", _("Open URL"), _("Open a web address")),
             ("settings", _("Open Settings"), _("Open JuhRadial settings")),
             ("emoji", _("Emoji Picker"), _("Show emoji picker")),

--- a/tests/test_app_icon_picker.py
+++ b/tests/test_app_icon_picker.py
@@ -5,8 +5,11 @@ that launch an app instead of a URL.
 Run: python3 -m pytest tests/test_app_icon_picker.py -q
 """
 
+import json
 import os
+import subprocess
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -100,6 +103,11 @@ def test_submenu_app_entry_round_trips(tmp_path):
         ("Files", "exec", "dolphin", str(icon_path)),
         ("Docs", "url", "https://docs.example.com", "browser"),
     ]
+    # The pixmap isn't rendered here - only a plain filesystem check runs at
+    # config-load time, since this path also runs at import time (before
+    # QApplication exists) and QPixmap/QSvgRenderer would abort the process.
+    assert str(icon_path) not in USER_ICONS
+    assert load_user_icon(str(icon_path)) is True
     assert str(icon_path) in USER_ICONS
 
 
@@ -112,3 +120,48 @@ def test_submenu_app_entry_with_unresolvable_icon_falls_back_to_browser():
     links = [{"label": "Files", "type": "exec", "command": "dolphin", "icon": "/no/such/icon.svg"}]
     result = submenu_from_config(links)
     assert result == [("Files", "exec", "dolphin", "browser")]
+
+
+def test_loading_config_with_app_icon_does_not_touch_qt_before_app_exists(tmp_path):
+    """Regression test: overlay_actions.ACTIONS is built by
+    load_actions_from_config() at *import* time (juhradial-overlay.py
+    imports overlay_actions before constructing QApplication). If that path
+    ever constructs a QPixmap/QSvgRenderer directly, Qt aborts the whole
+    process - this bit us in production for a slice with an imported app
+    icon. Runs in a fresh subprocess with no QApplication ever created."""
+    icon_path = tmp_path / "app-icon.svg"
+    icon_path.write_text(SVG_STUB, encoding="utf-8")
+
+    fake_home = tmp_path / "home"
+    config_dir = fake_home / ".config" / "juhradial"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "radial_menu": {
+                    "slices": [
+                        {
+                            "label": "App",
+                            "type": "exec",
+                            "command": "some-app",
+                            "color": "green",
+                            "icon": str(icon_path),
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    overlay_dir = Path(__file__).resolve().parents[1] / "overlay"
+    env = {**os.environ, "HOME": str(fake_home)}
+    result = subprocess.run(
+        [sys.executable, "-c", "import overlay_actions"],
+        cwd=str(overlay_dir),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_app_icon_picker.py
+++ b/tests/test_app_icon_picker.py
@@ -1,0 +1,114 @@
+"""App-picker icon import: resolving/caching a picked app's icon, loading
+arbitrary icon-file paths into the overlay's pixmap cache, and submenu rows
+that launch an app instead of a URL.
+
+Run: python3 -m pytest tests/test_app_icon_picker.py -q
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, "overlay")
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Gio
+
+from PyQt6.QtGui import QGuiApplication
+
+# QPixmap/QSvgRenderer need a live QGuiApplication (offscreen platform, set
+# above) even outside a real display session.
+_qt_app = QGuiApplication.instance() or QGuiApplication([])
+
+from overlay_actions import USER_ICONS, load_user_icon, submenu_from_config
+from settings_dialog_app_picker import command_for_app, resolve_and_cache_icon
+
+
+SVG_STUB = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">'
+    '<rect width="16" height="16"/></svg>'
+)
+
+
+def test_command_for_app_strips_field_codes():
+    app = SimpleNamespace(get_string=lambda key: "firefox %u")
+    assert command_for_app(app) == "firefox"
+
+    app = SimpleNamespace(get_string=lambda key: "code --new-window %F")
+    assert command_for_app(app) == "code --new-window"
+
+
+def test_resolve_and_cache_icon_from_file_icon(tmp_path, monkeypatch):
+    src = tmp_path / "app.svg"
+    src.write_text(SVG_STUB, encoding="utf-8")
+
+    import settings_config
+
+    monkeypatch.setattr(settings_config.ConfigManager, "CONFIG_DIR", tmp_path / "config")
+
+    app = SimpleNamespace(
+        get_icon=lambda: Gio.FileIcon.new(Gio.File.new_for_path(str(src))),
+        get_id=lambda: "org.example.App.desktop",
+    )
+    cached = resolve_and_cache_icon(app)
+
+    assert cached is not None
+    assert os.path.isfile(cached)
+    assert cached != str(src)  # copied into the cache dir, not the original
+
+
+def test_resolve_and_cache_icon_returns_none_without_icon():
+    app = SimpleNamespace(get_icon=lambda: None, get_id=lambda: "x")
+    assert resolve_and_cache_icon(app) is None
+
+
+def test_load_user_icon_caches_svg(tmp_path):
+    USER_ICONS.clear()
+    path = tmp_path / "imported.svg"
+    path.write_text(SVG_STUB, encoding="utf-8")
+
+    assert load_user_icon(str(path)) is True
+    assert str(path) in USER_ICONS
+
+    # Second call hits the cache without re-reading the file.
+    assert load_user_icon(str(path)) is True
+
+
+def test_load_user_icon_rejects_missing_or_relative_paths(tmp_path):
+    assert load_user_icon("") is False
+    assert load_user_icon("relative/icon.svg") is False
+    assert load_user_icon(str(tmp_path / "missing.svg")) is False
+
+
+def test_submenu_app_entry_round_trips(tmp_path):
+    USER_ICONS.clear()
+    icon_path = tmp_path / "app-icon.svg"
+    icon_path.write_text(SVG_STUB, encoding="utf-8")
+
+    links = [
+        {"label": "Files", "type": "exec", "command": "dolphin", "icon": str(icon_path)},
+        {"label": "Docs", "url": "https://docs.example.com"},
+    ]
+    result = submenu_from_config(links)
+
+    assert result == [
+        ("Files", "exec", "dolphin", str(icon_path)),
+        ("Docs", "url", "https://docs.example.com", "browser"),
+    ]
+    assert str(icon_path) in USER_ICONS
+
+
+def test_submenu_app_entry_without_command_is_skipped():
+    links = [{"label": "Broken", "type": "exec", "command": "", "icon": ""}]
+    assert submenu_from_config(links) is None
+
+
+def test_submenu_app_entry_with_unresolvable_icon_falls_back_to_browser():
+    links = [{"label": "Files", "type": "exec", "command": "dolphin", "icon": "/no/such/icon.svg"}]
+    result = submenu_from_config(links)
+    assert result == [("Files", "exec", "dolphin", "browser")]

--- a/tests/test_app_icon_picker.py
+++ b/tests/test_app_icon_picker.py
@@ -25,8 +25,11 @@ from gi.repository import Gio
 from PyQt6.QtGui import QGuiApplication
 
 # QPixmap/QSvgRenderer need a live QGuiApplication (offscreen platform, set
-# above) even outside a real display session.
+# above) even outside a real display session. Kept referenced via the assert
+# below: an unreferenced instance can be garbage-collected immediately,
+# tearing down the application before any test runs.
 _qt_app = QGuiApplication.instance() or QGuiApplication([])
+assert _qt_app is not None
 
 from overlay_actions import USER_ICONS, load_user_icon, submenu_from_config
 from settings_dialog_app_picker import command_for_app, resolve_and_cache_icon


### PR DESCRIPTION
## Summary
- Slice editor (Actions Ring) gets a "Pick Application…" button for `exec` slices, listing installed apps via `Gio.AppInfo.get_all()` (same set a desktop menu shows) instead of typing a raw command by hand; picking one fills the command and imports the app's real icon, cached under `~/.config/juhradial/icons/`.
- Submenu quick-link rows get the same treatment: an "App…" picker per row plus a "Clear" button to switch back to a plain URL link.
- Fixes a crash found while testing: `overlay_actions.py` builds its action list at import time (before `QApplication` exists), so pixmap rendering for imported icons is now deferred to first paint instead of config-load time.

## Test plan
- [x] `python3 -m pytest tests/` — 105 passed, including a new subprocess-based regression test for the QApplication-ordering crash
- [x] Manually verified on Kubuntu/KDE: pick an app for a slice, save, open the radial menu, icon renders and launches the app
- [x] Manually verified submenu row app-pick + clear-back-to-link flow