### PR TITLE
fix: prevent uinput device creation from triggering hotplug loop

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -110,8 +110,11 @@ fn spawn_device_hotplug_watcher() -> Arc<tokio::sync::Notify> {
                     // Access(Close(Write)) inotify events. If we react to those, we
                     // enter an infinite scan loop (~50ms cycle) that saturates the
                     // input subsystem and can block other devices (see issue #15).
-                    let is_hotplug =
-                        matches!(event.kind, EventKind::Create(_) | EventKind::Remove(_));
+                    // Only react to device removal. New event nodes can be
+                    // created by uinput/JuhRadial itself and must not restart
+                    // the active MX listener. The periodic poll remains as a
+                    // fallback for newly connected devices.
+                    let is_hotplug = matches!(event.kind, EventKind::Remove(_));
                     if !is_hotplug {
                         continue;
                     }
@@ -126,6 +129,34 @@ fn spawn_device_hotplug_watcher() -> Arc<tokio::sync::Notify> {
                         continue;
                     }
 
+                    // Ignore virtual input devices created by JuhRadial itself.
+                    // The MX evdev handler creates "JuhRadial Virtual Mouse" via
+                    // uinput when button suppression is enabled. That creates a
+                    // new /dev/input/event* node, but it is NOT a physical
+                    // hotplug and must not cause the active MX listener to restart.
+                    let is_juh_radial_virtual = event.paths.iter().any(|p| {
+                        if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
+                            if !name.starts_with("event") {
+                                return false;
+                            }
+
+                            if let Ok(device) = evdev::Device::open(p) {
+                                return device
+                                    .name()
+                                    .map(|n| n == "JuhRadial Virtual Mouse")
+                                    .unwrap_or(false);
+                            }
+                        }
+                        false
+                    });
+
+                    if is_juh_radial_virtual {
+                        debug!(
+                            "Ignoring JuhRadial virtual input device hotplug"
+                        );
+                        continue;
+                    }
+
                     // Debounce: coalesce rapid events (e.g. USB hub enumerating
                     // multiple devices) into a single scan notification.
                     let now = Instant::now();
@@ -135,7 +166,11 @@ fn spawn_device_hotplug_watcher() -> Arc<tokio::sync::Notify> {
                     }
                     last_notify = now;
 
-                    info!("Device hotplug detected: {:?}", event.kind);
+                    info!(
+                        "Device hotplug detected: {:?} paths={:?}",
+                        event.kind,
+                        event.paths
+                    );
                     hotplug_tx.notify_waiters();
                 }
                 Ok(Err(e)) => {


### PR DESCRIPTION
## Description

Fixes an input hotplug loop caused by JuhRadial's own uinput virtual mouse being detected as a physical device hotplug.

When the MX Master 4 is grabbed, JuhRadial creates a virtual input device, which generates a new /dev/input/event* node. The hotplug watcher was treating this Create event as a physical device connection, causing the active MX listener to repeatedly stop and rescan.

This resulted in noticeable mouse input issues, including the radial menu not opening and horizontal/thumb-wheel controls becoming unreliable.

## Related Issue

Closes #125 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Changed the /dev/input hotplug watcher to only react to Remove events.
- Prevented Create events from JuhRadial's own uinput virtual device from triggering MX device rescans.
- Kept the existing periodic device scan as a fallback for newly connected devices.
- Added a comment explaining why Create events are intentionally ignored.

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Tested on KDE Plasma 6 with Wayland
- [x] Tested with MX Master 4
- [x] Ran `make test`
- [x] Ran `cargo clippy` (no warnings)

**Test Configuration:**
- Linux Distribution: Fedora Linux
- Desktop Environment: KDE Plasma 6 with Wayland
- Mouse Model: Logitech MX Master 4

## Screenshots (if applicable)
N/A

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
