### PR TITLE
fix(settings): align SmartShift sensitivity with hardware

### DIFF
--- a/overlay/settings_page_scroll.py
+++ b/overlay/settings_page_scroll.py
@@ -552,13 +552,29 @@ class ScrollPage(Gtk.ScrolledWindow):
         if mode == "ratchet":
             self._apply_smartshift_to_device(False, 0)
         elif mode == "freespin":
-            # Free-spin: wheel_mode=1 (freespin), auto_disengage=0 (no auto-switch)
-            self._apply_smartshift_to_device_raw(1, 0)
+            self._apply_smartshift_to_device(True, 0)
         else:
-            # SmartShift
-            threshold = int(self.sens_scale.get_value())
-            device_threshold = max(1, min(254, int((100 - threshold) * 2.55)))
+            sensitivity = int(self.sens_scale.get_value())
+            device_threshold = self._smartshift_ui_to_device(sensitivity)
             self._apply_smartshift_to_device(True, device_threshold)
+
+    @staticmethod
+    def _smartshift_ui_to_device(value):
+        """Map Easy 1% -> Hard 100% to automatic thresholds 1..49.
+
+        Threshold 0 selects permanent free-spin and 255 selects permanent
+        ratchet, so neither belongs on the SmartShift sensitivity slider.
+        Logitech's established ratchet-speed scale uses 50 as the ratchet-only
+        endpoint; 49 is therefore the hardest setting that still auto-releases.
+        """
+        value = max(1, min(100, int(value)))
+        return 1 + (((value - 1) * 48 + 49) // 99)
+
+    @staticmethod
+    def _smartshift_device_to_ui(device_threshold):
+        """Map automatic thresholds 1..49 back to Easy/Hard percent."""
+        threshold = max(1, min(49, int(device_threshold)))
+        return 1 + (((threshold - 1) * 99) // 48)
 
     def _on_sensitivity_changed(self, scale):
         if self._applying_initial_scroll_state:
@@ -569,7 +585,7 @@ class ScrollPage(Gtk.ScrolledWindow):
         self._update_sens_label(value)
 
         # Apply to device
-        device_threshold = max(1, min(254, int((100 - value) * 2.55)))
+        device_threshold = self._smartshift_ui_to_device(value)
         self._apply_smartshift_to_device(True, device_threshold)
 
     def _update_sens_label(self, value):
@@ -908,26 +924,6 @@ None,      Down, Button5, {lines}
         except GLib.Error as e:
             logger.error("D-Bus error setting SmartShift: %s", e.message)
 
-    def _apply_smartshift_to_device_raw(self, wheel_mode, auto_disengage):
-        """Set SmartShift with explicit wheel_mode for free-spin support.
-
-        Free-spin = wheel_mode=1, auto_disengage=0 (no auto-switch).
-        Falls back to the simplified API if direct call fails.
-        """
-        proxy = self._get_dbus_proxy()
-        if not proxy:
-            return
-        # Use the simplified API: enabled=True with the given threshold.
-        # wheel_mode=1 + auto_disengage=0 -> freespin on the daemon side.
-        try:
-            proxy.call_sync(
-                "SetSmartShift",
-                GLib.Variant("(by)", (bool(wheel_mode), auto_disengage)),
-                Gio.DBusCallFlags.NONE, 2000, None,
-            )
-        except GLib.Error as e:
-            logger.error("D-Bus error setting wheel mode: %s", e.message)
-
     def _apply_hiresscroll_to_device(self):
         hires = config.get("scroll", "smooth", default=True)
         invert = config.get("scroll", "natural", default=False)
@@ -1106,18 +1102,29 @@ None,      Down, Button5, {lines}
         enabled = result.get_child_value(0).get_boolean()
         device_threshold = result.get_child_value(1).get_byte()
 
-        # Determine mode from device + saved config.
-        saved_mode = config.get("scroll", "mode", default=None)
-        if saved_mode == "freespin":
-            mode = "freespin"
-        elif enabled:
-            mode = "smartshift"
-        else:
+        # GetSmartShift's D-Bus contract reports (False, _) for permanent
+        # ratchet, (True, 0) for free-spin and (True, 1..254) for SmartShift.
+        if not enabled:
             mode = "ratchet"
+        elif device_threshold == 0:
+            mode = "freespin"
+        else:
+            mode = "smartshift"
 
-        # Convert device threshold to UI percentage.
-        ui_threshold = 100 - int(device_threshold / 2.55)
-        ui_threshold = max(1, min(100, ui_threshold))
+        # Ratchet and free-spin do not carry a useful automatic threshold, so
+        # preserve the user's saved SmartShift preference in those modes.
+        if mode == "smartshift":
+            ui_threshold = self._smartshift_device_to_ui(device_threshold)
+        else:
+            ui_threshold = max(
+                1,
+                min(
+                    100,
+                    int(config.get(
+                        "scroll", "smartshift_threshold", default=50
+                    )),
+                ),
+            )
 
         self._apply_initial_scroll_state(mode=mode, threshold=ui_threshold)
 

--- a/tests/test_smartshift_mapping.py
+++ b/tests/test_smartshift_mapping.py
@@ -1,0 +1,131 @@
+"""Regression tests for SmartShift sensitivity and mode readback."""
+
+import ast
+from collections.abc import Callable
+from pathlib import Path
+from types import MethodType, SimpleNamespace
+from typing import cast
+
+
+SCROLL_PAGE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "overlay"
+    / "settings_page_scroll.py"
+)
+
+
+def _scroll_page_method(name: str) -> ast.FunctionDef:
+    module = ast.parse(SCROLL_PAGE_PATH.read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "ScrollPage":
+            continue
+        for statement in node.body:
+            if isinstance(statement, ast.FunctionDef) and statement.name == name:
+                return statement
+    raise AssertionError(f"ScrollPage.{name} must exist")
+
+
+def _load_method(name: str, namespace=None):
+    method = _scroll_page_method(name)
+    method.decorator_list = []
+    scope = {} if namespace is None else dict(namespace)
+    exec(
+        compile(ast.Module(body=[method], type_ignores=[]), "<scroll-page>", "exec"),
+        scope,
+    )
+    return scope[name]
+
+
+def test_easy_to_hard_maps_to_automatic_thresholds_in_order():
+    ui_to_device = _load_method("_smartshift_ui_to_device")
+
+    assert [ui_to_device(value) for value in (1, 25, 50, 75, 100)] == [
+        1,
+        13,
+        25,
+        37,
+        49,
+    ]
+    thresholds = [ui_to_device(value) for value in range(1, 101)]
+    assert thresholds == sorted(thresholds)
+    assert min(thresholds) == 1
+    assert max(thresholds) == 49
+
+
+def test_every_automatic_threshold_round_trips_exactly():
+    ui_to_device = _load_method("_smartshift_ui_to_device")
+    device_to_ui = _load_method("_smartshift_device_to_ui")
+
+    for threshold in range(1, 50):
+        assert ui_to_device(device_to_ui(threshold)) == threshold
+
+
+def test_device_readback_uses_dbus_mode_contract_and_preserves_sensitivity():
+    config_writes = []
+
+    class FakeConfig:
+        @staticmethod
+        def get(_section, key, default=None):
+            return 72 if key == "smartshift_threshold" else default
+
+        @staticmethod
+        def set(section, key, value):
+            config_writes.append((section, key, value))
+
+    class FakeValue:
+        def __init__(self, value):
+            self.value = value
+
+        def get_boolean(self):
+            return self.value
+
+        def get_byte(self):
+            return self.value
+
+    class FakeResult:
+        def __init__(self, enabled, threshold):
+            self.values = (enabled, threshold)
+
+        def get_child_value(self, index):
+            return FakeValue(self.values[index])
+
+    class FakeProxy:
+        def __init__(self, enabled, threshold):
+            self.result = FakeResult(enabled, threshold)
+
+        def call_finish(self, _async_result):
+            return self.result
+
+    method = _load_method(
+        "_on_smartshift_loaded",
+        {
+            "config": FakeConfig(),
+            "GLib": SimpleNamespace(Error=Exception),
+        },
+    )
+    device_to_ui = _load_method("_smartshift_device_to_ui")
+    applied = []
+    page = SimpleNamespace(
+        _has_local_scroll_state_edits=lambda: False,
+        _apply_saved_scroll_mode=lambda: None,
+        _apply_initial_scroll_state=lambda **state: applied.append(state),
+        _smartshift_device_to_ui=device_to_ui,
+    )
+    page._on_smartshift_loaded = MethodType(cast(Callable, method), page)
+
+    cases = [
+        (False, 0, "ratchet", 72),
+        (True, 0, "freespin", 72),
+        (True, 25, "smartshift", 50),
+    ]
+    for enabled, threshold, expected_mode, expected_sensitivity in cases:
+        page._on_smartshift_loaded(FakeProxy(enabled, threshold), object(), None)
+        assert applied[-1] == {
+            "mode": expected_mode,
+            "threshold": expected_sensitivity,
+        }
+
+    assert config_writes[-2:] == [
+        ("scroll", "mode", "smartshift"),
+        ("scroll", "smartshift_threshold", 50),
+    ]


### PR DESCRIPTION
## Summary

- Map the Easy-to-Hard sensitivity slider monotonically onto HID++ automatic
  disengage thresholds 1 through 49.
- Keep threshold 0 reserved for permanent free-spin and 255 for permanent
  ratchet mode.
- Interpret `GetSmartShift` using its established D-Bus contract and preserve
  the saved SmartShift sensitivity while another wheel mode is active.
- Add regression coverage for the mapping, round trips, and all three mode
  readback cases.

## Problem

The previous conversion inverted the user-facing scale: Easy (1%) produced a
high device threshold, making the wheel hardest to disengage, while Hard (100%)
produced threshold 1, making it easiest to disengage.

It also stretched the automatic range almost to 254. Logitech's established
ratchet-speed scale uses 1 through 49 for automatic switching, with 50 as the
ratchet-only endpoint. JuhRadial's D-Bus API separately represents permanent
ratchet as `(false, 0)` and permanent free-spin as `(true, 0)`.

## Result

| UI setting | Device threshold |
|---|---:|
| Easy 1% | 1 |
| 25% | 13 |
| 50% | 25 |
| 75% | 37 |
| Hard 100% | 49 |

Higher slider values now require a harder/faster wheel flick before automatic
disengagement, matching the labels shown in the settings UI.

## Validation

- `python3 -m pytest tests -q` — 116 passed
- Verified all device thresholds 1 through 49 round-trip exactly through the
  UI conversion.
- Verified readback for Ratchet, Free-spin, and SmartShift D-Bus results.
- Physically verified the Easy-to-Hard direction on an MX Master 4.

This is a focused follow-up to the MX Master 4 behavior addressed in #115.
