### PR TITLE
feat(haptics): pulse on application window switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Pick an installed application for a radial slice** - The slice dialog in Settings has a "Pick Application…" button (for `exec` slices) that lists installed applications the same way your desktop menu would, instead of typing a raw command by hand. Picking one fills the command and imports the app's real icon (cached under `~/.config/juhradial/icons/`), replacing the generic glyph on the wheel. Submenu rows (Quick Links) got the same treatment: each of the four rows can now point at an app instead of a URL, via a per-row "App…" picker with a "Clear" button to switch back to a link.
 
+### Fixed
+
+- **Haptic feedback works inside submenus** - Hovering between items in an open submenu (Quick Links, AI assistant, the app-picker submenu rows) gave no haptic pulse, only the main Actions Ring did. Submenu hover now triggers the same `slice_change` pulse as the main ring.
+
 ## [0.4.4] - 2026-08-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Pick an installed application for a radial slice** - The slice dialog in Settings has a "Pick Application…" button (for `exec` slices) that lists installed applications the same way your desktop menu would, instead of typing a raw command by hand. Picking one fills the command and imports the app's real icon (cached under `~/.config/juhradial/icons/`), replacing the generic glyph on the wheel. Submenu rows (Quick Links) got the same treatment: each of the four rows can now point at an app instead of a URL, via a per-row "App…" picker with a "Clear" button to switch back to a link.
+- **Haptic feedback on application switch** - The MX Master 4 actuator now pulses whenever the focused application window changes (Alt+Tab, taskbar, clicking a different app), independent of the radial menu. On by default, with its own toggle and pattern in Settings → Haptics → App Switch, so it can be turned off separately from the menu's own haptics. Reuses the daemon's existing window tracker (also used for per-application profiles), so it works wherever that already does: KDE, Hyprland, and X11.
 
 ### Fixed
 

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -40,12 +40,17 @@ pub struct HapticEventConfig {
     /// Pattern for invalid/blocked actions (default: angry_alert)
     #[serde(default = "default_invalid")]
     pub invalid: String,
+
+    /// Pattern when the focused application window changes (default: subtle_collision)
+    #[serde(default = "default_window_switch")]
+    pub window_switch: String,
 }
 
 fn default_menu_appear() -> String { "damp_state_change".to_string() }
 fn default_slice_change() -> String { "subtle_collision".to_string() }
 fn default_confirm() -> String { "sharp_state_change".to_string() }
 fn default_invalid() -> String { "angry_alert".to_string() }
+fn default_window_switch() -> String { "subtle_collision".to_string() }
 
 impl Default for HapticEventConfig {
     fn default() -> Self {
@@ -54,6 +59,7 @@ impl Default for HapticEventConfig {
             slice_change: default_slice_change(),
             confirm: default_confirm(),
             invalid: default_invalid(),
+            window_switch: default_window_switch(),
         }
     }
 }
@@ -93,6 +99,11 @@ pub struct HapticConfig {
     /// Prevents duplicate haptic when cursor re-enters the same slice quickly
     #[serde(default = "default_reentry_debounce")]
     pub reentry_debounce_ms: u64,
+
+    /// Enable a haptic pulse when the focused application window changes,
+    /// independent of the radial menu
+    #[serde(default = "default_true")]
+    pub window_switch_enabled: bool,
 }
 
 fn default_true() -> bool { true }
@@ -110,6 +121,7 @@ impl Default for HapticConfig {
             debounce_ms: 20,
             slice_debounce_ms: 20,
             reentry_debounce_ms: 50,
+            window_switch_enabled: true,
         }
     }
 }
@@ -623,6 +635,8 @@ mod tests {
         assert_eq!(haptic.per_event.slice_change, "subtle_collision");
         assert_eq!(haptic.per_event.confirm, "sharp_state_change");
         assert_eq!(haptic.per_event.invalid, "angry_alert");
+        assert_eq!(haptic.per_event.window_switch, "subtle_collision");
+        assert!(haptic.window_switch_enabled);
     }
 
     #[test]

--- a/daemon/src/dbus/interface.rs
+++ b/daemon/src/dbus/interface.rs
@@ -146,6 +146,7 @@ impl JuhRadialService {
             "slice_change" => HapticEvent::SliceChange,
             "confirm" => HapticEvent::SelectionConfirm,
             "invalid" => HapticEvent::InvalidAction,
+            "window_switch" => HapticEvent::WindowSwitch,
             _ => {
                 tracing::warn!(event, "Unknown haptic event type");
                 return Ok(());

--- a/daemon/src/hidpp/manager.rs
+++ b/daemon/src/hidpp/manager.rs
@@ -44,6 +44,9 @@ pub struct HapticManager {
     pub(crate) per_event: PerEventPattern,
     /// Whether haptics are enabled
     enabled: bool,
+    /// Whether the window-switch haptic is enabled (independent of `enabled`,
+    /// which gates all haptics)
+    window_switch_enabled: bool,
     /// Last pulse timestamp for debouncing (milliseconds)
     last_pulse_ms: u64,
     /// Connection state for reconnection logic
@@ -74,6 +77,7 @@ impl HapticManager {
             default_pattern: Mx4HapticPattern::SubtleCollision,
             per_event: PerEventPattern::default(),
             enabled,
+            window_switch_enabled: true,
             last_pulse_ms: 0,
             connection_state: ConnectionState::NotConnected,
             last_disconnect_ms: 0,
@@ -99,8 +103,10 @@ impl HapticManager {
                 slice_change: Mx4HapticPattern::from_name(&config.per_event.slice_change),
                 confirm: Mx4HapticPattern::from_name(&config.per_event.confirm),
                 invalid: Mx4HapticPattern::from_name(&config.per_event.invalid),
+                window_switch: Mx4HapticPattern::from_name(&config.per_event.window_switch),
             },
             enabled: config.enabled,
+            window_switch_enabled: config.window_switch_enabled,
             last_pulse_ms: 0,
             connection_state: ConnectionState::NotConnected,
             last_disconnect_ms: 0,
@@ -122,8 +128,10 @@ impl HapticManager {
             slice_change: Mx4HapticPattern::from_name(&config.per_event.slice_change),
             confirm: Mx4HapticPattern::from_name(&config.per_event.confirm),
             invalid: Mx4HapticPattern::from_name(&config.per_event.invalid),
+            window_switch: Mx4HapticPattern::from_name(&config.per_event.window_switch),
         };
         self.enabled = config.enabled;
+        self.window_switch_enabled = config.window_switch_enabled;
         self.debounce_ms = config.debounce_ms;
         self.slice_debounce_ms = config.slice_debounce_ms;
         self.reentry_debounce_ms = config.reentry_debounce_ms;
@@ -391,6 +399,13 @@ impl HapticManager {
                 Ok(())
             }
         }
+    }
+
+    /// Whether the window-switch haptic is enabled (checked separately from
+    /// `emit()`'s own master `enabled` gate, since callers decide per-event
+    /// whether to emit at all rather than emitting and having it swallowed)
+    pub fn is_window_switch_enabled(&self) -> bool {
+        self.window_switch_enabled
     }
 
     pub fn emit(&mut self, event: HapticEvent) -> Result<(), HapticError> {

--- a/daemon/src/hidpp/patterns.rs
+++ b/daemon/src/hidpp/patterns.rs
@@ -212,6 +212,8 @@ pub enum HapticEvent {
     SelectionConfirm,
     /// User selects an empty or invalid slice
     InvalidAction,
+    /// The focused application window changed (independent of the radial menu)
+    WindowSwitch,
 }
 
 impl HapticEvent {
@@ -222,6 +224,7 @@ impl HapticEvent {
             HapticEvent::SliceChange => haptic_profiles::SLICE_CHANGE,
             HapticEvent::SelectionConfirm => haptic_profiles::CONFIRM,
             HapticEvent::InvalidAction => haptic_profiles::INVALID,
+            HapticEvent::WindowSwitch => haptic_profiles::SLICE_CHANGE,
         }
     }
 
@@ -232,6 +235,7 @@ impl HapticEvent {
             HapticEvent::SliceChange => HapticPattern::Single,
             HapticEvent::SelectionConfirm => HapticPattern::Double,
             HapticEvent::InvalidAction => HapticPattern::Triple,
+            HapticEvent::WindowSwitch => HapticPattern::Single,
         }
     }
 
@@ -260,6 +264,8 @@ impl HapticEvent {
             HapticEvent::SelectionConfirm => Mx4HapticPattern::Completed,
             // Invalid action: error/warning feel
             HapticEvent::InvalidAction => Mx4HapticPattern::AngryAlert,
+            // Window switch: same lightweight tick as slice hover
+            HapticEvent::WindowSwitch => Mx4HapticPattern::SubtleCollision,
         }
     }
 }
@@ -271,6 +277,7 @@ impl fmt::Display for HapticEvent {
             HapticEvent::SliceChange => write!(f, "slice_change"),
             HapticEvent::SelectionConfirm => write!(f, "selection_confirm"),
             HapticEvent::InvalidAction => write!(f, "invalid_action"),
+            HapticEvent::WindowSwitch => write!(f, "window_switch"),
         }
     }
 }
@@ -286,6 +293,8 @@ pub struct PerEventPattern {
     pub confirm: Mx4HapticPattern,
     /// Pattern for invalid action
     pub invalid: Mx4HapticPattern,
+    /// Pattern for a focused-application window switch
+    pub window_switch: Mx4HapticPattern,
 }
 
 impl Default for PerEventPattern {
@@ -295,6 +304,7 @@ impl Default for PerEventPattern {
             slice_change: Mx4HapticPattern::SubtleCollision,
             confirm: Mx4HapticPattern::SharpStateChange,
             invalid: Mx4HapticPattern::AngryAlert,
+            window_switch: Mx4HapticPattern::SubtleCollision,
         }
     }
 }
@@ -307,6 +317,7 @@ impl PerEventPattern {
             HapticEvent::SliceChange => self.slice_change,
             HapticEvent::SelectionConfirm => self.confirm,
             HapticEvent::InvalidAction => self.invalid,
+            HapticEvent::WindowSwitch => self.window_switch,
         }
     }
 }

--- a/daemon/src/hidpp/tests.rs
+++ b/daemon/src/hidpp/tests.rs
@@ -134,6 +134,7 @@ fn test_from_config() {
         debounce_ms: 30,
         slice_debounce_ms: 20,
         reentry_debounce_ms: 50,
+        window_switch_enabled: true,
     };
 
     let manager = HapticManager::from_config(&config);
@@ -152,6 +153,7 @@ fn test_from_config_disabled() {
         debounce_ms: 20,
         slice_debounce_ms: 20,
         reentry_debounce_ms: 50,
+        window_switch_enabled: true,
     };
 
     let manager = HapticManager::from_config(&config);
@@ -172,6 +174,7 @@ fn test_update_from_config() {
         debounce_ms: 25,
         slice_debounce_ms: 20,
         reentry_debounce_ms: 50,
+        window_switch_enabled: true,
     };
 
     manager.update_from_config(&new_config);
@@ -234,6 +237,7 @@ fn test_haptic_event_display() {
         "selection_confirm"
     );
     assert_eq!(format!("{}", HapticEvent::InvalidAction), "invalid_action");
+    assert_eq!(format!("{}", HapticEvent::WindowSwitch), "window_switch");
 }
 
 #[test]
@@ -243,6 +247,7 @@ fn test_per_event_pattern_defaults() {
     assert_eq!(per_event.slice_change, Mx4HapticPattern::SubtleCollision);
     assert_eq!(per_event.confirm, Mx4HapticPattern::SharpStateChange);
     assert_eq!(per_event.invalid, Mx4HapticPattern::AngryAlert);
+    assert_eq!(per_event.window_switch, Mx4HapticPattern::SubtleCollision);
 }
 
 #[test]
@@ -252,6 +257,7 @@ fn test_per_event_pattern_get() {
         slice_change: Mx4HapticPattern::DampStateChange,
         confirm: Mx4HapticPattern::AngryAlert,
         invalid: Mx4HapticPattern::SharpStateChange,
+        window_switch: Mx4HapticPattern::DampStateChange,
     };
 
     assert_eq!(
@@ -269,6 +275,10 @@ fn test_per_event_pattern_get() {
     assert_eq!(
         per_event.get(&HapticEvent::InvalidAction),
         Mx4HapticPattern::SharpStateChange
+    );
+    assert_eq!(
+        per_event.get(&HapticEvent::WindowSwitch),
+        Mx4HapticPattern::DampStateChange
     );
 }
 
@@ -317,10 +327,12 @@ fn test_from_config_with_per_event() {
             slice_change: "sharp_state_change".to_string(),
             confirm: "angry_alert".to_string(),
             invalid: "subtle_collision".to_string(),
+            window_switch: "subtle_collision".to_string(),
         },
         debounce_ms: 25,
         slice_debounce_ms: 20,
         reentry_debounce_ms: 50,
+        window_switch_enabled: true,
     };
 
     let manager = HapticManager::from_config(&config);
@@ -351,10 +363,12 @@ fn test_update_from_config_with_per_event() {
             slice_change: "angry_alert".to_string(),
             confirm: "damp_state_change".to_string(),
             invalid: "subtle_collision".to_string(),
+            window_switch: "subtle_collision".to_string(),
         },
         debounce_ms: 30,
         slice_debounce_ms: 20,
         reentry_debounce_ms: 50,
+        window_switch_enabled: true,
     };
 
     manager.update_from_config(&new_config);
@@ -640,6 +654,7 @@ fn test_from_config_with_slice_debounce() {
         debounce_ms: 20,
         slice_debounce_ms: 25,
         reentry_debounce_ms: 60,
+        window_switch_enabled: true,
     };
 
     let manager = HapticManager::from_config(&config);
@@ -662,6 +677,7 @@ fn test_update_from_config_with_slice_debounce() {
         debounce_ms: 20,
         slice_debounce_ms: 35,
         reentry_debounce_ms: 75,
+        window_switch_enabled: true,
     };
 
     manager.update_from_config(&new_config);

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -18,7 +18,7 @@ use juhradiald::{
     dbus::{DBUS_NAME, DBUS_PATH, claim_name, init_dbus_service_with_device},
     evdev::{EvdevError, EvdevHandler, GestureEvent},
     gaming::new_shared_gaming_mode,
-    hidpp::SharedHapticManager,
+    hidpp::{HapticEvent, SharedHapticManager},
     hidraw::{HidrawError, HidrawHandler},
     macros::{MacroEngine, MacroRecorder, TriggerMap},
     new_shared_haptic_manager,
@@ -582,6 +582,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     continue;
                 }
                 current_class = class.clone();
+
+                // Window-switch haptic fires on every app-class change,
+                // regardless of whether a hardware profile matches below.
+                let mgr_ws = hw_manager.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    if let Ok(mut m) = mgr_ws.lock() {
+                        if m.is_window_switch_enabled() {
+                            let _ = m.emit(HapticEvent::WindowSwitch);
+                        }
+                    }
+                })
+                .await;
+
                 // Lookup is case-insensitive: keys are lowercased at load, so
                 // lowercase the incoming class (window-tracker sources vary).
                 let hw = {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,11 +84,13 @@ systemctl --user restart juhradialmx-daemon.service
     "menu_appear": "damp_state_change",
     "slice_change": "subtle_collision",
     "confirm": "sharp_state_change",
-    "invalid": "angry_alert"
+    "invalid": "angry_alert",
+    "window_switch": "subtle_collision"
   },
   "debounce_ms": 20,
   "slice_debounce_ms": 20,
-  "reentry_debounce_ms": 50
+  "reentry_debounce_ms": 50,
+  "window_switch_enabled": true
 }
 ```
 
@@ -100,9 +102,13 @@ systemctl --user restart juhradialmx-daemon.service
 | `per_event.slice_change` | string | `subtle_collision` | Pulse when hovering a different slice |
 | `per_event.confirm` | string | `sharp_state_change` | Pulse when selecting an action |
 | `per_event.invalid` | string | `angry_alert` | Pulse for a blocked or invalid action |
+| `per_event.window_switch` | string | `subtle_collision` | Pulse when the focused application window changes |
 | `debounce_ms` | int | `20` | Minimum milliseconds between any two pulses |
 | `slice_debounce_ms` | int | `20` | Minimum milliseconds between slice-change pulses |
 | `reentry_debounce_ms` | int | `50` | Window that suppresses a duplicate pulse when the cursor re-enters the same slice |
+| `window_switch_enabled` | bool | `true` | Enable the app-switch pulse independently of the radial menu's own events |
+
+The app-switch pulse fires whenever the daemon's window tracker (used for [per-application profiles](#per-application-profiles-profilesjson)) sees the focused window's class change — it runs whenever window tracking is available (KDE, Hyprland, X11), whether or not any per-app profiles are configured, and is capped at one pulse per distinct app switch, not per window-focus event within the same app.
 
 Pattern names are MX Master 4 HID++ waveform IDs (for example `subtle_collision`, `damp_state_change`, `sharp_state_change`, `angry_alert`). Pick from the patterns offered in the HAPTIC FEEDBACK page of the Settings app.
 

--- a/overlay/juhradial-overlay.py
+++ b/overlay/juhradial-overlay.py
@@ -1387,6 +1387,7 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             if subitem >= 0:
                 if subitem != self.highlighted_subitem:
                     self.highlighted_subitem = subitem
+                    self._trigger_haptic("slice_change")
                     self.update()
                 return
             if new_slice == self.submenu_slice or distance > MENU_RADIUS:
@@ -1480,6 +1481,7 @@ class RadialMenu(RadialMenuPaintingMixin, QWidget):
             if subitem >= 0:
                 if subitem != self.highlighted_subitem:
                     self.highlighted_subitem = subitem
+                    self._trigger_haptic("slice_change")
                     self.update()
                 return
             if new_slice == self.submenu_slice or distance > MENU_RADIUS:

--- a/overlay/settings_page_haptics.py
+++ b/overlay/settings_page_haptics.py
@@ -231,12 +231,25 @@ class HapticsPage(Gtk.ScrolledWindow):
         card = SettingsCard(_("Per-Event Patterns"))
         card.set_hexpand(True)
 
+        window_switch_row = SettingRow(
+            _("App Switch"), _("Pulse when the focused application changes")
+        )
+        window_switch_switch = Gtk.Switch()
+        window_switch_switch.set_valign(Gtk.Align.CENTER)
+        window_switch_switch.set_active(
+            config.get("haptics", "window_switch_enabled", default=True)
+        )
+        window_switch_switch.connect("state-set", self._on_window_switch_toggled)
+        window_switch_row.set_control(window_switch_switch)
+        card.append(window_switch_row)
+
         self.event_dropdowns = {}
         event_settings = [
             ("menu_appear", _("Menu Appear"), _("Pattern when the radial menu opens")),
             ("slice_change", _("Slice Hover"), _("Pattern when hovering ring sectors")),
             ("confirm", _("Selection"), _("Pattern when selecting an action")),
             ("invalid", _("Invalid Action"), _("Pattern for blocked actions")),
+            ("window_switch", _("App Switch Pattern"), _("Pattern when the focused application changes")),
         ]
         for key, label, desc in event_settings:
             row = SettingRow(label, desc)
@@ -421,6 +434,12 @@ class HapticsPage(Gtk.ScrolledWindow):
         self._reload_daemon_config()
         return False
 
+    def _on_window_switch_toggled(self, switch, state):
+        config.set("haptics", "window_switch_enabled", state)
+        config.save(show_toast=False)
+        self._reload_daemon_config()
+        return False
+
     # ----------------------------------------------------- pattern dropdowns
     def _create_pattern_dropdown(self, current_value, on_change_callback):
         labels = [display_name for _id, display_name, _desc in self.HAPTIC_PATTERNS]
@@ -451,7 +470,7 @@ class HapticsPage(Gtk.ScrolledWindow):
     def _apply_pattern_to_all(self, pattern):
         if not pattern:
             return
-        for key in ["menu_appear", "slice_change", "confirm", "invalid"]:
+        for key in ["menu_appear", "slice_change", "confirm", "invalid", "window_switch"]:
             config.set("haptics", "per_event", key, pattern)
         pattern_index = 0
         for i, (pattern_id, _pname, _pdesc) in enumerate(self.HAPTIC_PATTERNS):

--- a/tests/test_submenu_repaints.py
+++ b/tests/test_submenu_repaints.py
@@ -72,6 +72,7 @@ class _MenuHarness:
         self._anim_timer = _Timer()
         self._subitem_result = subitem_result
         self.update_calls = 0
+        self.haptic_events = []
 
     def _hover_gate(self, *_args):
         return True
@@ -85,8 +86,8 @@ class _MenuHarness:
     def _update_kde_mask(self):
         pass
 
-    def _trigger_haptic(self, _event):
-        pass
+    def _trigger_haptic(self, event):
+        self.haptic_events.append(event)
 
     def update(self):
         self.update_calls += 1
@@ -139,6 +140,38 @@ def test_changing_the_highlighted_subitem_repaints_once():
 
     assert menu.highlighted_subitem == 2
     assert menu.update_calls == 1
+
+
+def test_changing_the_highlighted_subitem_triggers_haptic():
+    menu = _MenuHarness(highlighted_subitem=1, subitem_result=2)
+
+    _radial_menu_method("_poll_cursor")(menu)
+
+    assert menu.haptic_events == ["slice_change"]
+
+
+def test_clearing_the_highlighted_subitem_does_not_trigger_haptic():
+    menu = _MenuHarness(highlighted_subitem=2, subitem_result=-1)
+
+    _radial_menu_method("_poll_cursor")(menu)
+
+    assert menu.haptic_events == []
+
+
+def test_mouse_move_changing_the_highlighted_subitem_triggers_haptic():
+    menu = _MenuHarness(highlighted_subitem=1, subitem_result=2)
+
+    _radial_menu_method("mouseMoveEvent")(menu, _MouseEvent())
+
+    assert menu.haptic_events == ["slice_change"]
+
+
+def test_mouse_move_clearing_the_highlighted_subitem_does_not_trigger_haptic():
+    menu = _MenuHarness(highlighted_subitem=2, subitem_result=-1)
+
+    _radial_menu_method("mouseMoveEvent")(menu, _MouseEvent())
+
+    assert menu.haptic_events == []
 
 
 def test_submenu_animation_keeps_repainting_until_settled():


### PR DESCRIPTION
## Summary
- Adds a `HapticEvent::WindowSwitch`, threaded through the same `config -> HapticManager -> device` pipeline as `menu_appear`/`slice_change`/`confirm`/`invalid` — its own `per_event.window_switch` pattern (default `subtle_collision`) plus a separate `window_switch_enabled` toggle (on by default) so it can be turned off independently of the menu's own haptics.
- Fires from the daemon's existing window-focus-change consumer (`main.rs`, already running for per-app hardware profiles — KDE/Hyprland/X11-aware, deduped by window class) rather than adding a new watcher. Purely additive, no new D-Bus surface.
- Settings → Haptics gets an "App Switch" toggle and pattern dropdown, matching the existing per-event rows.

## Test plan
- [x] `cargo build --release && cargo test` — 302 passed
- [x] `python3 -m pytest tests/` — 113 passed
- [x] Manually verified on Fedora KDE: Alt+Tab / clicking between different app windows pulses once per switch; refocusing the same app's windows does not re-pulse; toggling "App Switch" off stops it while menu haptics (open/hover/select) keep working