### PR TITLE
fix(overlay): trigger haptic feedback on submenu hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Pick an installed application for a radial slice** - The slice dialog in Settings has a "Pick Application…" button (for `exec` slices) that lists installed applications the same way your desktop menu would, instead of typing a raw command by hand. Picking one fills the command and imports the app's real icon (cached under `~/.config/juhradial/icons/`), replacing the generic glyph on the wheel. Submenu rows (Quick Links) got the same treatment: each of the four rows can now point at an app instead of a URL, via a per-row "App…" picker with a "Clear" button to switch back to a link.
 
+### Fixed
+
+- **Haptic feedback works inside submenus** - Hovering between items in an open submenu (Quick Links, AI assistant, the app-picker submenu rows) gave no haptic pulse, only the main Actions Ring did. Submenu hover now triggers the same `slice_change` pulse as the main ring.
+
 ## [0.4.4] - 2026-08-18
 
 ### Fixed

--- a/overlay/juhradial-overlay.py
+++ b/overlay/juhradial-overlay.py
@@ -1387,6 +1387,7 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             if subitem >= 0:
                 if subitem != self.highlighted_subitem:
                     self.highlighted_subitem = subitem
+                    self._trigger_haptic("slice_change")
                     self.update()
                 return
             if new_slice == self.submenu_slice or distance > MENU_RADIUS:
@@ -1480,6 +1481,7 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             if subitem >= 0:
                 if subitem != self.highlighted_subitem:
                     self.highlighted_subitem = subitem
+                    self._trigger_haptic("slice_change")
                     self.update()
                 return
             if new_slice == self.submenu_slice or distance > MENU_RADIUS:

--- a/tests/test_submenu_repaints.py
+++ b/tests/test_submenu_repaints.py
@@ -72,6 +72,7 @@ class _MenuHarness:
         self._anim_timer = _Timer()
         self._subitem_result = subitem_result
         self.update_calls = 0
+        self.haptic_events = []
 
     def _hover_gate(self, *_args):
         return True
@@ -85,8 +86,8 @@ class _MenuHarness:
     def _update_kde_mask(self):
         pass
 
-    def _trigger_haptic(self, _event):
-        pass
+    def _trigger_haptic(self, event):
+        self.haptic_events.append(event)
 
     def update(self):
         self.update_calls += 1
@@ -139,6 +140,38 @@ def test_changing_the_highlighted_subitem_repaints_once():
 
     assert menu.highlighted_subitem == 2
     assert menu.update_calls == 1
+
+
+def test_changing_the_highlighted_subitem_triggers_haptic():
+    menu = _MenuHarness(highlighted_subitem=1, subitem_result=2)
+
+    _radial_menu_method("_poll_cursor")(menu)
+
+    assert menu.haptic_events == ["slice_change"]
+
+
+def test_clearing_the_highlighted_subitem_does_not_trigger_haptic():
+    menu = _MenuHarness(highlighted_subitem=2, subitem_result=-1)
+
+    _radial_menu_method("_poll_cursor")(menu)
+
+    assert menu.haptic_events == []
+
+
+def test_mouse_move_changing_the_highlighted_subitem_triggers_haptic():
+    menu = _MenuHarness(highlighted_subitem=1, subitem_result=2)
+
+    _radial_menu_method("mouseMoveEvent")(menu, _MouseEvent())
+
+    assert menu.haptic_events == ["slice_change"]
+
+
+def test_mouse_move_clearing_the_highlighted_subitem_does_not_trigger_haptic():
+    menu = _MenuHarness(highlighted_subitem=2, subitem_result=-1)
+
+    _radial_menu_method("mouseMoveEvent")(menu, _MouseEvent())
+
+    assert menu.haptic_events == []
 
 
 def test_submenu_animation_keeps_repainting_until_settled():


### PR DESCRIPTION
## Summary
- Haptic pulses fired on the main Actions Ring hover (`slice_change`) but not when hovering between items inside an open submenu (Quick Links, AI assistant, app-picker submenu rows) — only submenu selection/confirm pulsed. Submenu navigation felt dead by comparison.
- Added `self._trigger_haptic("slice_change")` in both submenu hover blocks (`_poll_cursor` and `mouseMoveEvent`), mirroring the existing main-ring pattern exactly — pulses only when entering a new, valid subitem, never on clearing back to none.
- No daemon changes: `TriggerHaptic` already treats the event name as opaque, reuses the existing `slice_change` pattern/debounce config.

## Test plan
- [x] `python3 -m pytest tests/` — 113 passed (4 new tests covering hover-triggers-haptic / clear-does-not, for both `_poll_cursor` and `mouseMoveEvent`)
- [x] Manually verified on Kubuntu/KDE: hovering submenu items now pulses per item like the main ring; leaving the submenu back to the ring still only pulses on re-entering a main slice