### PR TITLE
fix(hidpp): ignore hotplug events caused by our own suppression vdev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Haptic feedback works inside submenus** - Hovering between items in an open submenu (Quick Links, AI assistant, the app-picker submenu rows) gave no haptic pulse, only the main Actions Ring did. Submenu hover now triggers the same `slice_change` pulse as the main ring.
+- **Mouse no longer stutters/locks up over Bluetooth** - The daemon's own button-suppression virtual device is created and destroyed on every connection, and that generates genuine device-node events on `/dev/input` indistinguishable from a real plug/unplug. The active HID++ and evdev sessions cancel and restart on *any* such event, so this self-inflicted churn could re-trigger itself in a loop - on fast USB/Bolt the round-trip usually lands inside one debounce window and self-corrects invisibly, but Bluetooth's slower device I/O let the cycle escape the debounce repeatedly, producing a sustained reconnect loop that made the radial menu and thumb button unusable. The hotplug watcher now recognizes and ignores events on the daemon's own virtual device, leaving real hotplug detection (e.g. an Easy-Switch host change) untouched. Reported with logs by an MX Master 3S (Bluetooth) user. Fixes [#121](https://github.com/JuhLabs/juhradial-mx/issues/121).
 
 ## [0.4.4] - 2026-08-18
 

--- a/daemon/src/evdev.rs
+++ b/daemon/src/evdev.rs
@@ -15,8 +15,36 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::mpsc;
+
+/// Paths of uinput virtual devices the daemon itself created for button
+/// suppression, shared with the hotplug watcher so it can ignore Create/Remove
+/// events on them - see `run_event_loop`'s vdev-creation block and
+/// `main::event_is_self_caused` for why this exists (issue #121).
+pub type SharedVdevPaths = Arc<Mutex<HashSet<PathBuf>>>;
+
+/// Deregisters a virtual device's paths from `SharedVdevPaths` when dropped.
+///
+/// The vdev's owning future (`run_event_loop`, via `handler.start()`) can be
+/// cancelled mid-flight by the hotplug `select!` in `main.rs` - only `Drop`
+/// impls run reliably on async cancellation, so registration cleanup can't be
+/// inline cleanup code; it has to live here.
+struct VdevPathGuard {
+    paths: Vec<PathBuf>,
+    registry: SharedVdevPaths,
+}
+
+impl Drop for VdevPathGuard {
+    fn drop(&mut self) {
+        if let Ok(mut known) = self.registry.lock() {
+            for path in &self.paths {
+                known.remove(path);
+            }
+        }
+    }
+}
 
 /// MX Master 4 vendor ID (Logitech)
 pub const LOGITECH_VENDOR_ID: u16 = 0x046D;
@@ -121,6 +149,9 @@ pub struct EvdevHandler {
     kwin_available: Option<crate::compositor::KWinAvailability>,
     /// Native KWin scripting client backed by the daemon's session connection.
     kwin_scripting: Option<crate::compositor::KWinScripting>,
+    /// Registry the hotplug watcher consults to ignore Create/Remove events
+    /// caused by our own button-suppression virtual device (issue #121).
+    vdev_paths: Option<SharedVdevPaths>,
 }
 
 impl EvdevHandler {
@@ -145,6 +176,7 @@ impl EvdevHandler {
             active_button_action: None,
             kwin_available: None,
             kwin_scripting: None,
+            vdev_paths: None,
         }
     }
 
@@ -169,6 +201,7 @@ impl EvdevHandler {
             active_button_action: None,
             kwin_available: None,
             kwin_scripting: None,
+            vdev_paths: None,
         }
     }
 
@@ -193,6 +226,12 @@ impl EvdevHandler {
     /// events forwarded via a virtual device, minus the suppressed keys.
     pub fn set_suppressed_keys(&mut self, keys: HashSet<u16>) {
         self.suppressed_keys = keys;
+    }
+
+    /// Share the registry the hotplug watcher uses to ignore Create/Remove
+    /// events on our own button-suppression virtual device (issue #121).
+    pub fn set_vdev_paths_registry(&mut self, registry: SharedVdevPaths) {
+        self.vdev_paths = Some(registry);
     }
 
     /// Update the trigger button (e.g. after config reload)
@@ -585,6 +624,7 @@ impl EvdevHandler {
         // This prevents the OS from seeing macro-bound button presses (e.g.,
         // Back button won't trigger browser-back when a macro is assigned).
         let mut virtual_device = None;
+        let mut _vdev_path_guard: Option<VdevPathGuard> = None;
         if !self.suppressed_keys.is_empty() {
             let vdev_result = (|| -> Result<_, std::io::Error> {
                 let mut builder = UinputDevice::builder()?.name("JuhRadial Virtual Mouse");
@@ -600,11 +640,49 @@ impl EvdevHandler {
             })();
 
             match vdev_result {
-                Ok(vdev) => {
+                Ok(mut vdev) => {
                     tracing::info!(
                         suppressed = ?self.suppressed_keys,
                         "Device grabbed - macro buttons will be suppressed from OS"
                     );
+
+                    // Register this vdev's own /dev/input paths so the hotplug
+                    // watcher can tell its Create/Remove events (fired on every
+                    // connection) apart from a real external device change -
+                    // otherwise they self-trigger a reconnect loop, severe on
+                    // Bluetooth where I/O timing lines up with the watcher's
+                    // debounce window (issue #121).
+                    if let Some(registry) = self.vdev_paths.clone() {
+                        let mut own_paths = Vec::new();
+                        match vdev.enumerate_dev_nodes().await {
+                            Ok(mut nodes) => loop {
+                                match nodes.next_entry().await {
+                                    Ok(Some(path)) => {
+                                        if let Ok(mut known) = registry.lock() {
+                                            known.insert(path.clone());
+                                        }
+                                        own_paths.push(path);
+                                    }
+                                    Ok(None) => break,
+                                    Err(e) => {
+                                        tracing::debug!(
+                                            "Failed to enumerate virtual device node: {}",
+                                            e
+                                        );
+                                        break;
+                                    }
+                                }
+                            },
+                            Err(e) => {
+                                tracing::debug!(
+                                    "Failed to enumerate virtual device nodes: {}",
+                                    e
+                                );
+                            }
+                        }
+                        _vdev_path_guard = Some(VdevPathGuard { paths: own_paths, registry });
+                    }
+
                     virtual_device = Some(vdev);
                 }
                 Err(e) => {
@@ -948,6 +1026,40 @@ impl std::error::Error for EvdevError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn vdev_path_guard_removes_its_paths_on_drop() {
+        let registry: SharedVdevPaths = Arc::new(Mutex::new(HashSet::new()));
+        let a = PathBuf::from("/dev/input/event30");
+        let b = PathBuf::from("/dev/input/event31");
+        registry.lock().unwrap().insert(a.clone());
+        registry.lock().unwrap().insert(b.clone());
+
+        let guard = VdevPathGuard {
+            paths: vec![a.clone(), b.clone()],
+            registry: registry.clone(),
+        };
+        drop(guard);
+
+        let known = registry.lock().unwrap();
+        assert!(!known.contains(&a));
+        assert!(!known.contains(&b));
+    }
+
+    #[test]
+    fn vdev_path_guard_leaves_unrelated_paths_alone() {
+        let registry: SharedVdevPaths = Arc::new(Mutex::new(HashSet::new()));
+        let mine = PathBuf::from("/dev/input/event30");
+        let unrelated = PathBuf::from("/dev/input/event7");
+        registry.lock().unwrap().insert(mine.clone());
+        registry.lock().unwrap().insert(unrelated.clone());
+
+        drop(VdevPathGuard { paths: vec![mine.clone()], registry: registry.clone() });
+
+        let known = registry.lock().unwrap();
+        assert!(!known.contains(&mine));
+        assert!(known.contains(&unrelated));
+    }
 
     #[cfg(target_os = "linux")]
     use evdev::{EventType, InputEvent, RelativeAxisCode, SynchronizationCode};

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -57,6 +57,32 @@ fn log_startup_phase(started_at: &Instant, phase: &'static str) {
     );
 }
 
+/// True when every path in a hotplug event is a virtual device the daemon
+/// itself created for button suppression (`SharedVdevPaths`, populated by
+/// `evdev::run_event_loop`) - i.e. this event is self-caused, not a real
+/// external device change. A mixed event (one known path, one unknown one)
+/// is conservatively treated as real.
+///
+/// Why this exists (issue #121): that vdev is created on every MX connection
+/// (`GESTURE_BUTTON_CODES` is never empty), and creating/dropping it fires
+/// genuine Create/Remove events on /dev/input indistinguishable from a real
+/// plug/unplug to the watcher below. `run_evdev_loop`/`run_hidraw_loop` both
+/// cancel an active, healthy session on *any* hotplug notification (needed
+/// for real reconnects, e.g. an Easy-Switch host change), so without this
+/// filter the vdev's own churn self-triggers a reconnect loop. On USB/Bolt
+/// the whole round-trip is fast enough to land inside one debounce window
+/// and self-correct; on Bluetooth it's slow enough to escape the debounce
+/// repeatedly, producing a sustained lag loop.
+fn event_is_self_caused(paths: &[PathBuf], known: &juhradiald::evdev::SharedVdevPaths) -> bool {
+    if paths.is_empty() {
+        return false;
+    }
+    let Ok(known) = known.lock() else {
+        return false;
+    };
+    paths.iter().all(|p| known.contains(p))
+}
+
 /// Spawn a background thread that watches /dev/input/ for device hotplug events
 /// using inotify. Returns a Notify that fires when event* devices appear or disappear.
 /// This allows evdev loops to re-scan immediately instead of waiting for the 2s poll.
@@ -65,7 +91,11 @@ fn log_startup_phase(started_at: &Instant, phase: &'static str) {
 /// (e.g. Close(Write)) are filtered out to prevent a feedback loop where our own
 /// device scanning triggers inotify events that cause more scanning. A 500ms
 /// debounce window coalesces rapid events from USB hubs into a single notification.
-fn spawn_device_hotplug_watcher() -> Arc<tokio::sync::Notify> {
+/// Events on our own button-suppression virtual device are filtered out too -
+/// see `event_is_self_caused`.
+fn spawn_device_hotplug_watcher(
+    known_vdev_paths: juhradiald::evdev::SharedVdevPaths,
+) -> Arc<tokio::sync::Notify> {
     let hotplug = Arc::new(tokio::sync::Notify::new());
     let hotplug_tx = hotplug.clone();
 
@@ -123,6 +153,14 @@ fn spawn_device_hotplug_watcher() -> Arc<tokio::sync::Notify> {
                             .unwrap_or(false)
                     });
                     if !is_event_device {
+                        continue;
+                    }
+
+                    if event_is_self_caused(&event.paths, &known_vdev_paths) {
+                        debug!(
+                            "Hotplug event on own virtual device ignored: {:?}",
+                            event.paths
+                        );
                         continue;
                     }
 
@@ -505,11 +543,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // writes, so GetBatteryStatus reflects them even when the active query fails.
     let battery_state_for_events = battery_state.clone();
 
+    // Paths of uinput virtual devices the daemon creates for button
+    // suppression - shared with the hotplug watcher so it can tell their
+    // Create/Remove churn apart from a real external device change (issue #121).
+    let known_vdev_paths: juhradiald::evdev::SharedVdevPaths =
+        Arc::new(Mutex::new(HashSet::new()));
+
     // Start inotify watcher on /dev/input/ for instant device hotplug detection.
     // Shared across the evdev loops and the hidraw loop; the battery updater
     // also fires it when a failing poll starts succeeding again, which is how
     // a Bolt radio wake is detected without any node hotplug (issue #102).
-    let hotplug_notify = spawn_device_hotplug_watcher();
+    let hotplug_notify = spawn_device_hotplug_watcher(known_vdev_paths.clone());
 
     // Spawn battery status updater (shares HidppDevice with haptic via SharedHapticManager)
     let battery_radio_recovered = hotplug_notify.clone();
@@ -688,6 +732,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let hotplug_for_mx = hotplug_notify.clone();
     let evdev_config = shared_config.clone();
     let evdev_kwin = kwin_context.clone();
+    let evdev_vdev_paths = known_vdev_paths.clone();
     let evdev_handle = tokio::spawn(async move {
         run_evdev_loop(
             evdev_tx,
@@ -695,6 +740,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             hotplug_for_mx,
             evdev_config,
             evdev_kwin,
+            evdev_vdev_paths,
         )
         .await
     });
@@ -704,6 +750,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let hotplug_for_generic = hotplug_notify.clone();
     let generic_evdev_config = shared_config.clone();
     let generic_evdev_kwin = kwin_context;
+    let generic_evdev_vdev_paths = known_vdev_paths.clone();
     let generic_evdev_handle = tokio::spawn(async move {
         run_generic_evdev_loop(
             generic_evdev_tx,
@@ -711,6 +758,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             hotplug_for_generic,
             generic_evdev_config,
             generic_evdev_kwin,
+            generic_evdev_vdev_paths,
         )
         .await
     });
@@ -1119,12 +1167,14 @@ async fn run_evdev_loop(
     hotplug: Arc<tokio::sync::Notify>,
     shared_config: juhradiald::config::SharedConfig,
     kwin: KWinContext,
+    known_vdev_paths: juhradiald::evdev::SharedVdevPaths,
 ) {
     let mut handler = EvdevHandler::new(event_tx.clone());
     handler.set_suppressed_keys(suppressed_keys);
     handler.set_shared_config(shared_config);
     handler.set_kwin_availability(kwin.availability);
     handler.set_kwin_scripting(kwin.scripting);
+    handler.set_vdev_paths_registry(known_vdev_paths);
 
     let mut logged_waiting = false;
 
@@ -1241,6 +1291,7 @@ async fn run_generic_evdev_loop(
     hotplug: Arc<tokio::sync::Notify>,
     shared_config: juhradiald::config::SharedConfig,
     kwin: KWinContext,
+    known_vdev_paths: juhradiald::evdev::SharedVdevPaths,
 ) {
     let trigger = read_trigger_button_from_config();
     if let Some(code) = trigger {
@@ -1251,6 +1302,7 @@ async fn run_generic_evdev_loop(
     handler.set_shared_config(shared_config);
     handler.set_kwin_availability(kwin.availability);
     handler.set_kwin_scripting(kwin.scripting);
+    handler.set_vdev_paths_registry(known_vdev_paths);
 
     let mut logged_waiting = false;
 
@@ -1567,6 +1619,51 @@ async fn emit_cursor_moved(
 mod tests {
     use super::*;
     use juhradiald::cursor::{CursorPosition, EDGE_MARGIN, MENU_RADIUS, ScreenBounds};
+
+    #[test]
+    fn event_is_self_caused_ignores_when_all_paths_are_known_vdev_paths() {
+        let known: juhradiald::evdev::SharedVdevPaths = Arc::new(Mutex::new(HashSet::new()));
+        known
+            .lock()
+            .unwrap()
+            .insert(PathBuf::from("/dev/input/event30"));
+
+        let paths = vec![PathBuf::from("/dev/input/event30")];
+        assert!(event_is_self_caused(&paths, &known));
+    }
+
+    #[test]
+    fn event_is_self_caused_honors_unknown_path() {
+        let known: juhradiald::evdev::SharedVdevPaths = Arc::new(Mutex::new(HashSet::new()));
+        known
+            .lock()
+            .unwrap()
+            .insert(PathBuf::from("/dev/input/event30"));
+
+        let paths = vec![PathBuf::from("/dev/input/event7")];
+        assert!(!event_is_self_caused(&paths, &known));
+    }
+
+    #[test]
+    fn event_is_self_caused_honors_mixed_known_and_unknown_paths() {
+        let known: juhradiald::evdev::SharedVdevPaths = Arc::new(Mutex::new(HashSet::new()));
+        known
+            .lock()
+            .unwrap()
+            .insert(PathBuf::from("/dev/input/event30"));
+
+        let paths = vec![
+            PathBuf::from("/dev/input/event30"),
+            PathBuf::from("/dev/input/event7"),
+        ];
+        assert!(!event_is_self_caused(&paths, &known));
+    }
+
+    #[test]
+    fn event_is_self_caused_false_for_empty_event() {
+        let known: juhradiald::evdev::SharedVdevPaths = Arc::new(Mutex::new(HashSet::new()));
+        assert!(!event_is_self_caused(&[], &known));
+    }
 
     #[test]
     fn test_device_poll_interval() {


### PR DESCRIPTION
## Summary
Root-caused and fixed #121 (MX Master 3S over Bluetooth: mouse "stopping/lagging", radial menu and thumb button non-functional).

- The button-suppression virtual device ("JuhRadial Virtual Mouse") is created and destroyed on every MX connection (`GESTURE_BUTTON_CODES` is never empty), and creating/dropping a uinput device fires genuine Create/Remove events on `/dev/input` — indistinguishable from a real plug/unplug to the hotplug watcher, whose existing filter (built for #15) only excludes `Access` events.
- `run_evdev_loop` and `run_hidraw_loop` both race their entire active, healthy session against **any** hotplug notification (needed for real reconnects, e.g. an Easy-Switch host change), so the vdev's own churn could self-trigger a reconnect loop: grab → create vdev (Create) → notified → cancel → drop vdev (Remove) → notified → re-scan → repeat.
- On USB/Bolt the whole round-trip is fast enough to land inside one 500ms debounce window and self-correct invisibly. On Bluetooth it's slow enough to escape the debounce repeatedly, producing a sustained lag loop — confirmed against #121's logs: the observed Create→Remove gap sits just past the debounce window.
- Fixed at the source rather than per-consumer: `EvdevHandler` now registers a just-created vdev's own `/dev/input` paths into a shared registry, and the hotplug watcher skips notifying when every path in an event is a known vdev path. Real hotplug reactivity (external devices, actual disconnects) is untouched.

## Test plan
- [x] `cargo build --release && cargo test` — 322 passed (307 lib + 12 bin + 3 integration), 4 new tests for the path-matching logic, 2 for the cleanup guard
- [x] Manually verified normal (wired/Bolt) connection still works: device connects, buttons divert, radial menu opens
- [ ] **Cannot reproduce the Bluetooth race locally** (no BT MX Master on hand) — needs confirmation from someone who can reproduce #121